### PR TITLE
spec(#260): natural 1/20 step adjustment + crit specialization + fumble config

### DIFF
--- a/docs/superpowers/specs/2026-04-25-natural-1-and-20.md
+++ b/docs/superpowers/specs/2026-04-25-natural-1-and-20.md
@@ -1,0 +1,211 @@
+---
+title: Natural 1 / Natural 20 — Crit Fumble and Crit Success
+issue: https://github.com/cory-johannsen/mud/issues/260
+date: 2026-04-25
+status: spec
+prefix: CRIT
+depends_on:
+  - "#245 Duplicate effects handling (typed bonus pipeline carries fumble penalties)"
+related:
+  - "#252 Non-combat actions (NCA-7 already encodes the natural-1/20 step rule for skill actions; attack rolls land it for the combat path)"
+  - "#254 Detection states (off-guard via condition pipeline — fumble reuses)"
+---
+
+# Natural 1 / Natural 20
+
+## 1. Summary
+
+Today's attack pipeline computes outcome purely from `roll + modifiers vs AC`:
+
+- `OutcomeFor` (`internal/game/combat/combat.go:219-230`) returns `CritSuccess` when total ≥ AC+10, `Success` when ≥ AC, `Failure` when ≥ AC-10, else `CritFailure`.
+- `Outcome` enum (`combat.go:26-49`) already has all four PF2E degrees of success.
+- The DoS-step natural-1/20 rule from PF2E is **not** applied: a natural 20 against a high AC stays at `Success` (or even `Failure`), and a natural 1 against a low AC stays at `Success` (or even `CritSuccess`).
+- Crit success doubles the final damage total via `EffectiveDamage()` (`combat.go:30-42`); PF2E says "double the dice and add modifiers once" but the practical end-state is the same magnitude on average and the issue does not call this out.
+- Crit failure already drops the attacker `prone` (`round.go:407-410`); the issue asks for off-guard-until-next-turn or dropped-weapon alternatives.
+- Weapon critical specialization (the PF2E concept where a weapon group — sword, bow, etc. — adds a per-group rider on a crit hit) is **not** modeled. `WeaponDef` has no `Group`-based crit-effect dispatch. The issue asks for it.
+- Combat log already prints `*** CRITICAL HIT ***` / `*** CRITICAL MISS ***` headers and shows the raw d20 roll and target AC inline, satisfying the issue's "outcomes should be clearly displayed in console output".
+
+This spec ships the three remaining gaps: the natural-1/20 step adjustment, a content-driven weapon critical specialization table keyed on `WeaponDef.Group`, and a configurable fumble outcome.
+
+## 2. Goals & Non-Goals
+
+### 2.1 Goals
+
+- CRIT-G1: A natural-20 roll bumps the attack outcome up one DoS step; a natural-1 bumps it down one step.
+- CRIT-G2: Critical specialization effects fire on `CritSuccess` attack outcomes; effects are content-driven from a per-weapon-group YAML table.
+- CRIT-G3: Critical failure outcomes fire one of three configurable fumble effects: `off_guard_until_next_turn`, `prone` (existing default), or `drop_weapon`. The fumble effect is per-NPC and per-character (default `prone` to preserve current behavior).
+- CRIT-G4: Combat log narrative explicitly shows when the natural-1/20 step adjustment changed the outcome (e.g., "Natural 20 — Success bumped to Critical Success").
+- CRIT-G5: Existing tests pinning attack outcome math continue to pass; the step-adjustment rule applies *after* the AC comparison, not before.
+
+### 2.2 Non-Goals
+
+- CRIT-NG1: Rebalancing crit damage from `× 2 final` to PF2E "double dice + modifiers". The damage shape stays as-is.
+- CRIT-NG2: Authoring crit specialization for every weapon group on day one. v1 ships specialization data for the four most-used groups; the rest fall through to a generic effect.
+- CRIT-NG3: Fumble outcomes that change AP economy (e.g., "lose your next action"). Stays at condition / item drop only.
+- CRIT-NG4: Crit-fishing feats / traits that expand crit ranges (e.g., 19-20). PF2E does not have these by default; future tickets can add traits.
+- CRIT-NG5: Natural-1/20 rules on saving throws or skill checks. Skill actions are already handled by spec #252 NCA-7; saves are owned by the save subsystem (separate spec when authored).
+
+## 3. Glossary
+
+- **DoS step**: a movement up or down the four-tier outcome ladder `CritFailure → Failure → Success → CritSuccess`.
+- **Natural 20 / Natural 1**: the raw d20 result before modifiers.
+- **Crit specialization**: a per-weapon-group effect that fires only on `CritSuccess` attacks.
+- **Fumble**: a `CritFailure` attack outcome and the configurable consequence applied to the attacker.
+- **Weapon group**: an existing `WeaponDef.Group` field already on the weapon model (e.g., `firearm`, `melee_blade`, `bow`, `polearm`).
+
+## 4. Requirements
+
+### 4.1 Step Adjustment
+
+- CRIT-1: `OutcomeFor` MUST gain a parameter `naturalRoll int` (raw d20). Existing call sites MUST be updated to pass it.
+- CRIT-2: After computing the base outcome from `total vs AC`:
+  - When `naturalRoll == 20` AND base outcome is `CritFailure`, bump to `Failure`.
+  - When `naturalRoll == 20` AND base outcome is `Failure`, bump to `Success`.
+  - When `naturalRoll == 20` AND base outcome is `Success`, bump to `CritSuccess`.
+  - When `naturalRoll == 20` AND base outcome is `CritSuccess`, no change.
+  - When `naturalRoll == 1` AND base outcome is `CritSuccess`, drop to `Success`.
+  - When `naturalRoll == 1` AND base outcome is `Success`, drop to `Failure`.
+  - When `naturalRoll == 1` AND base outcome is `Failure`, drop to `CritFailure`.
+  - When `naturalRoll == 1` AND base outcome is `CritFailure`, no change.
+- CRIT-3: The step-adjustment MUST apply *after* the AC comparison, never before. This preserves the existing test invariants on the AC band math.
+- CRIT-4: The function MUST return the (possibly adjusted) outcome plus a new `StepAdjusted bool` field on `AttackResult` so the renderer knows whether to call out the adjustment.
+- CRIT-5: The same step-adjustment logic MUST be exposed as `combat.AdjustForNatural(outcome Outcome, naturalRoll int) (Outcome, bool)` so it can be reused by future code paths (saves, future skill action integration) without duplication.
+- CRIT-6: The skill-action resolver from spec #252 (NCA-7) already encodes this rule for skill checks; the implementer MUST refactor #252's implementation to call `combat.AdjustForNatural` so there is a single source of truth.
+
+### 4.2 Weapon Critical Specialization
+
+- CRIT-7: A new content directory `content/weapons/crit_specializations/` MUST hold one YAML per weapon group with shape:
+  - `group` (string, matches `WeaponDef.Group`).
+  - `display_name` (string).
+  - `effects` (list of effect blocks; reuses the dispatch from spec #255 EXC-3 / #252 NCA-2 — `apply_condition`, `damage`, `move`, `narrative`).
+- CRIT-8: At least four groups MUST have specializations authored at landing: `firearm`, `melee_blade`, `polearm`, `improvised`. Choices to be confirmed with the user before content is finalized.
+- CRIT-9: A fallback `default.yaml` MUST exist with a single generic effect: a `narrative` block reading `"<attacker>'s critical hit lands solidly on <target>."` Used when a weapon's group has no specialization file.
+- CRIT-10: When an attack resolves with `CritSuccess`, the resolver MUST look up the weapon group's specialization (or fall back to default) and apply each effect in authoring order, in addition to the doubled damage.
+- CRIT-11: Specialization effects MUST emit through the typed-bonus pipeline (#245) when they apply conditions or modifiers, so override / dedup rules apply correctly.
+
+### 4.3 Fumble Configuration
+
+- CRIT-12: `Combatant` MUST gain a new field `FumbleEffect string` (default `prone`) with allowed values `prone`, `off_guard_until_next_turn`, `drop_weapon`.
+- CRIT-13: For NPCs, `FumbleEffect` MUST be settable via `NPCTemplate.CombatStrategy.FumbleEffect`. Defaults to `prone` to preserve existing behavior.
+- CRIT-14: For player characters, `FumbleEffect` MUST be settable via a new account preference `combat.fumble_effect` (default `prone`) so players can pick which downside they prefer to suffer.
+- CRIT-15: When an attack resolves with `CritFailure`:
+  - `prone` — apply the existing `prone` condition (no change in behavior).
+  - `off_guard_until_next_turn` — apply the `off_guard` condition (per spec #252 NCA-4) for one turn.
+  - `drop_weapon` — unequip the active weapon and drop it to the attacker's grid cell as a pickup. The weapon is recovered with the existing `pickup` interaction.
+- CRIT-16: Drop-weapon fumble MUST be silently no-op when the attacker is already weapon-less (unarmed strike or already disarmed), defaulting to `prone` instead so the fumble still has *some* consequence.
+
+### 4.4 Combat Log Narrative
+
+- CRIT-17: When `AttackResult.StepAdjusted == true`, the combat log MUST include a clarifying line beneath the outcome banner: `"Natural <N> — outcome bumped <up|down>: <prev> → <new>"`.
+- CRIT-18: The natural-roll value already shown in the existing `1d20 (N)` breakdown MUST be retained; the step-adjustment line is additional, not a replacement.
+- CRIT-19: When a crit specialization effect fires, the combat log MUST emit one line per effect block summarizing the rider (e.g., `"<weapon group> critical specialization: <target> is staggered"`).
+- CRIT-20: Fumble-effect application MUST emit a clear line naming the effect (e.g., `"<attacker> drops the <weapon-name>"`).
+
+### 4.5 Tests
+
+- CRIT-21: Existing attack-outcome tests MUST pass unchanged.
+- CRIT-22: New unit tests in `internal/game/combat/resolver_natural_test.go` MUST cover every branch of CRIT-2 (eight transitions plus the two no-ops).
+- CRIT-23: A new test MUST verify that `combat.AdjustForNatural` produces the same result as the inlined version (anti-drift guard) and that the skill-action resolver (#252) shares the call.
+- CRIT-24: Crit specialization effects MUST be exercised by a scenario test per ground-truth weapon group, confirming the effect block is applied through the existing dispatch.
+- CRIT-25: Fumble configuration MUST be exercised by three scenario tests, one per `FumbleEffect` value, including the `drop_weapon → prone` fallback when unarmed.
+
+## 5. Architecture
+
+### 5.1 Where the new code lives
+
+```
+internal/game/combat/
+  combat.go                          # Outcome enum unchanged; AttackResult gains StepAdjusted bool
+  resolver.go                        # OutcomeFor signature change; AdjustForNatural helper added
+  resolver_natural_test.go           # NEW
+  fumble.go                          # NEW: applyFumble(combatant, FumbleEffect) → effect
+  fumble_test.go                     # NEW
+  crit_specialization.go             # NEW: load + apply per-group specialization
+
+internal/game/inventory/
+  weapon.go                          # existing; Group field already present (used as lookup key)
+
+content/weapons/crit_specializations/
+  default.yaml, firearm.yaml, melee_blade.yaml, polearm.yaml, improvised.yaml
+
+internal/game/npc/
+  template.go                        # CombatStrategy.FumbleEffect added
+
+internal/game/skillaction/           # existing; use combat.AdjustForNatural (refactor)
+
+internal/gameserver/grpc_service.go  # PreferenceUpdate for combat.fumble_effect
+
+api/proto/game/v1/game.proto
+  CombatPreferences message: optional combat.fumble_effect
+
+cmd/webclient/ui/src/game/character/
+  CombatPreferencesPanel.tsx         # NEW: toggle for fumble effect
+```
+
+### 5.2 Attack outcome flow
+
+```
+attack roll: d20 + modifiers
+   │
+   ▼
+OutcomeFor(total, ac, naturalRoll)
+   │
+   ├── base = baseOutcomeFromBands(total, ac)
+   ├── adjusted, stepAdjusted = AdjustForNatural(base, naturalRoll)
+   ▼
+AttackResult{ Outcome: adjusted, StepAdjusted: stepAdjusted, ... }
+   │
+   ▼
+round.go event emitter:
+   if stepAdjusted: emit "Natural N — outcome bumped: <prev> → <new>"
+   if outcome == CritSuccess: applySpecialization(weapon.Group, attacker, target)
+   if outcome == CritFailure: applyFumble(attacker, attacker.FumbleEffect)
+   if outcome in {Success, CritSuccess}: target.ApplyDamage(EffectiveDamage)
+```
+
+### 5.3 Single sources of truth
+
+- Step adjustment: `combat.AdjustForNatural` only.
+- Crit specialization data: `content/weapons/crit_specializations/*.yaml`.
+- Fumble dispatch: `combat.applyFumble` only.
+
+## 6. Open Questions
+
+- CRIT-Q1: Does the fumble `drop_weapon` fall back to `prone` (CRIT-16) or to `off_guard_until_next_turn`? Recommendation: `prone` for narrative consistency with the existing default; revisit if playtest shows it's too punishing on unarmed combatants.
+- CRIT-Q2: Does the natural-20 step bump apply to non-attack rolls beyond skill actions (saves, perception, initiative)? Recommendation: yes — `combat.AdjustForNatural` is generic. The actual integration with saves/perception/initiative is a follow-on each owned by their subsystem; this spec exposes the helper.
+- CRIT-Q3: Multi-attack actions (Strike with second-attack MAP) — does each attack's natural roll independently trigger the step? Recommendation: yes — every d20 roll is independently evaluated. Locked.
+- CRIT-Q4: Should a player's preference for `FumbleEffect` be visible to GMs / opponents (e.g., enemies anticipate that the player drops the weapon)? Recommendation: no — treat as private game-feel preference, server keeps it confidential.
+- CRIT-Q5: Crit specialization on AoE/template attacks (#250) — fires once per target, or once per template? Recommendation: once per target (per-attack evaluation) so the effect feels weapon-driven, not template-driven.
+
+## 7. Acceptance
+
+- [ ] All existing attack-outcome tests pass.
+- [ ] Eight new unit tests cover every step-adjustment branch.
+- [ ] Skill-action resolver (#252) and combat resolver share `combat.AdjustForNatural`.
+- [ ] At least four weapon groups have `crit_specializations/<group>.yaml` files; `default.yaml` is the fallback.
+- [ ] On a `CritSuccess` attack, the configured specialization fires and is logged.
+- [ ] On a `CritFailure` attack, the configured fumble fires (per attacker's `FumbleEffect`) and is logged; `drop_weapon` falls back to `prone` when unarmed.
+- [ ] Combat log shows the step-adjustment line when the natural roll bumped the outcome.
+- [ ] Player can change `combat.fumble_effect` from the web preferences panel.
+
+## 8. Out-of-Scope Follow-Ons
+
+- CRIT-F1: Crit-fishing feats / traits that expand crit ranges to 19-20.
+- CRIT-F2: Crit damage shape change to PF2E "double dice + modifiers" (current `× 2 final` stays).
+- CRIT-F3: Saving-throw integration of `AdjustForNatural`.
+- CRIT-F4: Initiative roll integration.
+- CRIT-F5: Crit-success on natural 20 even when total cannot meet AC (PF2E auto-success on natural-20 vs Will 100 is debated; current rule is bump-by-one only, so a natural 20 against impossible AC still misses unless one bump is enough).
+- CRIT-F6: Fumble tables (a random table of bizarre effects on crit-fail) — fun but out of scope.
+
+## 9. References
+
+- Issue: https://github.com/cory-johannsen/mud/issues/260
+- Outcome enum: `internal/game/combat/combat.go:26-49`
+- Outcome computation: `internal/game/combat/combat.go:219-230` (`OutcomeFor`)
+- Crit damage multiplier: `internal/game/combat/combat.go:30-42` (`EffectiveDamage`)
+- Existing `prone` on crit-fail: `internal/game/combat/round.go:407-410`
+- Crit narrative: `internal/game/combat/round.go:163-199` (`attackNarrative`)
+- Weapon model with Group field: `internal/game/inventory/weapon.go:38-67`
+- Skill action DoS resolver (sibling): `docs/superpowers/specs/2026-04-24-noncombat-actions-vs-combat-npcs.md` NCA-7
+- Off-guard condition: `docs/superpowers/specs/2026-04-24-noncombat-actions-vs-combat-npcs.md` NCA-4
+- Bonus pipeline used by specialization riders: `docs/superpowers/specs/2026-04-21-duplicate-effects-handling.md`


### PR DESCRIPTION
Spec for [issue #260](https://github.com/cory-johannsen/mud/issues/260). Outcome enum and band math exist; spec adds:

- Natural-roll step adjustment in OutcomeFor (post-band), shared via combat.AdjustForNatural with the skill-action resolver from #252.
- Weapon-group critical specialization keyed on existing WeaponDef.Group; 4 groups + default.
- Configurable fumble effect (prone | off_guard_until_next_turn | drop_weapon) per-NPC and per-character preference; existing prone default unchanged.
- Combat-log narrative line when step adjustment changed the outcome.

Spec file: `docs/superpowers/specs/2026-04-25-natural-1-and-20.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)