### PR TITLE
plan(#260): natural 1/20 step adjustment + crit specialization + fumble config

### DIFF
--- a/docs/superpowers/plans/2026-04-25-natural-1-and-20.md
+++ b/docs/superpowers/plans/2026-04-25-natural-1-and-20.md
@@ -1,0 +1,490 @@
+# Natural 1 / Natural 20 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the PF2E natural-1/20 step adjustment to the attack pipeline. Fire content-driven weapon critical specialization on `CritSuccess` keyed off `WeaponDef.Group`. Make the crit-failure fumble effect configurable per-NPC and per-character (`prone` default; alternatives `off_guard_until_next_turn`, `drop_weapon`). Single helper `combat.AdjustForNatural` is shared with the skill-action resolver from #252 so the rule lives in one place.
+
+**Spec:** [docs/superpowers/specs/2026-04-25-natural-1-and-20.md](https://github.com/cory-johannsen/mud/blob/main/docs/superpowers/specs/2026-04-25-natural-1-and-20.md) (PR [#287](https://github.com/cory-johannsen/mud/pull/287))
+
+**Architecture:** `OutcomeFor(total, ac, naturalRoll)` computes the band outcome, then calls `AdjustForNatural(base, naturalRoll) (Outcome, bool)` which encapsulates the eight-branch table. `AttackResult` gains a `StepAdjusted bool` so the renderer can emit the clarification line. Crit specialization data lives in `content/weapons/crit_specializations/<group>.yaml` and is dispatched on `CritSuccess` via the existing effect-block dispatch (shared with #255 / #252 / #257). Fumble effect is a `Combatant.FumbleEffect string` field set from `NPCTemplate.CombatStrategy.FumbleEffect` for NPCs and from a new `combat.fumble_effect` account preference for players.
+
+**Tech Stack:** Go (`internal/game/combat/`, `internal/game/inventory/`, `internal/game/npc/`, `internal/gameserver/`), protobuf (CombatPreferences), telnet, React/TypeScript (`cmd/webclient/ui/src/game/character/`).
+
+**Prerequisite:** None hard. #245 typed-bonus pipeline is merged. #252's NCA-7 already encodes this rule; this plan refactors that to share `combat.AdjustForNatural`. If #252 has not landed yet, the helper is created here and #252 imports it later.
+
+**Note on spec PR**: Spec is on PR #287, not yet merged. Plan PR depends on spec PR landing first.
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Modify | `internal/game/combat/combat.go` (`AttackResult.StepAdjusted`) |
+| Modify | `internal/game/combat/resolver.go` (`OutcomeFor` signature change; `AdjustForNatural`) |
+| Create | `internal/game/combat/resolver_natural_test.go` |
+| Create | `internal/game/combat/fumble.go` (`applyFumble`) |
+| Create | `internal/game/combat/fumble_test.go` |
+| Create | `internal/game/combat/crit_specialization.go` |
+| Create | `internal/game/combat/crit_specialization_test.go` |
+| Modify | `internal/game/combat/round.go` (route to `AdjustForNatural`; emit step-adjusted line; call specialization + fumble) |
+| Modify | `internal/game/combat/round_test.go` |
+| Modify | `internal/game/npc/template.go` (`CombatStrategy.FumbleEffect`) |
+| Modify | `internal/game/npc/template_test.go` |
+| Modify | `internal/gameserver/grpc_service.go` (`CombatPreferences` set/get) |
+| Modify | `api/proto/game/v1/game.proto` (`CombatPreferences` message; `combat.fumble_effect` field) |
+| Modify | `internal/game/skillaction/dos.go` or `resolver.go` (refactor to call `combat.AdjustForNatural`) |
+| Create | `content/weapons/crit_specializations/default.yaml`, `firearm.yaml`, `melee_blade.yaml`, `polearm.yaml`, `improvised.yaml` |
+| Create | `cmd/webclient/ui/src/game/character/CombatPreferencesPanel.tsx` |
+| Create | `cmd/webclient/ui/src/game/character/CombatPreferencesPanel.test.tsx` |
+| Modify | `docs/architecture/combat.md` |
+
+---
+
+### Task 1: `AdjustForNatural` helper + `OutcomeFor` extension
+
+**Files:**
+- Modify: `internal/game/combat/combat.go`
+- Modify: `internal/game/combat/resolver.go`
+- Create: `internal/game/combat/resolver_natural_test.go`
+
+- [ ] **Step 1: Failing tests** — every branch of CRIT-2 (CRIT-22):
+
+```go
+func TestAdjustForNatural_Nat20Cases(t *testing.T) {
+    cases := []struct {
+        base   combat.Outcome
+        want   combat.Outcome
+        bumped bool
+    }{
+        {combat.CritFailure, combat.Failure,    true},
+        {combat.Failure,     combat.Success,    true},
+        {combat.Success,     combat.CritSuccess,true},
+        {combat.CritSuccess, combat.CritSuccess,false},
+    }
+    for _, c := range cases {
+        got, bumped := combat.AdjustForNatural(c.base, 20)
+        require.Equal(t, c.want, got)
+        require.Equal(t, c.bumped, bumped)
+    }
+}
+
+func TestAdjustForNatural_Nat1Cases(t *testing.T) {
+    cases := []struct {
+        base   combat.Outcome
+        want   combat.Outcome
+        bumped bool
+    }{
+        {combat.CritSuccess, combat.Success,    true},
+        {combat.Success,     combat.Failure,    true},
+        {combat.Failure,     combat.CritFailure,true},
+        {combat.CritFailure, combat.CritFailure,false},
+    }
+    for _, c := range cases {
+        got, bumped := combat.AdjustForNatural(c.base, 1)
+        require.Equal(t, c.want, got)
+        require.Equal(t, c.bumped, bumped)
+    }
+}
+
+func TestAdjustForNatural_NeitherEdge_NoChange(t *testing.T) {
+    for _, base := range []combat.Outcome{combat.CritFailure, combat.Failure, combat.Success, combat.CritSuccess} {
+        for _, n := range []int{2, 10, 19} {
+            got, bumped := combat.AdjustForNatural(base, n)
+            require.Equal(t, base, got)
+            require.False(t, bumped)
+        }
+    }
+}
+
+func TestOutcomeFor_AppliesAdjustmentAfterAC(t *testing.T) {
+    // Total 5 vs AC 20 = CritFailure base; nat 20 bumps to Failure.
+    res := combat.OutcomeFor(5, 20, 20)
+    require.Equal(t, combat.Failure, res.Outcome)
+    require.True(t, res.StepAdjusted)
+}
+
+func TestOutcomeFor_BaseCalculationUnchangedAtNonNat(t *testing.T) {
+    res := combat.OutcomeFor(15, 14, 11)
+    require.Equal(t, combat.Success, res.Outcome)
+    require.False(t, res.StepAdjusted)
+}
+```
+
+- [ ] **Step 2: Implement**:
+
+```go
+func AdjustForNatural(base Outcome, naturalRoll int) (Outcome, bool) {
+    switch naturalRoll {
+    case 20:
+        switch base {
+        case CritFailure: return Failure, true
+        case Failure:     return Success, true
+        case Success:     return CritSuccess, true
+        }
+    case 1:
+        switch base {
+        case CritSuccess: return Success, true
+        case Success:     return Failure, true
+        case Failure:     return CritFailure, true
+        }
+    }
+    return base, false
+}
+
+type AttackResult struct {
+    Outcome      Outcome
+    StepAdjusted bool
+    // ... existing fields
+}
+
+func OutcomeFor(total, ac, naturalRoll int) AttackResult {
+    base := baseOutcomeFromBands(total, ac)
+    adj, bumped := AdjustForNatural(base, naturalRoll)
+    return AttackResult{Outcome: adj, StepAdjusted: bumped}
+}
+```
+
+- [ ] **Step 3: Update existing call sites** of `OutcomeFor` to pass `naturalRoll`. The roll is already captured at the resolver entry point.
+
+- [ ] **Step 4: Refactor #252** (if landed): replace its inline DoS step-adjustment with a call to `combat.AdjustForNatural`. Anti-drift test:
+
+```go
+func TestSkillActionResolver_UsesSharedAdjustForNatural(t *testing.T) {
+    require.True(t, usesSharedAdjustForNatural(t, "skillaction.Resolve"))
+}
+```
+
+(Implemented as a small reflection-based audit.)
+
+---
+
+### Task 2: Crit specialization content + dispatch
+
+**Files:**
+- Create: `internal/game/combat/crit_specialization.go`
+- Create: `internal/game/combat/crit_specialization_test.go`
+- Create: `content/weapons/crit_specializations/default.yaml`, `firearm.yaml`, `melee_blade.yaml`, `polearm.yaml`, `improvised.yaml`
+
+- [ ] **Step 1: Checkpoint (CRIT-8).** Confirm with user the specialization content for each of the four ground-truth weapon groups. Suggested defaults (from PF2E):
+  - `firearm`: target takes `1d6` persistent fire damage (cordite burn).
+  - `melee_blade`: target is `flat-footed` until end of attacker's next turn.
+  - `polearm`: target is `prone`.
+  - `improvised`: target is `clumsy 1` for one round.
+
+- [ ] **Step 2: Failing tests** (CRIT-7, CRIT-10, CRIT-11):
+
+```go
+func TestCritSpecialization_LoadsAllGroups(t *testing.T) {
+    spec := combat.LoadCritSpecializations(t, "content/weapons/crit_specializations")
+    require.NotNil(t, spec.ByGroup("firearm"))
+    require.NotNil(t, spec.ByGroup("melee_blade"))
+    require.NotNil(t, spec.ByGroup("default"))
+}
+
+func TestCritSpecialization_FiresOnCritSuccess(t *testing.T) {
+    cbt := newCombat()
+    a := newCombatant(cbt, "a", withWeaponGroup("firearm"))
+    b := newCombatant(cbt, "b")
+    combat.ApplyCritSpecialization(cbt, a, b, "firearm")
+    require.True(t, b.HasActive("persistent_fire"))
+}
+
+func TestCritSpecialization_FallsBackToDefault(t *testing.T) {
+    cbt := newCombat()
+    a := newCombatant(cbt, "a", withWeaponGroup("magic_wand_pistol")) // unknown group
+    b := newCombatant(cbt, "b")
+    log := captureLog(t)
+    combat.ApplyCritSpecialization(cbt, a, b, "magic_wand_pistol")
+    require.Contains(t, log.LastLine(), "lands solidly")
+}
+
+func TestCritSpecialization_EffectsRouteThroughBonusPipeline(t *testing.T) {
+    // CRIT-11: when a specialization applies a typed condition, the bonus
+    // pipeline picks it up via the same dispatch as skill actions and challenges.
+    ...
+}
+```
+
+- [ ] **Step 3: Implement** the loader and dispatcher. Specialization YAML reuses the effect-block dispatch from #255 / #252 / #257:
+
+```yaml
+# content/weapons/crit_specializations/firearm.yaml
+group: firearm
+display_name: Firearm Critical Specialization
+effects:
+  - { apply_condition: { id: persistent_fire, stacks: 1, duration_rounds: 3 } }
+  - { narrative: { text: "{attacker}'s shot ignites {target}." } }
+```
+
+```go
+type Specializations struct {
+    byGroup map[string]*Specialization
+    fallback *Specialization
+}
+
+func ApplyCritSpecialization(cbt *Combat, attacker, target *Combatant, group string) {
+    spec := cbt.CritSpec.ByGroup(group)
+    if spec == nil { spec = cbt.CritSpec.Fallback() }
+    for _, e := range spec.Effects {
+        e.Apply(applyCtx(cbt, attacker, target))
+    }
+}
+```
+
+---
+
+### Task 3: Fumble configuration + dispatch
+
+**Files:**
+- Create: `internal/game/combat/fumble.go`
+- Create: `internal/game/combat/fumble_test.go`
+- Modify: `internal/game/npc/template.go` (`CombatStrategy.FumbleEffect`)
+- Modify: `internal/game/combat/combatant_effects.go` or appropriate construction site (set `Combatant.FumbleEffect` from npc template / character preference)
+
+- [ ] **Step 1: Failing tests** (CRIT-12..16, CRIT-25):
+
+```go
+func TestApplyFumble_ProneIsDefault(t *testing.T) {
+    a := newCombatant(t)
+    require.Equal(t, "prone", a.FumbleEffect)
+    combat.ApplyFumble(a)
+    require.True(t, a.HasActive("prone"))
+}
+
+func TestApplyFumble_OffGuardUntilNextTurn(t *testing.T) {
+    a := newCombatant(t, withFumble("off_guard_until_next_turn"))
+    combat.ApplyFumble(a)
+    require.True(t, a.HasActive("off_guard"))
+    advanceTurn(t, a)
+    require.False(t, a.HasActive("off_guard"), "expires at start of next turn")
+}
+
+func TestApplyFumble_DropWeapon(t *testing.T) {
+    a := newCombatant(t, withFumble("drop_weapon"), withEquippedWeapon("pistol"))
+    combat.ApplyFumble(a)
+    require.Empty(t, a.EquippedWeapon())
+    require.Contains(t, roomItemsAt(a.Cell()), "pistol")
+}
+
+func TestApplyFumble_DropWeapon_FallsBackToProneWhenUnarmed(t *testing.T) {
+    a := newCombatant(t, withFumble("drop_weapon"), withNoWeapon())
+    combat.ApplyFumble(a)
+    require.True(t, a.HasActive("prone"), "CRIT-16 fallback")
+}
+```
+
+- [ ] **Step 2: Implement**:
+
+```go
+type FumbleEffect string
+
+const (
+    FumbleProne                FumbleEffect = "prone"
+    FumbleOffGuardUntilNextTurn FumbleEffect = "off_guard_until_next_turn"
+    FumbleDropWeapon           FumbleEffect = "drop_weapon"
+)
+
+func ApplyFumble(a *Combatant) {
+    eff := FumbleEffect(a.FumbleEffect)
+    if eff == "" { eff = FumbleProne }
+    switch eff {
+    case FumbleProne:
+        a.ApplyCondition("prone", DurationUntilStandUp)
+    case FumbleOffGuardUntilNextTurn:
+        a.ApplyCondition("off_guard", DurationUntilNextTurn)
+    case FumbleDropWeapon:
+        if w := a.EquippedWeapon(); w != nil {
+            a.UnequipWeapon()
+            a.Combat.RoomDropAt(a.Cell(), w)
+        } else {
+            a.ApplyCondition("prone", DurationUntilStandUp) // CRIT-16 fallback
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add NPC template field**:
+
+```go
+type CombatStrategy struct {
+    // ... existing ...
+    FumbleEffect string // prone | off_guard_until_next_turn | drop_weapon
+}
+```
+
+- [ ] **Step 4: Wire** `Combatant.FumbleEffect` from the NPC template at instance creation; from the character's `combat.fumble_effect` preference at character load.
+
+- [ ] **Step 5:** Existing crit-fail prone behavior (`round.go:407-410`) is replaced by a call to `ApplyFumble(attacker)`.
+
+---
+
+### Task 4: Combat log narrative — step-adjusted line + specialization + fumble
+
+**Files:**
+- Modify: `internal/game/combat/round.go`
+- Modify: `internal/game/combat/round_test.go`
+
+- [ ] **Step 1: Failing tests** (CRIT-17..20):
+
+```go
+func TestRoundLog_StepAdjustedLineEmittedOnNat20Bump(t *testing.T) {
+    cbt := buildCombatWithKnownDice(20)
+    res := resolveAttack(cbt, attacker, target /*low total vs high AC, base = Failure*/)
+    require.True(t, res.StepAdjusted)
+    require.Contains(t, cbt.LastLog(), "Natural 20 — outcome bumped up: failure → success")
+}
+
+func TestRoundLog_SpecializationLineOnCrit(t *testing.T) {
+    cbt := buildCombatWithKnownDice(20, totalAboveAC10)
+    resolveAttackToCrit(cbt, attacker, target)
+    require.Contains(t, cbt.LastLog(), "firearm critical specialization")
+    require.Contains(t, cbt.LastLog(), "ignites")
+}
+
+func TestRoundLog_FumbleLineEmittedOnCritFailure(t *testing.T) {
+    cbt := buildCombatWithKnownDice(1)
+    resolveAttackToCritFail(cbt, attackerWithFumbleDropWeapon, target)
+    require.Contains(t, cbt.LastLog(), "drops the")
+}
+```
+
+- [ ] **Step 2: Implement** the three log emit points in `round.go`:
+
+```go
+result := OutcomeFor(total, target.AC, naturalRoll)
+if result.StepAdjusted {
+    log.Emit(formatStepAdjusted(naturalRoll, baseOf(result), result.Outcome))
+}
+switch result.Outcome {
+case CritSuccess:
+    ApplyCritSpecialization(cbt, attacker, target, attacker.WeaponGroup())
+case CritFailure:
+    ApplyFumble(attacker)
+}
+```
+
+The narrative format for CRIT-17 follows the spec text exactly: `"Natural <N> — outcome bumped <up|down>: <prev> → <new>"`.
+
+---
+
+### Task 5: gRPC `CombatPreferences` + web panel
+
+**Files:**
+- Modify: `api/proto/game/v1/game.proto`
+- Modify: `internal/gameserver/grpc_service.go`
+- Create: `cmd/webclient/ui/src/game/character/CombatPreferencesPanel.tsx`
+- Create: `cmd/webclient/ui/src/game/character/CombatPreferencesPanel.test.tsx`
+
+- [ ] **Step 1: Add proto messages** (CRIT-14):
+
+```proto
+message CombatPreferences {
+  string fumble_effect = 1;  // "prone" | "off_guard_until_next_turn" | "drop_weapon"
+}
+
+message GetCombatPreferencesRequest  { string character_id = 1; }
+message GetCombatPreferencesResponse { CombatPreferences prefs = 1; }
+message UpdateCombatPreferencesRequest  { string character_id = 1; CombatPreferences prefs = 2; }
+message UpdateCombatPreferencesResponse {}
+```
+
+- [ ] **Step 2: Failing handler tests**:
+
+```go
+func TestUpdateCombatPreferences_PersistsAndRound(t *testing.T) {
+    s := newServer(t, withCharacter("c1"))
+    s.UpdateCombatPreferences(ctx, &gamev1.UpdateCombatPreferencesRequest{
+        CharacterId: "c1",
+        Prefs: &gamev1.CombatPreferences{FumbleEffect: "drop_weapon"},
+    })
+    res, _ := s.GetCombatPreferences(ctx, &gamev1.GetCombatPreferencesRequest{CharacterId: "c1"})
+    require.Equal(t, "drop_weapon", res.Prefs.FumbleEffect)
+    // Verify the in-flight character struct picks it up.
+    char := s.LoadCharacter("c1")
+    require.Equal(t, "drop_weapon", char.Combatant().FumbleEffect)
+}
+
+func TestUpdateCombatPreferences_RejectsInvalidValue(t *testing.T) {
+    s := newServer(t, withCharacter("c1"))
+    _, err := s.UpdateCombatPreferences(ctx, &gamev1.UpdateCombatPreferencesRequest{
+        CharacterId: "c1",
+        Prefs: &gamev1.CombatPreferences{FumbleEffect: "bogus"},
+    })
+    require.Error(t, err)
+}
+```
+
+- [ ] **Step 3: Persistence** — preference stored in the existing per-character preferences blob (no new table required if the project uses a JSON column; otherwise small `character_combat_preferences` table).
+
+- [ ] **Step 4: Web panel tests** (CRIT-Q4 — privacy):
+
+```ts
+test("CombatPreferencesPanel renders three radio options", () => {
+  render(<CombatPreferencesPanel value={"prone"} />);
+  expect(screen.getByLabelText(/Prone/)).toBeChecked();
+  expect(screen.getByLabelText(/Off-guard/)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Drop weapon/)).toBeInTheDocument();
+});
+
+test("Selecting an option dispatches UpdateCombatPreferences", () => {
+  const dispatch = jest.fn();
+  render(<CombatPreferencesPanel value={"prone"} dispatch={dispatch} />);
+  fireEvent.click(screen.getByLabelText(/Drop weapon/));
+  expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ fumble_effect: "drop_weapon" }));
+});
+```
+
+- [ ] **Step 5: Implement** the panel. Visible only to the character's owner (server keeps the preference confidential per CRIT-Q4).
+
+---
+
+### Task 6: Architecture documentation
+
+**Files:**
+- Modify: `docs/architecture/combat.md`
+
+- [ ] **Step 1: Add a "Critical Outcomes" section** documenting:
+  - The natural-1/20 step adjustment table.
+  - The shared `combat.AdjustForNatural` helper and where it is called from.
+  - The crit-specialization content path and the per-group authoring shape.
+  - The fumble effect ladder and the per-NPC / per-character configuration.
+  - Open question resolutions (CRIT-Q1..Q5).
+
+- [ ] **Step 2: Cross-link** `internal/game/combat/resolver.go`, `crit_specialization.go`, `fumble.go`, the spec, and the consuming subsystems (#252 sharing the helper).
+
+---
+
+## Verification
+
+```
+go test ./...
+( cd cmd/webclient/ui && pnpm test )
+```
+
+Additional sanity:
+
+- `go vet ./...` clean.
+- `make proto` re-runs cleanly.
+- Telnet smoke test: trigger an attack with deterministic dice (`1d20 == 20`, total still below AC by some margin), verify the step-adjustment line and the new outcome; trigger `CritSuccess` with a `firearm`, verify the persistent-fire condition; trigger `CritFailure` with `drop_weapon`, verify the weapon drops to the cell.
+- Web smoke test: open the combat preferences panel; pick `drop_weapon`; confirm the preference round-trips.
+
+---
+
+## Rollout / Open Questions Resolved at Plan Time
+
+- **CRIT-Q1**: `drop_weapon` falls back to `prone` (CRIT-16) for narrative consistency. Revisit at playtest.
+- **CRIT-Q2**: `AdjustForNatural` is generic. Saves / perception / initiative integrate as follow-ons each owned by their subsystem.
+- **CRIT-Q3**: Multi-attack actions evaluate every d20 independently.
+- **CRIT-Q4**: `combat.fumble_effect` is private to the player. Server does not surface to opponents.
+- **CRIT-Q5**: AoE / template attacks fire crit specialization once per target.
+
+## Non-Goals Reaffirmed
+
+Per spec §2.2:
+
+- No crit damage shape change.
+- No crit specialization for every weapon group on day one (four + default).
+- No fumble outcomes that change AP economy.
+- No crit-fishing range expansion.
+- No saving-throw / skill-check natural-1/20 integration (skill actions handled by #252).


### PR DESCRIPTION
Plan for [#260](https://github.com/cory-johannsen/mud/issues/260); spec on PR [#287](https://github.com/cory-johannsen/mud/pull/287) (not merged — depends on it).

Plan: docs/superpowers/plans/2026-04-25-natural-1-and-20.md

Six tasks covering all 25 CRIT-N requirements: AdjustForNatural helper, crit-specialization YAML + dispatch (firearm/melee_blade/polearm/improvised + default fallback), fumble config (prone/off_guard_until_next_turn/drop_weapon), combat log narrative, CombatPreferences RPC + web panel, architecture docs.

## User-confirmation checkpoint
- Task 2 (CRIT-8): Confirm specialization content for the four ground-truth weapon groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)