### PR TITLE
fix(ui): XP progress bar in character selector (BUG-152)

### DIFF
--- a/cmd/webclient/ui/src/pages/CharactersPage.tsx
+++ b/cmd/webclient/ui/src/pages/CharactersPage.tsx
@@ -120,6 +120,11 @@ function CharacterCard({ char, onPlay, onDelete, onForceLogout }: {
   const hpPct = char.max_hp > 0 ? (char.current_hp / char.max_hp) * 100 : 0
   const hpColor = hpPct > 50 ? '#4caf50' : hpPct > 25 ? '#ff9800' : '#f44336'
   const isOnline = char.is_online === true
+  // XP formula: xp_to_reach_level(n) = n² × 100 (BaseXP=100, matches server xp package)
+  const xpToNext = (char.level + 1) * (char.level + 1) * 100
+  const xpPct = char.experience !== undefined && xpToNext > 0
+    ? Math.min(100, (char.experience / xpToNext) * 100)
+    : 0
 
   return (
     <div style={{ ...styles.card, ...(isOnline ? styles.cardOnline : {}) }}>
@@ -143,9 +148,14 @@ function CharacterCard({ char, onPlay, onDelete, onForceLogout }: {
         {char.current_hp} / {char.max_hp} HP
       </div>
       {char.experience !== undefined && (
-        <div style={{ ...styles.cardSub, marginTop: '0.25rem' }}>
-          XP: {char.experience.toLocaleString()}
-        </div>
+        <>
+          <div style={styles.xpBar}>
+            <div style={{ ...styles.xpFill, width: `${xpPct}%` }} />
+          </div>
+          <div style={styles.hpText}>
+            {char.experience.toLocaleString()} / {xpToNext.toLocaleString()} XP
+          </div>
+        </>
       )}
       <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem' }}>
         {isOnline ? (
@@ -229,6 +239,8 @@ const styles: Record<string, React.CSSProperties> = {
   hpBar: { background: '#333', borderRadius: '4px', height: '6px', overflow: 'hidden', marginTop: '0.5rem' },
   hpFill: { height: '100%', borderRadius: '4px', transition: 'width 0.3s' },
   hpText: { fontSize: '0.75rem', color: '#aaa' },
+  xpBar: { background: '#333', borderRadius: '4px', height: '6px', overflow: 'hidden', marginTop: '0.5rem' },
+  xpFill: { height: '100%', borderRadius: '4px', transition: 'width 0.3s', background: '#4a7aaf' },
   playButton: {
     marginTop: '0.75rem',
     padding: '0.4rem',

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1264,11 +1264,11 @@
 ### BUG-152: Character selector XP shown as text instead of a progress bar
 
 **Severity:** low
-**Status:** open
+**Status:** fixed
 **Category:** UI
 **Description:** In the web UI character selector, XP is displayed as raw text rather than a progress bar like HP, leaving the player with no visual indication of progress toward the next level.
 **Steps:** Open the web UI character selector; observe XP is shown as a number/text field rather than a filled progress bar matching the HP bar style.
-**Fix:**
+**Fix:** Replaced the raw XP text in `CharacterCard` (CharactersPage.tsx) with a progress bar matching the HP bar style. XP to next level is computed client-side using the formula `(level+1)² × 100` (BaseXP=100, matching the server `xp` package). Bar fills blue (`#4a7aaf`); label shows `current / next XP`.
 
 ### BUG-153: Web UI panels do not auto-size on load — player must manually resize every session
 


### PR DESCRIPTION
## Summary
- Replaced raw XP text in character selector cards with a progress bar (same style as HP bar)
- XP to next level computed client-side: `(level+1)² × 100` (matches server `xp` package formula, BaseXP=100)
- Bar fills blue; label shows `current / next XP`

## Test Plan
- [ ] Open character selector — XP shows as a blue progress bar, not raw text
- [ ] TypeScript: `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)