### PR TITLE
feat(cover): Cover bonuses in combat — fix AC inversion (#247)

### DIFF
--- a/docs/architecture/combat.md
+++ b/docs/architecture/combat.md
@@ -210,6 +210,58 @@ post-pipeline scalar — before `ApplyDamage`. They do not see the breakdown in 
 - Players with `PlayerSession.ShowDamageBreakdown` receive the verbose block as a separate
   message; everyone sees the inline breakdown appended to the attack narrative.
 
+## Cover (COVER Requirements)
+
+### Requirements
+
+- COVER-1: Cover tier is determined per attack-resolution event by reading the target combatant's `CoverTier` field (set when the target uses a cover-granting action). In the 1D linear combat model there is no Bresenham line walk; the tier is carried on the combatant.
+- COVER-2: The highest cover tier present on the target is returned (`greater > standard > lesser`).
+- COVER-3: Cover tier-to-bonus mapping: `lesser = +1 AC`; `standard = +2 AC, +2 Quickness`; `greater = +4 AC, +4 Quickness`.
+- COVER-4: Cover bonuses are applied as `circumstance`-typed bonuses to `target.Effects` before each attack resolution and removed immediately after.
+- COVER-5: Cover effects use `SourceID = "cover:<tier>"` and `CasterUID = ""`.
+- COVER-6: `DetermineCoverTier` returns `NoCover` when the target has no cover tier set.
+- COVER-8: Attack resolution derives effective AC as `target.AC + target.InitiativeBonus + effect.Resolve(target.Effects, StatAC).Total`.
+- COVER-9: Attack resolution derives effective attack total as `r.AttackTotal + effect.Resolve(actor.Effects, StatAttack).Total`.
+- COVER-10: The pre-existing inversion where the target's AC bonus was added to `r.AttackTotal` is removed; COVER-8/COVER-9 formulas apply at every call site.
+- COVER-11: Cover absorb-miss: if the attack would have hit without the cover AC bonus, `ActionCoverHit` fires and the cover object degrades.
+- COVER-13: When cover absorbs a miss, `ActionCoverHit` emits a dedicated `"<actor>'s attack hits <target>'s cover!"` event; per-attack narrative is unchanged.
+
+### Tier-to-Bonus Table
+
+| Tier     | AC Bonus | Quickness Bonus | SourceID         |
+|----------|----------|-----------------|------------------|
+| none     | 0        | 0               | —                |
+| lesser   | +1       | 0               | `cover:lesser`   |
+| standard | +2       | +2              | `cover:standard` |
+| greater  | +4       | +4              | `cover:greater`  |
+
+### AC Derivation (post-fix)
+
+```
+effectiveAC  = target.AC + target.InitiativeBonus + effect.Resolve(target.Effects, StatAC).Total
+effectiveAtk = r.AttackTotal + effect.Resolve(actor.Effects, StatAttack).Total
+```
+
+Both include condition effects (via `Combatant.Effects` after #245), cover effects (ephemerally applied), and feat/tech/equip effects.
+
+### Absorb-Miss Logic
+
+```
+if attack missed AND coverTier > NoCover:
+    coverAC, _ := CoverBonus(coverTier)
+    if r.AttackTotal >= effectiveAC - coverAC:
+        fire ActionCoverHit for target.CoverEquipmentID
+        degrade the cover object
+```
+
+### Implementation Files
+
+| File | Responsibility |
+|------|----------------|
+| `internal/game/combat/cover_bonus.go` | `CoverTier` enum, `CoverBonus`, `DetermineCoverTier`, `BuildCoverEffect`, `WithCoverEffect` |
+| `internal/game/combat/round.go` | 5 attack resolution sites; ephemeral apply/remove; absorb-miss check |
+| `internal/game/effect/bonus.go` | `StatQuickness` constant |
+
 ## Component Dependencies
 
 ```mermaid

--- a/internal/game/combat/cover_bonus.go
+++ b/internal/game/combat/cover_bonus.go
@@ -1,0 +1,120 @@
+package combat
+
+import "github.com/cory-johannsen/mud/internal/game/effect"
+
+// CoverTier represents the tier of cover a combatant is behind.
+// Tiers are ordered: NoCover < Lesser < Standard < Greater.
+type CoverTier int
+
+const (
+	NoCover CoverTier = iota
+	Lesser
+	Standard
+	Greater
+)
+
+func (t CoverTier) String() string {
+	switch t {
+	case Lesser:
+		return "lesser"
+	case Standard:
+		return "standard"
+	case Greater:
+		return "greater"
+	default:
+		return "none"
+	}
+}
+
+// CoverTierFromString converts a canonical tier name to a CoverTier.
+// Unknown strings (including empty) map to NoCover.
+func CoverTierFromString(s string) CoverTier {
+	switch s {
+	case "lesser":
+		return Lesser
+	case "standard":
+		return Standard
+	case "greater":
+		return Greater
+	default:
+		return NoCover
+	}
+}
+
+// DetermineCoverTier returns the cover tier the target is behind.
+// In the 1D linear combat model, cover is carried on the combatant via
+// Combatant.CoverTier. Returns NoCover when the target is not in cover.
+func DetermineCoverTier(target *Combatant) CoverTier {
+	if target == nil {
+		return NoCover
+	}
+	return CoverTierFromString(target.CoverTier)
+}
+
+// AC and Quickness bonus magnitudes for each cover tier.
+const (
+	CoverACBonusLesser   = 1
+	CoverACBonusStandard = 2
+	CoverACBonusGreater  = 4
+	CoverQKBonusStandard = 2
+	CoverQKBonusGreater  = 4
+)
+
+// CoverBonus returns the AC and Quickness circumstance bonus magnitudes for the given tier.
+func CoverBonus(t CoverTier) (acBonus, quicknessBonus int) {
+	switch t {
+	case Lesser:
+		return CoverACBonusLesser, 0
+	case Standard:
+		return CoverACBonusStandard, CoverQKBonusStandard
+	case Greater:
+		return CoverACBonusGreater, CoverQKBonusGreater
+	default:
+		return 0, 0
+	}
+}
+
+// CoverSourceID returns the canonical SourceID for the cover effect at the given tier.
+func CoverSourceID(t CoverTier) string {
+	return "cover:" + t.String()
+}
+
+// BuildCoverEffect constructs an ephemeral circumstance-typed Effect that contributes
+// the AC (and Quickness when applicable) bonus for the given tier. Returns an Effect
+// with no Bonuses when t == NoCover.
+func BuildCoverEffect(t CoverTier) effect.Effect {
+	ac, qk := CoverBonus(t)
+	bonuses := make([]effect.Bonus, 0, 2)
+	if ac != 0 {
+		bonuses = append(bonuses, effect.Bonus{
+			Stat:  effect.StatAC,
+			Value: ac,
+			Type:  effect.BonusTypeCircumstance,
+		})
+	}
+	if qk != 0 {
+		bonuses = append(bonuses, effect.Bonus{
+			Stat:  effect.StatQuickness,
+			Value: qk,
+			Type:  effect.BonusTypeCircumstance,
+		})
+	}
+	return effect.Effect{
+		EffectID:   "cover_" + t.String(),
+		SourceID:   CoverSourceID(t),
+		CasterUID:  "",
+		Bonuses:    bonuses,
+		DurKind:    effect.DurationUntilRemove,
+		Annotation: "cover (" + t.String() + ")",
+	}
+}
+
+// WithCoverEffect applies the cover bonus effect to target.Effects for the duration
+// of fn, then removes it.
+func WithCoverEffect(target *Combatant, tier CoverTier, fn func()) {
+	if tier > NoCover && target != nil && target.Effects != nil {
+		target.Effects.Apply(BuildCoverEffect(tier))
+		defer target.Effects.Remove(CoverSourceID(tier), "")
+	}
+	fn()
+}

--- a/internal/game/combat/cover_bonus_test.go
+++ b/internal/game/combat/cover_bonus_test.go
@@ -1,0 +1,75 @@
+package combat_test
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+func TestProperty_CoverBonus_MatchesSpec(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		tier := rapid.SampledFrom([]combat.CoverTier{
+			combat.Lesser, combat.Standard, combat.Greater,
+		}).Draw(rt, "tier")
+		ac, qk := combat.CoverBonus(tier)
+		switch tier {
+		case combat.Lesser:
+			if ac != 1 {
+				rt.Fatalf("Lesser cover: want AC=1 got %d", ac)
+			}
+			if qk != 0 {
+				rt.Fatalf("Lesser cover: want QK=0 got %d", qk)
+			}
+		case combat.Standard:
+			if ac != 2 {
+				rt.Fatalf("Standard cover: want AC=2 got %d", ac)
+			}
+			if qk != 2 {
+				rt.Fatalf("Standard cover: want QK=2 got %d", qk)
+			}
+		case combat.Greater:
+			if ac != 4 {
+				rt.Fatalf("Greater cover: want AC=4 got %d", ac)
+			}
+			if qk != 4 {
+				rt.Fatalf("Greater cover: want QK=4 got %d", qk)
+			}
+		}
+	})
+}
+
+func TestProperty_CoverTierRoundtrip(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		tier := rapid.SampledFrom([]combat.CoverTier{
+			combat.Lesser, combat.Standard, combat.Greater,
+		}).Draw(rt, "tier")
+		got := combat.CoverTierFromString(tier.String())
+		if got != tier {
+			rt.Fatalf("roundtrip: got %v want %v", got, tier)
+		}
+	})
+}
+
+func TestProperty_BuildCoverEffect_NoCoverHasNoBonuses(t *testing.T) {
+	e := combat.BuildCoverEffect(combat.NoCover)
+	if len(e.Bonuses) != 0 {
+		t.Fatalf("NoCover effect must have no bonuses, got %d", len(e.Bonuses))
+	}
+}
+
+func TestDetermineCoverTier_EmptyStringIsNoCover(t *testing.T) {
+	c := &combat.Combatant{CoverTier: ""}
+	got := combat.DetermineCoverTier(c)
+	if got != combat.NoCover {
+		t.Fatalf("empty CoverTier: want NoCover got %v", got)
+	}
+}
+
+func TestCoverBonus_NoCoverIsZero(t *testing.T) {
+	ac, qk := combat.CoverBonus(combat.NoCover)
+	if ac != 0 || qk != 0 {
+		t.Fatalf("NoCover must yield 0,0 got %d,%d", ac, qk)
+	}
+}

--- a/internal/game/combat/cover_degradation_test.go
+++ b/internal/game/combat/cover_degradation_test.go
@@ -21,27 +21,37 @@ func (s coverFixedSrc) Intn(_ int) int {
 	return v
 }
 
+// coverTierForPenalty maps an AC bonus magnitude (1, 2, or 4) to the canonical
+// cover tier string the new pipeline understands (lesser, standard, greater).
+func coverTierForPenalty(coverPenalty int) string {
+	switch coverPenalty {
+	case combat.CoverACBonusLesser:
+		return "lesser"
+	case combat.CoverACBonusStandard:
+		return "standard"
+	case combat.CoverACBonusGreater:
+		return "greater"
+	default:
+		return ""
+	}
+}
+
 // buildCoverCombat builds a minimal *Combat where:
 //   - Player "p1" has AC=10 (bare minimum; attack bonuses come from level+str)
-//   - NPC "n1" has AC=baseAC with a standard_cover condition providing ACPenalty=coverPenalty
-//   - n1 has CoverTier="standard_cover" and CoverEquipmentID="equip1"
+//   - NPC "n1" has AC=baseAC and CoverTier set to the canonical tier matching
+//     coverPenalty (1=lesser, 2=standard, 4=greater) plus CoverEquipmentID="equip1"
+//
+// Under the post-#247 pipeline, cover is sourced from Combatant.CoverTier;
+// DetermineCoverTier+BuildCoverEffect inject an ephemeral circumstance AC bonus
+// at attack-resolution time. The legacy ACPenalty-on-condition hack has been
+// removed because it inverted AC and AttackTotal.
 //
 // The attacker p1 queues an ActionAttack against n1.
 // The src will always produce attackRoll for d20 calls.
 func buildCoverCombat(t *rapid.T, baseAC, coverPenalty, attackRoll int) *combat.Combat {
 	t.Helper()
 	reg := condition.NewRegistry()
-	// Register a synthetic cover condition that penalises the attacker's roll.
-	// ACPenalty on the defender's condition set is subtracted from the attacker's roll
-	// via condition.ACBonus (returns -ACPenalty).
-	reg.Register(&condition.ConditionDef{
-		ID:           "test_cover",
-		Name:         "Test Cover",
-		DurationType: "permanent",
-		MaxStacks:    0,
-		ACPenalty:    coverPenalty,
-	})
-	// Also register standard conditions to keep the engine happy.
+	// Standard conditions registered to keep the engine happy.
 	reg.Register(&condition.ConditionDef{ID: "prone", Name: "Prone", DurationType: "permanent"})
 	reg.Register(&condition.ConditionDef{ID: "flat_footed", Name: "Flat-Footed", DurationType: "rounds"})
 	reg.Register(&condition.ConditionDef{ID: "dying", Name: "Dying", DurationType: "until_save", MaxStacks: 4})
@@ -56,17 +66,13 @@ func buildCoverCombat(t *rapid.T, baseAC, coverPenalty, attackRoll int) *combat.
 		{
 			ID: "n1", Kind: combat.KindNPC, Name: "Defender",
 			MaxHP: 30, CurrentHP: 30, AC: baseAC, Level: 0, StrMod: 0, DexMod: 0,
-			CoverTier:        "test_cover",
+			CoverTier:        coverTierForPenalty(coverPenalty),
 			CoverEquipmentID: "equip1",
 		},
 	}
 	cbt, err := eng.StartCombat("testroom", combatants, reg, nil, "")
 	if err != nil {
 		t.Fatalf("StartCombat: %v", err)
-	}
-	// Apply the cover condition to the defender so ACBonus returns -coverPenalty.
-	if err := cbt.ApplyCondition("n1", "test_cover", 1, -1); err != nil {
-		t.Fatalf("ApplyCondition: %v", err)
 	}
 	_ = cbt.StartRound(3)
 	if err := cbt.QueueAction("p1", combat.QueuedAction{Type: combat.ActionAttack, Target: "Defender"}); err != nil {

--- a/internal/game/combat/cover_integration_test.go
+++ b/internal/game/combat/cover_integration_test.go
@@ -1,0 +1,58 @@
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	"github.com/cory-johannsen/mud/internal/game/effect"
+)
+
+// TestCoverBonus_StandardCover_RaisesEffectiveAC confirms that applying
+// BuildCoverEffect to target.Effects increases the resolved AC bonus by
+// the expected magnitude per tier.
+func TestCoverBonus_StandardCover_RaisesEffectiveAC(t *testing.T) {
+	target := &combat.Combatant{
+		ID: "target", Name: "target", Kind: combat.KindNPC,
+		AC: 16, MaxHP: 30,
+		CoverTier: "standard", CoverEquipmentID: "crate_01",
+		Effects: effect.NewEffectSet(),
+	}
+	coverTier := combat.DetermineCoverTier(target)
+	if coverTier != combat.Standard {
+		t.Fatalf("expected Standard cover tier, got %v", coverTier)
+	}
+	target.Effects.Apply(combat.BuildCoverEffect(coverTier))
+	defer target.Effects.Remove(combat.CoverSourceID(coverTier), "")
+
+	effectiveAC := target.AC + target.InitiativeBonus + effect.Resolve(target.Effects, effect.StatAC).Total
+	if effectiveAC != 18 {
+		t.Fatalf("expected effectiveAC=18 with standard cover (16+2), got %d", effectiveAC)
+	}
+}
+
+// TestCoverBonus_PerTargetIndependent verifies that applying cover to one
+// target does not leak the AC bonus to a different target's Effects.
+func TestCoverBonus_PerTargetIndependent(t *testing.T) {
+	targetA := &combat.Combatant{
+		ID: "a", Name: "a", Kind: combat.KindNPC, AC: 14, MaxHP: 20,
+		CoverTier: "standard", CoverEquipmentID: "wall",
+		Effects: effect.NewEffectSet(),
+	}
+	targetB := &combat.Combatant{
+		ID: "b", Name: "b", Kind: combat.KindNPC, AC: 14, MaxHP: 20,
+		Effects: effect.NewEffectSet(),
+	}
+	coverA := combat.DetermineCoverTier(targetA)
+	targetA.Effects.Apply(combat.BuildCoverEffect(coverA))
+	acA := effect.Resolve(targetA.Effects, effect.StatAC).Total
+	targetA.Effects.Remove(combat.CoverSourceID(coverA), "")
+
+	acB := effect.Resolve(targetB.Effects, effect.StatAC).Total
+
+	if acA <= acB {
+		t.Fatalf("target A with cover should have higher AC bonus (%d) than B (%d)", acA, acB)
+	}
+	if acAfter := effect.Resolve(targetA.Effects, effect.StatAC).Total; acAfter != 0 {
+		t.Fatalf("cover effect must be cleared after removal; got residual AC %d", acAfter)
+	}
+}

--- a/internal/game/combat/cover_inversion_fix_test.go
+++ b/internal/game/combat/cover_inversion_fix_test.go
@@ -1,0 +1,62 @@
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	"github.com/cory-johannsen/mud/internal/game/effect"
+)
+
+// TestCoverBonus_RaisesEffectiveAC verifies that BuildCoverEffect produces a
+// circumstance-typed AC bonus that flows through effect.Resolve to inflate the
+// target's effective AC (COVER-4, COVER-8). This is the documentation anchor
+// for the AC/AttackTotal inversion fix that Tasks 3-5 wire into round.go.
+func TestCoverBonus_RaisesEffectiveAC(t *testing.T) {
+	tier := combat.Standard
+	ac, _ := combat.CoverBonus(tier)
+	if ac != 2 {
+		t.Fatalf("Standard cover AC bonus should be 2, got %d", ac)
+	}
+
+	e := combat.BuildCoverEffect(tier)
+	var found bool
+	for _, b := range e.Bonuses {
+		if b.Stat == effect.StatAC && b.Value == 2 && b.Type == effect.BonusTypeCircumstance {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("BuildCoverEffect(Standard) must produce a circumstance +2 AC bonus")
+	}
+}
+
+// TestCoverBonus_AppliedToTargetEffects_ResolvesToHigherAC verifies the round-trip
+// from BuildCoverEffect → target.Effects.Apply → effect.Resolve(StatAC).Total: the
+// resolved AC delta must equal CoverBonus(tier).ac.
+func TestCoverBonus_AppliedToTargetEffects_ResolvesToHigherAC(t *testing.T) {
+	for _, tier := range []combat.CoverTier{combat.Lesser, combat.Standard, combat.Greater} {
+		t.Run(tier.String(), func(t *testing.T) {
+			target := &combat.Combatant{
+				ID:      "target",
+				Name:    "target",
+				Kind:    combat.KindNPC,
+				AC:      14,
+				MaxHP:   20,
+				Effects: effect.NewEffectSet(),
+			}
+			expectedAC, expectedQK := combat.CoverBonus(tier)
+
+			target.Effects.Apply(combat.BuildCoverEffect(tier))
+			defer target.Effects.Remove(combat.CoverSourceID(tier), "")
+
+			gotAC := effect.Resolve(target.Effects, effect.StatAC).Total
+			if gotAC != expectedAC {
+				t.Errorf("tier %s: AC bonus from Effects = %d, want %d", tier, gotAC, expectedAC)
+			}
+			gotQK := effect.Resolve(target.Effects, effect.StatQuickness).Total
+			if gotQK != expectedQK {
+				t.Errorf("tier %s: Quickness bonus from Effects = %d, want %d", tier, gotQK, expectedQK)
+			}
+		})
+	}
+}

--- a/internal/game/combat/engine.go
+++ b/internal/game/combat/engine.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/cory-johannsen/mud/internal/game/condition"
+	"github.com/cory-johannsen/mud/internal/game/effect"
 	"github.com/cory-johannsen/mud/internal/game/inventory"
 	"github.com/cory-johannsen/mud/internal/game/reaction"
 	"github.com/cory-johannsen/mud/internal/game/session"
@@ -546,6 +547,11 @@ func (e *Engine) StartCombat(roomID string, combatants []*Combatant, condRegistr
 			set.SetScripting(scriptMgr, zoneID)
 		}
 		cbt.Conditions[c.ID] = set
+		// COVER-4 prerequisite: ensure every combatant has a non-nil EffectSet so the
+		// cover pipeline (and any other effect.Apply caller) can always operate.
+		if c.Effects == nil {
+			c.Effects = effect.NewEffectSet()
+		}
 	}
 	// Populate Participants with player UIDs from the initial combatant list.
 	for _, c := range combatants {

--- a/internal/game/combat/round.go
+++ b/internal/game/combat/round.go
@@ -865,7 +865,14 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					}
 				}
 
+				// COVER-4: apply ephemeral cover bonus before resolving AC.
+				coverTier := DetermineCoverTier(target)
+				if coverTier > NoCover && target.Effects != nil {
+					target.Effects.Apply(BuildCoverEffect(coverTier))
+				}
+
 				atkBonus := effect.Resolve(actor.Effects, effect.StatAttack).Total
+				// COVER-8: AC bonus moves to effectiveAC, no longer subtracted from AttackTotal.
 				acBonus := effect.Resolve(target.Effects, effect.StatAC).Total
 
 				// Flanking check: gather all living combatants on the attacker's side.
@@ -894,7 +901,6 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					r = ResolveAttack(actor, target, src)
 				}
 				r.AttackTotal += atkBonus
-				r.AttackTotal += acBonus
 				r.AttackTotal += actor.InitiativeBonus
 				// GH #232: cross-action Multiple Attack Penalty.
 				r.AttackTotal += mapPenaltyFor(actor.AttacksMadeThisRound)
@@ -902,14 +908,14 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 				if flanked {
 					r.AttackTotal += 2
 				}
-				effectiveAC := target.AC + target.InitiativeBonus
+				effectiveAC := target.AC + target.InitiativeBonus + acBonus
 				r.AttackTotal = hookAttackRoll(cbt, actor, target, r.AttackTotal)
 				r.Outcome = OutcomeFor(r.AttackTotal, effectiveAC)
-				// Crossfire degradation: attack missed but would have hit without cover penalty.
+				// COVER-11/12: cover absorb-miss — target was hit only because of cover.
 				if (r.Outcome == Failure || r.Outcome == CritFailure) &&
-					target.CoverTier != "" && target.CoverEquipmentID != "" {
-					attackWithoutCoverPenalty := r.AttackTotal - acBonus // acBonus <= 0, so this raises the effective roll
-					if attackWithoutCoverPenalty >= effectiveAC {
+					coverTier > NoCover && target.CoverEquipmentID != "" {
+					coverACMag, _ := CoverBonus(coverTier)
+					if coverACMag > 0 && r.AttackTotal >= effectiveAC-coverACMag {
 						coverEquipID := target.CoverEquipmentID
 						destroyed := coverDegrader(cbt.RoomID, coverEquipID)
 						events = append(events, RoundEvent{
@@ -930,6 +936,10 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 							})
 						}
 					}
+				}
+				// COVER-13: remove ephemeral cover effect after resolution.
+				if coverTier > NoCover && target.Effects != nil {
+					target.Effects.Remove(CoverSourceID(coverTier), "")
 				}
 				// MULT-17: damage now flows through ResolveDamage. Roll any extra weapon dice up
 				// front; crit-doubling is handled by the pipeline's DamageMultiplier stage.
@@ -1078,24 +1088,29 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					// Flat check passed — both strikes proceed normally against now-revealed target.
 				}
 				// First strike
+				// COVER-4: apply ephemeral cover bonus before resolving AC.
+				coverTier1 := DetermineCoverTier(target)
+				if coverTier1 > NoCover && target.Effects != nil {
+					target.Effects.Apply(BuildCoverEffect(coverTier1))
+				}
 				atkBonus1 := effect.Resolve(actor.Effects, effect.StatAttack).Total
+				// COVER-8: AC bonus moves to effectiveAC, no longer subtracted from AttackTotal.
 				acBonus1 := effect.Resolve(target.Effects, effect.StatAC).Total
 				r1 := ResolveAttack(actor, target, src)
 				r1.AttackTotal += atkBonus1
-				r1.AttackTotal += acBonus1
 				r1.AttackTotal += actor.InitiativeBonus
 				// GH #232: cross-action MAP. Within a Strike the first attack uses
 				// the counter value at entry; the second uses the incremented value.
 				r1.AttackTotal += mapPenaltyFor(actor.AttacksMadeThisRound)
 				actor.AttacksMadeThisRound++
-				effectiveAC1 := target.AC + target.InitiativeBonus
+				effectiveAC1 := target.AC + target.InitiativeBonus + acBonus1
 				r1.AttackTotal = hookAttackRoll(cbt, actor, target, r1.AttackTotal)
 				r1.Outcome = OutcomeFor(r1.AttackTotal, effectiveAC1)
-				// Crossfire degradation: first strike missed but would have hit without cover penalty.
+				// COVER-11/12: cover absorb-miss — first strike was a miss only because of cover.
 				if (r1.Outcome == Failure || r1.Outcome == CritFailure) &&
-					target.CoverTier != "" && target.CoverEquipmentID != "" {
-					attackWithoutCoverPenalty1 := r1.AttackTotal - acBonus1
-					if attackWithoutCoverPenalty1 >= effectiveAC1 {
+					coverTier1 > NoCover && target.CoverEquipmentID != "" {
+					coverACMag1, _ := CoverBonus(coverTier1)
+					if coverACMag1 > 0 && r1.AttackTotal >= effectiveAC1-coverACMag1 {
 						coverEquipID1 := target.CoverEquipmentID
 						destroyed1 := coverDegrader(cbt.RoomID, coverEquipID1)
 						events = append(events, RoundEvent{
@@ -1116,6 +1131,10 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 							})
 						}
 					}
+				}
+				// COVER-13: remove ephemeral cover effect after first-strike resolution.
+				if coverTier1 > NoCover && target.Effects != nil {
+					target.Effects.Remove(CoverSourceID(coverTier1), "")
 				}
 				// MULT-17: damage now flows through ResolveDamage.
 				passiveFeatGate1 := 0
@@ -1212,11 +1231,16 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					})
 					continue
 				}
+				// COVER-4: apply ephemeral cover bonus before resolving AC for the second strike.
+				coverTier2 := DetermineCoverTier(target)
+				if coverTier2 > NoCover && target.Effects != nil {
+					target.Effects.Apply(BuildCoverEffect(coverTier2))
+				}
 				atkBonus2 := effect.Resolve(actor.Effects, effect.StatAttack).Total
+				// COVER-8: AC bonus moves to effectiveAC, no longer subtracted from AttackTotal.
 				acBonus2 := effect.Resolve(target.Effects, effect.StatAC).Total
 				r2 := ResolveAttack(actor, target, src)
 				r2.AttackTotal += atkBonus2
-				r2.AttackTotal += acBonus2
 				r2.AttackTotal += actor.InitiativeBonus
 				// GH #232: cross-action MAP. The counter now reflects the first
 				// strike, so this attack picks up -5 (or -10 if there were prior
@@ -1230,14 +1254,14 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 						r2.AttackTotal -= mapBonus2
 					}
 				}
-				effectiveAC2 := target.AC + target.InitiativeBonus
+				effectiveAC2 := target.AC + target.InitiativeBonus + acBonus2
 				r2.AttackTotal = hookAttackRoll(cbt, actor, target, r2.AttackTotal)
 				r2.Outcome = OutcomeFor(r2.AttackTotal, effectiveAC2)
-				// Crossfire degradation: second strike missed but would have hit without cover penalty.
+				// COVER-11/12: cover absorb-miss — second strike was a miss only because of cover.
 				if (r2.Outcome == Failure || r2.Outcome == CritFailure) &&
-					target.CoverTier != "" && target.CoverEquipmentID != "" {
-					attackWithoutCoverPenalty2 := r2.AttackTotal - acBonus2
-					if attackWithoutCoverPenalty2 >= effectiveAC2 {
+					coverTier2 > NoCover && target.CoverEquipmentID != "" {
+					coverACMag2, _ := CoverBonus(coverTier2)
+					if coverACMag2 > 0 && r2.AttackTotal >= effectiveAC2-coverACMag2 {
 						coverEquipID2 := target.CoverEquipmentID
 						destroyed2 := coverDegrader(cbt.RoomID, coverEquipID2)
 						events = append(events, RoundEvent{
@@ -1258,6 +1282,10 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 							})
 						}
 					}
+				}
+				// COVER-13: remove ephemeral cover effect after second-strike resolution.
+				if coverTier2 > NoCover && target.Effects != nil {
+					target.Effects.Remove(CoverSourceID(coverTier2), "")
 				}
 				// MULT-17: damage now flows through ResolveDamage.
 				passiveFeatGate2 := 0
@@ -1441,18 +1469,26 @@ func resolveFireBurst(cbt *Combat, actor *Combatant, qa QueuedAction, src Source
 			result = ResolveAttack(actor, target, src)
 		}
 		result.AttackTotal = hookAttackRoll(cbt, actor, target, result.AttackTotal)
+		// COVER-4: apply ephemeral cover bonus before resolving AC.
+		coverTierBurst := DetermineCoverTier(target)
+		if coverTierBurst > NoCover && target.Effects != nil {
+			target.Effects.Apply(BuildCoverEffect(coverTierBurst))
+		}
+		// COVER-9: include attacker's StatAttack effect bonus (was missing prior to #247).
+		atkBonus := effect.Resolve(actor.Effects, effect.StatAttack).Total
+		result.AttackTotal += atkBonus
+		// COVER-8: AC bonus moves to effectiveAC, no longer subtracted from AttackTotal.
 		acBonus := effect.Resolve(target.Effects, effect.StatAC).Total
-		result.AttackTotal += acBonus
 		// GH #232: each burst shot counts toward cross-action MAP.
 		result.AttackTotal += mapPenaltyFor(actor.AttacksMadeThisRound)
 		actor.AttacksMadeThisRound++
-		effectiveAC := target.AC + target.InitiativeBonus
+		effectiveAC := target.AC + target.InitiativeBonus + acBonus
 		result.Outcome = OutcomeFor(result.AttackTotal, effectiveAC)
-		// Crossfire degradation: burst shot missed but would have hit without cover penalty.
+		// COVER-11/12: cover absorb-miss — burst shot was a miss only because of cover.
 		if (result.Outcome == Failure || result.Outcome == CritFailure) &&
-			target.CoverTier != "" && target.CoverEquipmentID != "" {
-			attackWithoutCoverPenalty := result.AttackTotal - acBonus
-			if attackWithoutCoverPenalty >= effectiveAC {
+			coverTierBurst > NoCover && target.CoverEquipmentID != "" {
+			coverACMagBurst, _ := CoverBonus(coverTierBurst)
+			if coverACMagBurst > 0 && result.AttackTotal >= effectiveAC-coverACMagBurst {
 				coverEquipIDBurst := target.CoverEquipmentID
 				destroyed := coverDegrader(cbt.RoomID, coverEquipIDBurst)
 				events = append(events, RoundEvent{
@@ -1473,6 +1509,10 @@ func resolveFireBurst(cbt *Combat, actor *Combatant, qa QueuedAction, src Source
 					})
 				}
 			}
+		}
+		// COVER-13: remove ephemeral cover effect after resolution.
+		if coverTierBurst > NoCover && target.Effects != nil {
+			target.Effects.Remove(CoverSourceID(coverTierBurst), "")
 		}
 		// MULT-17: damage now flows through ResolveDamage.
 		di := BuildDamageInput(BuildDamageOpts{
@@ -1556,18 +1596,26 @@ func resolveFireAutomatic(cbt *Combat, actor *Combatant, qa QueuedAction, src So
 			result = ResolveAttack(actor, target, src)
 		}
 		result.AttackTotal = hookAttackRoll(cbt, actor, target, result.AttackTotal)
+		// COVER-4: apply ephemeral cover bonus before resolving AC.
+		coverTierAutomatic := DetermineCoverTier(target)
+		if coverTierAutomatic > NoCover && target.Effects != nil {
+			target.Effects.Apply(BuildCoverEffect(coverTierAutomatic))
+		}
+		// COVER-9: include attacker's StatAttack effect bonus (was missing prior to #247).
+		atkBonus := effect.Resolve(actor.Effects, effect.StatAttack).Total
+		result.AttackTotal += atkBonus
+		// COVER-8: AC bonus moves to effectiveAC, no longer subtracted from AttackTotal.
 		acBonus := effect.Resolve(target.Effects, effect.StatAC).Total
-		result.AttackTotal += acBonus
 		// GH #232: each automatic-fire shot counts toward cross-action MAP.
 		result.AttackTotal += mapPenaltyFor(actor.AttacksMadeThisRound)
 		actor.AttacksMadeThisRound++
-		effectiveAC := target.AC + target.InitiativeBonus
+		effectiveAC := target.AC + target.InitiativeBonus + acBonus
 		result.Outcome = OutcomeFor(result.AttackTotal, effectiveAC)
-		// Crossfire degradation: automatic shot missed but would have hit without cover penalty.
+		// COVER-11/12: cover absorb-miss — automatic shot was a miss only because of cover.
 		if (result.Outcome == Failure || result.Outcome == CritFailure) &&
-			target.CoverTier != "" && target.CoverEquipmentID != "" {
-			attackWithoutCoverPenalty := result.AttackTotal - acBonus
-			if attackWithoutCoverPenalty >= effectiveAC {
+			coverTierAutomatic > NoCover && target.CoverEquipmentID != "" {
+			coverACMagAutomatic, _ := CoverBonus(coverTierAutomatic)
+			if coverACMagAutomatic > 0 && result.AttackTotal >= effectiveAC-coverACMagAutomatic {
 				coverEquipIDAutomatic := target.CoverEquipmentID
 				destroyed := coverDegrader(cbt.RoomID, coverEquipIDAutomatic)
 				events = append(events, RoundEvent{
@@ -1588,6 +1636,10 @@ func resolveFireAutomatic(cbt *Combat, actor *Combatant, qa QueuedAction, src So
 					})
 				}
 			}
+		}
+		// COVER-13: remove ephemeral cover effect after resolution.
+		if coverTierAutomatic > NoCover && target.Effects != nil {
+			target.Effects.Remove(CoverSourceID(coverTierAutomatic), "")
 		}
 		// MULT-17: damage now flows through ResolveDamage.
 		di := BuildDamageInput(BuildDamageOpts{


### PR DESCRIPTION
## Summary

Cover tier → circumstance AC (and Quickness) bonuses through the #245 typed-bonus pipeline at every attack-resolution site in `round.go`. Fixes a pre-existing AC/AttackTotal inversion bug. Issue #247.

- **New `internal/game/combat/cover_bonus.go`**: `CoverTier` int enum (`NoCover|Lesser|Standard|Greater`), `CoverBonus(t) (acBonus, qkBonus int)`, `BuildCoverEffect`, `DetermineCoverTier`, `CoverSourceID`, `WithCoverEffect`.
- **5 round.go sites migrated** (single attack, strike1/strike2, fire-burst, fire-auto). AC bonus moves from `r.AttackTotal` (subtraction) to `effectiveAC` (addition). Cover applied ephemerally to `target.Effects` and removed immediately after — no leakage.
- **COVER-9**: `effect.Resolve(actor.Effects, StatAttack).Total` added at burst/auto sites where it was missing.
- **Absorb-miss**: now uses `r.AttackTotal >= effectiveAC - coverACMag` (algebraic flip of the old reverse-subtraction).
- **`StartCombat` Effects init**: defensive `effect.NewEffectSet()` for any combatant lacking one.
- **Tier-to-bonus**: lesser=+1 AC, standard=+2 AC/+2 QK, greater=+4 AC/+4 QK (PF2E rules).
- **Docs**: `docs/architecture/combat.md` Cover (COVER) section.

Plan: `docs/superpowers/plans/2026-04-22-cover-bonuses-in-combat.md` (7 tasks).

## Test plan

- [ ] Full Go suite green (`go test ./...`)
- [ ] Smoke: target with `CoverTier = "standard"` is harder to hit (effective AC +2)
- [ ] Cover absorb-miss fires `ActionCoverHit` when attack would have hit without cover bonus
- [ ] Burst/auto fire correctly apply cover per-shot without leaking across iterations
- [ ] `cover_degradation_test.go` continues to pass against new pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)