### PR TITLE
feat(terrain): Terrain type penalties in combat (#248)

### DIFF
--- a/api/proto/game/v1/game.proto
+++ b/api/proto/game/v1/game.proto
@@ -1025,6 +1025,15 @@ message CoverObjectPosition {
   string cover_tier = 5; // "lesser", "standard", or "greater"
 }
 
+// TerrainCell describes one non-normal cell in the combat grid's terrain layer.
+// Cells absent from the repeated terrain field are TerrainNormal by default.
+message TerrainCell {
+  int32  x           = 1; // grid column (0-based)
+  int32  y           = 2; // grid row (0-based)
+  string type        = 3; // "difficult", "greater_difficult", or "hazardous"
+  string hazard_name = 4; // populated for hazardous cells (HazardDef.ID); empty otherwise
+}
+
 // RoundStartEvent is broadcast to all combatants when a new round begins.
 message RoundStartEvent {
   int32                      round             = 1;
@@ -1035,6 +1044,7 @@ message RoundStartEvent {
   int32                      grid_width        = 6;
   int32                      grid_height       = 7;
   repeated CoverObjectPosition cover_objects   = 8;
+  repeated TerrainCell       terrain           = 9; // non-normal cells only
 }
 
 // RoundEndEvent is broadcast when a round's actions have resolved.

--- a/cmd/webclient/ui/src/game/panels/MapPanel.tsx
+++ b/cmd/webclient/ui/src/game/panels/MapPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { useGame } from '../GameContext'
-import type { MapTile, CoverObjectPosition } from '../../proto'
+import type { MapTile, CoverObjectPosition, TerrainCell } from '../../proto'
 import { RoomTooltip } from '../RoomTooltip'
 import { ZoneMapSvg, REFERENCE_W } from '../ZoneMapSvg'
 import { WorldMapSvg } from '../WorldMapSvg'
@@ -84,6 +84,7 @@ function renderBattleGrid(
   strideCells: number,
   movementRemaining: number,
   coverObjects: CoverObjectPosition[],
+  terrain: TerrainCell[],
 ): JSX.Element {
   const rawCell = Math.floor(320 / Math.max(gridWidth, gridHeight))
   const CELL_PX = Math.max(12, Math.min(32, rawCell))
@@ -100,6 +101,15 @@ function renderBattleGrid(
     coverMap[`${cx},${cy}`] = co
   }
 
+  // Terrain lookup keyed by "x,y". Cells absent from this map are TerrainNormal
+  // and receive no terrain class. The proto only sends non-normal cells.
+  const terrainMap: Record<string, TerrainCell> = {}
+  for (const tc of terrain) {
+    const tx = tc.x ?? 0
+    const ty = tc.y ?? 0
+    terrainMap[`${tx},${ty}`] = tc
+  }
+
   const cells: JSX.Element[] = []
   for (let y = 0; y < gridHeight; y++) {
     for (let x = 0; x < gridWidth; x++) {
@@ -108,12 +118,22 @@ function renderBattleGrid(
       const isEnemy = name !== '' && !isPlayer
       const cover = coverMap[`${x},${y}`]
       const isCover = cover !== undefined && name === ''
+      const terrainCell = terrainMap[`${x},${y}`]
+      const terrainType = terrainCell?.type ?? ''
+      // Convert "greater_difficult" → "greater-difficult" for CSS class naming.
+      const terrainClass = terrainType
+        ? `terrain-${terrainType.replace(/_/g, '-')}`
+        : ''
 
       const moveCost = (name === '' && !isCover && playerX >= 0)
         ? cellMoveCost(playerX, playerY, x, y, strideCells, movementRemaining)
         : 0
 
-      let bg: string
+      // bg may be undefined when the cell is "default" and has terrain — in that
+      // case the CSS class supplies the background tint. Inline styles win over
+      // class styles, so highlighted cells (occupant/cover/move-cost) keep their
+      // explicit colour and the terrain class is visually masked under them.
+      let bg: string | undefined
       if (isPlayer) {
         bg = '#1a3a6b'
       } else if (isEnemy) {
@@ -125,6 +145,8 @@ function renderBattleGrid(
         bg = '#0d3b0d'
       } else if (moveCost === 2) {
         bg = '#2e2600'
+      } else if (terrainClass !== '') {
+        bg = undefined // let CSS class paint the terrain tint
       } else {
         bg = '#1a1a2e'
       }
@@ -150,24 +172,29 @@ function renderBattleGrid(
         ? `${cover.name ?? cover.itemId ?? cover.item_id ?? 'Cover'} (${cover.coverTier ?? cover.cover_tier ?? 'lesser'})`
         : undefined
 
+      const cellStyle: React.CSSProperties = {
+        width: CELL_PX,
+        height: CELL_PX,
+        border,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '0.75rem',
+        color: isPlayer ? '#7bb8ff' : isEnemy ? '#ff7b7b' : isCover ? '#c8a060' : '#555',
+        fontWeight: 'bold',
+        cursor,
+        flexShrink: 0,
+      }
+      if (bg !== undefined) {
+        cellStyle.background = bg
+      }
+
       cells.push(
         <div
           key={`${x},${y}`}
+          className={terrainClass || undefined}
           title={coverTitle}
-          style={{
-            width: CELL_PX,
-            height: CELL_PX,
-            background: bg,
-            border,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: '0.75rem',
-            color: isPlayer ? '#7bb8ff' : isEnemy ? '#ff7b7b' : isCover ? '#c8a060' : '#555',
-            fontWeight: 'bold',
-            cursor,
-            flexShrink: 0,
-          }}
+          style={cellStyle}
           onMouseEnter={e => {
             onCellHover(x, y)
             if (name !== '') {
@@ -356,6 +383,7 @@ export function MapPanel() {
               strideCells,
               movementRemaining,
               state.combatRound?.coverObjects ?? state.combatRound?.cover_objects ?? [],
+              state.combatRound?.terrain ?? [],
             )}
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', justifyContent: 'center' }}>

--- a/cmd/webclient/ui/src/proto/index.ts
+++ b/cmd/webclient/ui/src/proto/index.ts
@@ -651,6 +651,14 @@ export interface CoverObjectPosition {
   cover_tier?: string
 }
 
+export interface TerrainCell {
+  x?: number
+  y?: number
+  type?: string
+  hazardName?: string
+  hazard_name?: string
+}
+
 export interface RoundStartEvent {
   round?: number
   actionsPerTurn?: number
@@ -665,6 +673,7 @@ export interface RoundStartEvent {
   grid_height?: number
   coverObjects?: CoverObjectPosition[]
   cover_objects?: CoverObjectPosition[]
+  terrain?: TerrainCell[]
 }
 
 export interface RoundEndEvent {

--- a/cmd/webclient/ui/src/styles/game.css
+++ b/cmd/webclient/ui/src/styles/game.css
@@ -688,3 +688,12 @@ body:has(.game-layout) #root { height: 100%; overflow: hidden; }
     z-index: 101;
   }
 }
+
+/* Combat-grid terrain layer (#248). Applied as a className on each cell.
+ * Absent (normal) terrain has no class — falls through to the cell's base
+ * background. Tints are translucent so they overlay the move-cost shading. */
+.terrain-normal { /* no tint — default */ }
+.terrain-difficult { background-color: rgba(180, 140, 60, 0.3); }
+.terrain-greater-difficult { background-color: rgba(80, 80, 80, 0.5); }
+.terrain-hazardous { background-color: rgba(220, 50, 50, 0.3); }
+

--- a/docs/architecture/combat.md
+++ b/docs/architecture/combat.md
@@ -262,6 +262,58 @@ if attack missed AND coverTier > NoCover:
 | `internal/game/combat/round.go` | 5 attack resolution sites; ephemeral apply/remove; absorb-miss check |
 | `internal/game/effect/bonus.go` | `StatQuickness` constant |
 
+## Terrain (TERRAIN Requirements)
+
+### Requirements
+
+- TERRAIN-1: Per-cell layer with types `normal`, `difficult`, `greater_difficult`, `hazardous`.
+- TERRAIN-2: Absent cells default to `normal`.
+- TERRAIN-3: Room YAML accepts explicit grid (shape A) or default+overrides (shape B); both in same room is a load error.
+- TERRAIN-4: Hazardous cell requires exactly one of `hazard_id` or `hazard`; non-hazardous cells carrying either is a load error.
+- TERRAIN-5: `greater_difficult` may not combine with `difficult` or any hazard.
+- TERRAIN-6: Speed costs — `normal=1`, `difficult=2`, `hazardous=1` (+1 if `DifficultOverlay`), `greater_difficult=impassable`.
+- TERRAIN-7: Stride terminates when next step would exceed budget or enter impassable cell.
+- TERRAIN-8: `SpeedSquares()` deprecated; `SpeedBudget()` is canonical.
+- TERRAIN-9: Entering hazardous cell fires `on_enter` hazard.
+- TERRAIN-10: At `StartRound`, living combatants on hazardous cells fire `round_start` hazard.
+- TERRAIN-11: Hazard damage routes through `ResolveDamage` (#246).
+- TERRAIN-12: Combat-start placement fires `on_enter` once; `round_start` suppressed in round 1 (gameserver wiring is a follow-up).
+- TERRAIN-17: Terrain-stopped stride emits explanatory narrative.
+- TERRAIN-18: Zero-movement stride emits informational narrative.
+- TERRAIN-19: Unresolved `hazard_id` resolves to `Def=nil`; the cell is treated as inert at runtime.
+- TERRAIN-20: Terrain is static per combat (not mutated during a round).
+
+### Type / Cost Table
+
+| Type               | Entry Cost | Passable |
+|--------------------|-----------|----------|
+| `normal`           | 1         | yes      |
+| `difficult`        | 2         | yes      |
+| `hazardous`        | 1 (or 2 with `DifficultOverlay`) | yes |
+| `greater_difficult`| —         | no       |
+
+### Stride Budget Model
+
+```
+budget = actor.SpeedBudget()  // e.g. 5 for 25 ft
+for budget > 0:
+    cost, ok = cbt.EntryCost(newX, newY)
+    if !ok or cost > budget: stop
+    budget -= cost
+    move to (newX, newY)
+    if hazardous: fire on_enter hazard via applyCellHazard
+```
+
+### Implementation Files
+
+| File | Responsibility |
+|------|----------------|
+| `internal/game/combat/terrain.go` | `GridCell`, `TerrainType`, `TerrainCell`, `CellHazard`, `TerrainAt`, `EntryCost`, `TerrainGlyph`, `TerrainLegendText` |
+| `internal/game/world/terrain_load.go` | YAML loader for both authoring shapes |
+| `internal/game/combat/round.go` | Budget-based stride, `applyCellHazard` |
+| `internal/game/combat/engine.go` | `Combat.Terrain`, `RoomHazards`, `skipHazardRoundStart` fields; round_start hazard hook in `StartRoundWithSrc` |
+| `internal/game/combat/combat.go` | `Combatant.SpeedBudget()` (replaces deprecated `SpeedSquares()`); `WeaknessFor`/`ResistanceFor` helpers |
+
 ## Component Dependencies
 
 ```mermaid

--- a/internal/frontend/handlers/bridge_handlers.go
+++ b/internal/frontend/handlers/bridge_handlers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cory-johannsen/mud/internal/frontend/telnet"
+	"github.com/cory-johannsen/mud/internal/game/combat"
 	"github.com/cory-johannsen/mud/internal/game/command"
 	gamev1 "github.com/cory-johannsen/mud/internal/gameserver/gamev1"
 )
@@ -71,6 +72,7 @@ var bridgeHandlerMap = map[string]bridgeHandlerFunc{
 	command.HandlerStrike:             bridgeStrike,
 	command.HandlerStatus:             bridgeStatus,
 	command.HandlerEffects:            bridgeEffects,
+	command.HandlerTerrain:            bridgeTerrain,
 	command.HandlerEquip:              bridgeEquip,
 	command.HandlerReload:             bridgeReload,
 	command.HandlerFireBurst:          bridgeFireBurst,
@@ -478,6 +480,31 @@ func bridgeEffects(bctx *bridgeContext) (bridgeResult, error) {
 		RequestId: bctx.reqID,
 		Payload:   &gamev1.ClientMessage_CharSheet{CharSheet: &gamev1.CharacterSheetRequest{}},
 	}}, nil
+}
+
+// bridgeTerrain renders the combat-map terrain legend describing the
+// glyph used for each terrain type and the movement / hazard semantics
+// associated with it. The output is rendered locally — no server round
+// trip is required.
+//
+// Precondition: bctx must be non-nil with a valid conn.
+// Postcondition: returns done=true after writing the legend to the
+// console; never produces a ClientMessage.
+func bridgeTerrain(bctx *bridgeContext) (bridgeResult, error) {
+	// Default to ASCII glyphs: the telnet session has no per-connection
+	// Unicode capability flag, so we render the safe fallback set that
+	// renders correctly on every terminal.
+	legend := combat.TerrainLegendText(false)
+	if bctx.conn != nil {
+		if bctx.conn.IsSplitScreen() {
+			_ = bctx.conn.WriteConsole(legend)
+			_ = bctx.conn.WritePromptSplit(bctx.promptFn())
+		} else {
+			_ = bctx.conn.WriteLine(legend)
+			_ = bctx.conn.WritePrompt(bctx.promptFn())
+		}
+	}
+	return bridgeResult{done: true}, nil
 }
 
 // bridgeEquip builds an EquipRequest with an optional slot argument.

--- a/internal/game/combat/action.go
+++ b/internal/game/combat/action.go
@@ -26,6 +26,7 @@ const (
 	ActionAid                             // costs 2 AP; aid an ally
 	ActionUseTech                         // costs AbilityCost AP; activate a technology during round resolution
 	ActionReady                           // costs 2 AP; prepares one 1-AP action bound to a trigger
+	ActionHazardDamage                    // informational: terrain hazard fires damage on entry or round start
 )
 
 // Cost returns the action point cost for the ActionType.
@@ -93,6 +94,8 @@ func (a ActionType) String() string {
 		return "use_tech"
 	case ActionReady:
 		return "ready"
+	case ActionHazardDamage:
+		return "hazard_damage"
 	default:
 		return "unknown"
 	}

--- a/internal/game/combat/combat.go
+++ b/internal/game/combat/combat.go
@@ -209,6 +209,24 @@ func (c *Combatant) IsDead() bool {
 	return c.CurrentHP <= 0
 }
 
+// WeaknessFor returns the combatant's weakness value for the given damage type,
+// or 0 when no weakness is configured.
+func (c *Combatant) WeaknessFor(dt string) int {
+	if c.Weaknesses == nil {
+		return 0
+	}
+	return c.Weaknesses[dt]
+}
+
+// ResistanceFor returns the combatant's resistance value for the given damage type,
+// or 0 when no resistance is configured.
+func (c *Combatant) ResistanceFor(dt string) int {
+	if c.Resistances == nil {
+		return 0
+	}
+	return c.Resistances[dt]
+}
+
 // ApplyDamage reduces CurrentHP by amount, flooring at zero.
 // Precondition: amount must be >= 0.
 // Postcondition: CurrentHP >= 0.

--- a/internal/game/combat/combat.go
+++ b/internal/game/combat/combat.go
@@ -170,12 +170,11 @@ type Combatant struct {
 	Effects *effect.EffectSet
 }
 
-// SpeedSquares returns the number of grid squares this combatant may move per stride action.
-// SpeedFt == 0 is treated as the PF2e default of 25 ft = 5 squares.
-// Minimum 1 square.
+// SpeedBudget returns the number of speed budget points available per stride action.
+// Difficult cells cost 2 points; normal and hazardous cost 1. Default 25 ft = 5 points.
 //
 // Postcondition: returns >= 1.
-func (c *Combatant) SpeedSquares() int {
+func (c *Combatant) SpeedBudget() int {
 	ft := c.SpeedFt
 	if ft <= 0 {
 		ft = 25
@@ -185,6 +184,13 @@ func (c *Combatant) SpeedSquares() int {
 		sq = 1
 	}
 	return sq
+}
+
+// SpeedSquares is deprecated: use SpeedBudget instead.
+//
+// Deprecated: SpeedSquares delegates to SpeedBudget. Retained for external callers.
+func (c *Combatant) SpeedSquares() int {
+	return c.SpeedBudget()
 }
 
 // IsPlayer reports whether this combatant is a player character.

--- a/internal/game/combat/engine.go
+++ b/internal/game/combat/engine.go
@@ -220,6 +220,24 @@ func (c *Combat) StartRoundWithSrc(actionsPerRound int, src Source) []RoundCondi
 		}
 	}
 
+	// TERRAIN-10: fire round_start hazards for combatants occupying hazardous cells.
+	for _, cbt := range c.Combatants {
+		if cbt.IsDead() {
+			continue
+		}
+		// TERRAIN-12: skip round_start in round 1 for combatants that entered at combat start.
+		if c.skipHazardRoundStart != nil && c.skipHazardRoundStart[cbt.ID] {
+			delete(c.skipHazardRoundStart, cbt.ID)
+			continue
+		}
+		if tc := c.TerrainAt(cbt.GridX, cbt.GridY); tc.Type == TerrainHazardous && tc.Hazard != nil {
+			_ = applyCellHazard(c, cbt, tc, "round_start", src)
+			// Note: applyCellHazard events are not propagated from StartRoundWithSrc in v1
+			// (StartRoundWithSrc returns []RoundConditionEvent, not []RoundEvent).
+			// The damage is applied; a follow-up ticket may surface the narrative.
+		}
+	}
+
 	// Reset per-round modifiers so condition effects do not carry across rounds.
 	for _, cbt := range c.Combatants {
 		if cbt.IsDead() {

--- a/internal/game/combat/engine.go
+++ b/internal/game/combat/engine.go
@@ -71,6 +71,18 @@ type Combat struct {
 	ReadyRegistry *reaction.ReadyRegistry
 }
 
+// SkipHazardRoundStart marks uid so that the next StartRoundWithSrc call will
+// NOT fire round_start hazards for this combatant — used by gameserver
+// combat-start placement after firing on_enter so round 1 doesn't double-fire.
+//
+// Precondition: uid is non-empty.
+func (c *Combat) SkipHazardRoundStart(uid string) {
+	if c.skipHazardRoundStart == nil {
+		c.skipHazardRoundStart = map[string]bool{}
+	}
+	c.skipHazardRoundStart[uid] = true
+}
+
 // CoverObject is a cover item placed on the combat grid. It blocks movement
 // through its cell until destroyed.
 type CoverObject struct {

--- a/internal/game/combat/engine.go
+++ b/internal/game/combat/engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cory-johannsen/mud/internal/game/inventory"
 	"github.com/cory-johannsen/mud/internal/game/reaction"
 	"github.com/cory-johannsen/mud/internal/game/session"
+	"github.com/cory-johannsen/mud/internal/game/world"
 	"github.com/cory-johannsen/mud/internal/scripting"
 )
 
@@ -55,6 +56,16 @@ type Combat struct {
 	// combat handler populates this slice at StartCombat from the room's
 	// equipment and removes entries when cover HP reaches zero.
 	CoverObjects []CoverObject
+	// Terrain is the per-cell terrain layer for this combat. Absent cells are TerrainNormal.
+	// Populated at combat start from the room's CombatTerrain config.
+	Terrain map[GridCell]*TerrainCell
+	// RoomHazards is a copy of the room's HazardDef list, used to resolve hazard_id
+	// references on TerrainHazardous cells at combat start.
+	RoomHazards []world.HazardDef
+	// skipHazardRoundStart tracks combatant IDs that entered a hazardous cell at
+	// combat start (via on_enter) and must not fire round_start hazards in round 1.
+	// Cleared by StartRoundWithSrc on first use.
+	skipHazardRoundStart map[string]bool
 	// ReadyRegistry holds pending Ready entries for the current round.
 	// Populated by QueueAction(ActionReady); consumed by ResolveRound.
 	ReadyRegistry *reaction.ReadyRegistry

--- a/internal/game/combat/round.go
+++ b/internal/game/combat/round.go
@@ -772,7 +772,6 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					stepsTaken++
 
 					// TERRAIN-9: fire on_enter hazard for hazardous cells.
-					// (Task 5 will replace applyCellHazard's stub with real logic.)
 					if tc := cbt.TerrainAt(newX, newY); tc.Type == TerrainHazardous && tc.Hazard != nil {
 						events = append(events, applyCellHazard(cbt, actor, tc, "on_enter", src)...)
 					}
@@ -1895,8 +1894,7 @@ func buildNarrative(actor, target *Combatant, result AttackResult, dmg int) stri
 // Returns zero or more RoundEvents (damage narrative, condition narrative, etc.).
 //
 // Precondition: tc.Type == TerrainHazardous; tc.Hazard must not be nil.
-func applyCellHazard(cbt *Combat, victim *Combatant, tc TerrainCell, trigger string, src Source) []RoundEvent {
-	_ = cbt
+func applyCellHazard(_ *Combat, victim *Combatant, tc TerrainCell, trigger string, src Source) []RoundEvent {
 	if tc.Hazard == nil || tc.Hazard.Def == nil {
 		return nil
 	}

--- a/internal/game/combat/round.go
+++ b/internal/game/combat/round.go
@@ -704,10 +704,14 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					}
 				}
 
-				// REQ-STRIDE-SPEED: Move up to SpeedSquares() cells per stride (default 5 = 25 ft).
+				// TERRAIN-6/7/8: Move up to SpeedBudget() points per stride. Each cell
+				// consumed costs EntryCost(newX, newY); TerrainGreaterDifficult is
+				// impassable. SpeedBudget defaults to 5 (25 ft) when SpeedFt is 0.
 				// Each step recomputes direction for "toward"/"away" since position changes.
-				steps := actor.SpeedSquares()
-				for step := 0; step < steps; step++ {
+				budget := actor.SpeedBudget()
+				strideNarrative := fmt.Sprintf("%s strides %s.", actor.Name, dir)
+				stepsTaken := 0
+				for budget > 0 {
 					// REQ-STRIDE-STOP: For "toward" strides, stop when already adjacent (≤ 5 ft).
 					if dir == "toward" && opponent != nil && CombatRange(*actor, *opponent) <= 5 {
 						break
@@ -740,8 +744,35 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					if CellBlocked(cbt, actor.ID, newX, newY) {
 						break
 					}
+					// TERRAIN-8/17: Greater-difficult cells are impassable.
+					cost, passable := cbt.EntryCost(newX, newY)
+					if !passable {
+						if stepsTaken == 0 {
+							strideNarrative = fmt.Sprintf("%s tries to move but the terrain blocks the way.", actor.Name)
+						} else {
+							strideNarrative = fmt.Sprintf("%s strides %s and stops at the terrain.", actor.Name, dir)
+						}
+						break
+					}
+					// TERRAIN-7/18: Insufficient budget to enter the next cell.
+					if cost > budget {
+						if stepsTaken == 0 {
+							strideNarrative = fmt.Sprintf("%s cannot afford to move — not enough movement speed.", actor.Name)
+						} else {
+							strideNarrative = fmt.Sprintf("%s strides %s and stops — terrain too rough to continue.", actor.Name, dir)
+						}
+						break
+					}
+					budget -= cost
 					actor.GridX = newX
 					actor.GridY = newY
+					stepsTaken++
+
+					// TERRAIN-9: fire on_enter hazard for hazardous cells.
+					// (Task 5 will replace applyCellHazard's stub with real logic.)
+					if tc := cbt.TerrainAt(newX, newY); tc.Type == TerrainHazardous && tc.Hazard != nil {
+						events = append(events, applyCellHazard(cbt, actor, tc, "on_enter", src)...)
+					}
 
 					// REQ-RXN19: TriggerOnEnemyMoveAdjacent fires when an NPC moves into melee range of a player.
 					if actor.Kind == KindNPC {
@@ -761,7 +792,7 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					ActionType: ActionStride,
 					ActorID:    actor.ID,
 					ActorName:  actor.Name,
-					Narrative:  fmt.Sprintf("%s strides %s.", actor.Name, dir),
+					Narrative:  strideNarrative,
 				})
 
 			case ActionPass:
@@ -1854,4 +1885,17 @@ func buildNarrative(actor, target *Combatant, result AttackResult, dmg int) stri
 	default:
 		return fmt.Sprintf("%s attacks %s.", actor.Name, target.Name)
 	}
+}
+
+// applyCellHazard fires the per-cell hazard for the given trigger ("on_enter",
+// "on_start_round") and returns the resulting RoundEvents. Task 4 ships this
+// as a stub so the budget-based stride loop compiles; Task 5 replaces it with
+// the real hazard-resolution implementation (TERRAIN-9..14).
+func applyCellHazard(cbt *Combat, actor *Combatant, tc TerrainCell, trigger string, src Source) []RoundEvent {
+	_ = cbt
+	_ = actor
+	_ = tc
+	_ = trigger
+	_ = src
+	return nil
 }

--- a/internal/game/combat/round.go
+++ b/internal/game/combat/round.go
@@ -227,6 +227,9 @@ type RoundEvent struct {
 	// prepared action after ResolveRound returns; inline execution is deferred
 	// to keep this package's responsibilities focused on dispatch.
 	ReadyEntry *reaction.ReadyEntry
+	// Damage is the post-pipeline damage applied by this event (TERRAIN-9..14).
+	// Used by hazard-damage events; zero for non-damaging events.
+	Damage int
 	// DamageBreakdown is the inline-formatted breakdown line (MULT-14).
 	// Empty string when the breakdown was trivial (only StageBase).
 	DamageBreakdown string
@@ -1887,15 +1890,52 @@ func buildNarrative(actor, target *Combatant, result AttackResult, dmg int) stri
 	}
 }
 
-// applyCellHazard fires the per-cell hazard for the given trigger ("on_enter",
-// "on_start_round") and returns the resulting RoundEvents. Task 4 ships this
-// as a stub so the budget-based stride loop compiles; Task 5 replaces it with
-// the real hazard-resolution implementation (TERRAIN-9..14).
-func applyCellHazard(cbt *Combat, actor *Combatant, tc TerrainCell, trigger string, src Source) []RoundEvent {
+// applyCellHazard fires a hazard on victim if its trigger matches.
+// Routes damage through ResolveDamage (#246 pipeline).
+// Returns zero or more RoundEvents (damage narrative, condition narrative, etc.).
+//
+// Precondition: tc.Type == TerrainHazardous; tc.Hazard must not be nil.
+func applyCellHazard(cbt *Combat, victim *Combatant, tc TerrainCell, trigger string, src Source) []RoundEvent {
 	_ = cbt
-	_ = actor
-	_ = tc
-	_ = trigger
-	_ = src
-	return nil
+	if tc.Hazard == nil || tc.Hazard.Def == nil {
+		return nil
+	}
+	def := tc.Hazard.Def
+	if def.Trigger != trigger {
+		return nil
+	}
+	var events []RoundEvent
+	if def.DamageExpr != "" {
+		rollResult, err := dice.RollExpr(def.DamageExpr, src)
+		if err == nil && rollResult.Total() > 0 {
+			in := DamageInput{
+				Additives: []DamageAdditive{
+					{Label: def.ID, Value: rollResult.Total(), Source: "hazard:" + def.ID},
+				},
+				DamageType: def.DamageType,
+				Weakness:   victim.WeaknessFor(def.DamageType),
+				Resistance: victim.ResistanceFor(def.DamageType),
+			}
+			result := ResolveDamage(in)
+			victim.ApplyDamage(result.Final)
+			narrative := fmt.Sprintf("%s is hit by %s! (%s → %d damage)",
+				victim.Name, def.ID, def.DamageExpr, result.Final)
+			if def.Message != "" {
+				narrative = fmt.Sprintf("%s — %s (%s → %d damage)", def.Message, victim.Name, def.DamageExpr, result.Final)
+			}
+			events = append(events, RoundEvent{
+				ActionType: ActionHazardDamage,
+				ActorID:    victim.ID,
+				ActorName:  victim.Name,
+				Damage:     result.Final,
+				Narrative:  narrative,
+			})
+		}
+	}
+	return events
+}
+
+// ApplyCellHazardForTest exposes applyCellHazard for package-external tests.
+func ApplyCellHazardForTest(cbt *Combat, victim *Combatant, tc TerrainCell, trigger string, src Source) []RoundEvent {
+	return applyCellHazard(cbt, victim, tc, trigger, src)
 }

--- a/internal/game/combat/round_hazard_test.go
+++ b/internal/game/combat/round_hazard_test.go
@@ -1,0 +1,76 @@
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	"github.com/cory-johannsen/mud/internal/game/condition"
+	"github.com/cory-johannsen/mud/internal/game/world"
+)
+
+// TestHazard_OnEnter_DealsDamage verifies that entering a hazardous cell
+// applies damage to the combatant.
+func TestHazard_OnEnter_DealsDamage(t *testing.T) {
+	src := fixedSrc{val: 1}
+	actor := &combat.Combatant{
+		ID: "actor", Name: "actor", Kind: combat.KindPlayer,
+		CurrentHP: 20, MaxHP: 20, AC: 12,
+		GridX: 0, GridY: 5,
+	}
+	hazDef := &world.HazardDef{
+		ID: "fire_vent", Trigger: "on_enter",
+		DamageExpr: "1d4", DamageType: "fire",
+		Message: "flames lick at you",
+	}
+	tc := combat.TerrainCell{X: 1, Y: 5, Type: combat.TerrainHazardous,
+		Hazard: &combat.CellHazard{Def: hazDef},
+	}
+	hpBefore := actor.CurrentHP
+	events := combat.ApplyCellHazardForTest(nil, actor, tc, "on_enter", src)
+	if actor.CurrentHP >= hpBefore {
+		t.Errorf("on_enter hazard must deal damage; HP before=%d after=%d", hpBefore, actor.CurrentHP)
+	}
+	if len(events) == 0 {
+		t.Error("applyCellHazard must emit at least one RoundEvent")
+	}
+}
+
+// TestHazard_RoundStart_FiresRoundStart verifies that round_start hazards
+// fire on combatants occupying hazardous cells.
+func TestHazard_RoundStart_FiresRoundStart(t *testing.T) {
+	src := &fixedSrc{val: 2}
+	reg := condition.NewRegistry()
+	eng := combat.NewEngine()
+	actor := &combat.Combatant{
+		ID: "actor", Name: "actor", Kind: combat.KindPlayer,
+		CurrentHP: 30, MaxHP: 30, AC: 12, Level: 1,
+		GridX: 3, GridY: 3, Initiative: 10,
+	}
+	cbt, err := eng.StartCombat("room1", []*combat.Combatant{actor}, reg, nil, "")
+	require.NoError(t, err)
+	cbt.GridWidth = 10
+	cbt.GridHeight = 10
+	hazDef := &world.HazardDef{
+		ID: "acid_pool", Trigger: "round_start",
+		DamageExpr: "1d4", DamageType: "acid",
+	}
+	cbt.Terrain = map[combat.GridCell]*combat.TerrainCell{
+		{X: 3, Y: 3}: {X: 3, Y: 3, Type: combat.TerrainHazardous,
+			Hazard: &combat.CellHazard{Def: hazDef},
+		},
+	}
+	hpBefore := actor.CurrentHP
+	cbt.StartRoundWithSrc(2, src)
+	if actor.CurrentHP >= hpBefore {
+		t.Errorf("round_start hazard must deal damage; HP before=%d after=%d", hpBefore, actor.CurrentHP)
+	}
+}
+
+// TestHazard_CombatStart_NoDoubleFireRound1 verifies that
+// a combatant placed on a hazardous cell at combat start fires on_enter once
+// and round_start does NOT double-fire in round 1.
+func TestHazard_CombatStart_NoDoubleFireRound1(t *testing.T) {
+	t.Skip("implement after gameserver combat-start placement hazard wiring lands")
+}

--- a/internal/game/combat/round_stride_terrain_test.go
+++ b/internal/game/combat/round_stride_terrain_test.go
@@ -1,0 +1,173 @@
+package combat_test
+
+// Tests for Task 4 of #248 — terrain-type penalties in the stride loop.
+//
+// REQ-TERRAIN-6: Stride MUST consume EntryCost per cell from SpeedBudget.
+// REQ-TERRAIN-7: Stride MUST stop when remaining budget < EntryCost of the next cell.
+// REQ-TERRAIN-8: Stride MUST stop before a TerrainGreaterDifficult (impassable) cell.
+// REQ-TERRAIN-17: Greater-difficult barriers MUST emit an informational narrative.
+// REQ-TERRAIN-18: Zero-budget strides MUST emit an informational narrative.
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+// runStride queues a single stride action for actor with the given direction
+// and resolves one round. Returns the events emitted during the round.
+func runStride(cbt *combat.Combat, actor *combat.Combatant, dir string, src combat.Source) []combat.RoundEvent {
+	if cbt.ActionQueues == nil {
+		cbt.ActionQueues = map[string]*combat.ActionQueue{}
+	}
+	q := combat.NewActionQueue(actor.ID, 3)
+	if err := q.Enqueue(combat.QueuedAction{Type: combat.ActionStride, Direction: dir}); err != nil {
+		panic(err)
+	}
+	cbt.ActionQueues[actor.ID] = q
+	return combat.ResolveRound(cbt, src, func(string, int) {}, nil, 0)
+}
+
+// newStrideActor returns a player combatant placed at (gx, gy) with the given
+// movement speed (in feet).
+func newStrideActor(id string, gx, gy, speedFt int) *combat.Combatant {
+	return &combat.Combatant{
+		ID: id, Name: id, Kind: combat.KindPlayer,
+		MaxHP: 20, CurrentHP: 20, AC: 12,
+		GridX: gx, GridY: gy, SpeedFt: speedFt,
+	}
+}
+
+// TestStride_AllNormal_MovesFullBudget verifies that a stride across normal
+// terrain moves exactly SpeedBudget() squares.
+func TestStride_AllNormal_MovesFullBudget(t *testing.T) {
+	actor := newStrideActor("actor", 0, 5, 25) // SpeedBudget == 5
+	// Place an opponent far to the right so "toward" produces a +x delta and
+	// the actor never reaches melee range mid-stride.
+	opponent := &combat.Combatant{
+		ID: "enemy", Name: "Enemy", Kind: combat.KindNPC,
+		MaxHP: 30, CurrentHP: 30, AC: 12,
+		GridX: 19, GridY: 5,
+	}
+	cbt := &combat.Combat{
+		GridWidth:    20,
+		GridHeight:   20,
+		Combatants:   []*combat.Combatant{actor, opponent},
+		ActionQueues: map[string]*combat.ActionQueue{},
+	}
+	budget := actor.SpeedBudget()
+	startX := actor.GridX
+	runStride(cbt, actor, "toward", fixedSrc{val: 0})
+	moved := actor.GridX - startX
+	if moved != budget {
+		t.Fatalf("all-normal stride: expected to move %d squares, moved %d (GridX=%d)",
+			budget, moved, actor.GridX)
+	}
+}
+
+// TestStride_DifficultHalvesDistance verifies that difficult terrain doubles
+// cost, halving the distance traversed by a full-budget stride.
+func TestStride_DifficultHalvesDistance(t *testing.T) {
+	actor := newStrideActor("actor", 0, 5, 25) // SpeedBudget == 5
+	opponent := &combat.Combatant{
+		ID: "enemy", Name: "Enemy", Kind: combat.KindNPC,
+		MaxHP: 30, CurrentHP: 30, AC: 12,
+		GridX: 19, GridY: 5,
+	}
+	terrain := map[combat.GridCell]*combat.TerrainCell{}
+	for x := 1; x <= 19; x++ {
+		terrain[combat.GridCell{X: x, Y: 5}] = &combat.TerrainCell{X: x, Y: 5, Type: combat.TerrainDifficult}
+	}
+	cbt := &combat.Combat{
+		GridWidth:    20,
+		GridHeight:   20,
+		Combatants:   []*combat.Combatant{actor, opponent},
+		Terrain:      terrain,
+		ActionQueues: map[string]*combat.ActionQueue{},
+	}
+	startX := actor.GridX
+	runStride(cbt, actor, "toward", fixedSrc{val: 0})
+	moved := actor.GridX - startX
+	// budget=5, each difficult cell costs 2 → floor(5/2)=2 cells.
+	if moved != 2 {
+		t.Fatalf("difficult terrain: expected to move 2 squares, moved %d (GridX=%d)",
+			moved, actor.GridX)
+	}
+}
+
+// TestStride_GreaterDifficultBlocks verifies stride stops before a
+// greater_difficult cell.
+func TestStride_GreaterDifficultBlocks(t *testing.T) {
+	actor := newStrideActor("actor", 0, 5, 25) // SpeedBudget == 5
+	opponent := &combat.Combatant{
+		ID: "enemy", Name: "Enemy", Kind: combat.KindNPC,
+		MaxHP: 30, CurrentHP: 30, AC: 12,
+		GridX: 19, GridY: 5,
+	}
+	terrain := map[combat.GridCell]*combat.TerrainCell{
+		{X: 1, Y: 5}: {X: 1, Y: 5, Type: combat.TerrainGreaterDifficult},
+	}
+	cbt := &combat.Combat{
+		GridWidth:    20,
+		GridHeight:   20,
+		Combatants:   []*combat.Combatant{actor, opponent},
+		Terrain:      terrain,
+		ActionQueues: map[string]*combat.ActionQueue{},
+	}
+	events := runStride(cbt, actor, "toward", fixedSrc{val: 0})
+	if actor.GridX != 0 {
+		t.Fatalf("greater_difficult: actor must not advance past the barrier, got GridX=%d", actor.GridX)
+	}
+	// REQ-TERRAIN-17: must emit an informational narrative for the stride.
+	found := false
+	for _, e := range events {
+		if e.ActionType == combat.ActionStride && e.ActorID == "actor" {
+			found = true
+			if e.Narrative == "" {
+				t.Error("greater_difficult: stride event must have a non-empty narrative")
+			}
+		}
+	}
+	if !found {
+		t.Error("greater_difficult: must emit a stride event")
+	}
+}
+
+// TestStride_ZeroBudgetNoMove verifies that a combatant whose first step is
+// unaffordable emits an informational narrative and does not move.
+func TestStride_ZeroBudgetNoMove(t *testing.T) {
+	actor := newStrideActor("actor", 0, 5, 5) // SpeedBudget == 1
+	opponent := &combat.Combatant{
+		ID: "enemy", Name: "Enemy", Kind: combat.KindNPC,
+		MaxHP: 30, CurrentHP: 30, AC: 12,
+		GridX: 19, GridY: 5,
+	}
+	terrain := map[combat.GridCell]*combat.TerrainCell{
+		// First step is difficult (cost 2) — exceeds budget 1.
+		{X: 1, Y: 5}: {X: 1, Y: 5, Type: combat.TerrainDifficult},
+	}
+	cbt := &combat.Combat{
+		GridWidth:    20,
+		GridHeight:   20,
+		Combatants:   []*combat.Combatant{actor, opponent},
+		Terrain:      terrain,
+		ActionQueues: map[string]*combat.ActionQueue{},
+	}
+	events := runStride(cbt, actor, "toward", fixedSrc{val: 0})
+	if actor.GridX != 0 {
+		t.Fatalf("zero-budget: actor must not move, got GridX=%d", actor.GridX)
+	}
+	// REQ-TERRAIN-18: must emit an informational stride event.
+	found := false
+	for _, e := range events {
+		if e.ActionType == combat.ActionStride && e.ActorID == "actor" {
+			found = true
+			if e.Narrative == "" {
+				t.Error("zero-budget: stride event must have a non-empty narrative")
+			}
+		}
+	}
+	if !found {
+		t.Error("zero-budget: must emit a stride event")
+	}
+}

--- a/internal/game/combat/terrain.go
+++ b/internal/game/combat/terrain.go
@@ -1,0 +1,72 @@
+package combat
+
+import "github.com/cory-johannsen/mud/internal/game/world"
+
+// GridCell is a 2D grid coordinate (column, row).
+type GridCell struct {
+	X, Y int
+}
+
+// TerrainType enumerates the four terrain types supported in v1.
+type TerrainType string
+
+const (
+	TerrainNormal           TerrainType = "normal"
+	TerrainDifficult        TerrainType = "difficult"
+	TerrainGreaterDifficult TerrainType = "greater_difficult"
+	TerrainHazardous        TerrainType = "hazardous"
+)
+
+// TerrainCell is one cell in the combat grid's terrain layer.
+type TerrainCell struct {
+	X, Y int
+	Type TerrainType
+	// DifficultOverlay, when true on a TerrainHazardous cell, makes the cell
+	// cost 2 movement to enter instead of 1. Ignored on other types.
+	DifficultOverlay bool
+	// Hazard is populated iff Type == TerrainHazardous.
+	Hazard *CellHazard
+}
+
+// CellHazard is the resolved hazard descriptor for a hazardous cell.
+type CellHazard struct {
+	HazardID string
+	Def      *world.HazardDef
+}
+
+// TerrainAt returns the TerrainCell at (x, y). Absent cells map to TerrainNormal.
+//
+// Postcondition: returned cell Type is always a valid TerrainType.
+func (c *Combat) TerrainAt(x, y int) TerrainCell {
+	if c.Terrain == nil {
+		return TerrainCell{X: x, Y: y, Type: TerrainNormal}
+	}
+	if tc, ok := c.Terrain[GridCell{X: x, Y: y}]; ok {
+		return *tc
+	}
+	return TerrainCell{X: x, Y: y, Type: TerrainNormal}
+}
+
+// EntryCost returns the speed budget cost to enter cell (x, y).
+// ok=false means the cell is impassable (TerrainGreaterDifficult).
+//
+//   - TerrainNormal: 1
+//   - TerrainDifficult: 2
+//   - TerrainHazardous: 1 (or 2 if DifficultOverlay)
+//   - TerrainGreaterDifficult: impassable (ok=false)
+func (c *Combat) EntryCost(x, y int) (cost int, ok bool) {
+	tc := c.TerrainAt(x, y)
+	switch tc.Type {
+	case TerrainGreaterDifficult:
+		return 0, false
+	case TerrainDifficult:
+		return 2, true
+	case TerrainHazardous:
+		if tc.DifficultOverlay {
+			return 2, true
+		}
+		return 1, true
+	default:
+		return 1, true
+	}
+}

--- a/internal/game/combat/terrain.go
+++ b/internal/game/combat/terrain.go
@@ -1,6 +1,10 @@
 package combat
 
-import "github.com/cory-johannsen/mud/internal/game/world"
+import (
+	"fmt"
+
+	"github.com/cory-johannsen/mud/internal/game/world"
+)
 
 // GridCell is a 2D grid coordinate (column, row).
 type GridCell struct {
@@ -69,4 +73,57 @@ func (c *Combat) EntryCost(x, y int) (cost int, ok bool) {
 	default:
 		return 1, true
 	}
+}
+
+// TerrainGlyph returns the display character for a terrain type.
+// When unicode is true, returns block-shade glyphs; otherwise returns
+// ASCII fallbacks suitable for clients that cannot render UTF-8.
+//
+// Precondition: t should be a valid TerrainType; unknown values map to
+// the normal-terrain glyph.
+// Postcondition: the returned string is always non-empty.
+func TerrainGlyph(t TerrainType, unicode bool) string {
+	if unicode {
+		switch t {
+		case TerrainDifficult:
+			return "▒"
+		case TerrainGreaterDifficult:
+			return "▓"
+		case TerrainHazardous:
+			return "!"
+		default:
+			return "·"
+		}
+	}
+	switch t {
+	case TerrainDifficult:
+		return "+"
+	case TerrainGreaterDifficult:
+		return "#"
+	case TerrainHazardous:
+		return "!"
+	default:
+		return "."
+	}
+}
+
+// TerrainLegendText returns a printable legend describing the four
+// terrain types and their movement / hazard semantics. It is the
+// canonical output of the `terrain` telnet command.
+//
+// Postcondition: the returned text always mentions all four terrain
+// keywords (normal, difficult, impassable, hazardous).
+func TerrainLegendText(unicode bool) string {
+	dot := TerrainGlyph(TerrainNormal, unicode)
+	diff := TerrainGlyph(TerrainDifficult, unicode)
+	greater := TerrainGlyph(TerrainGreaterDifficult, unicode)
+	haz := TerrainGlyph(TerrainHazardous, unicode)
+	return fmt.Sprintf(
+		"Combat map legend:\n"+
+			"  %s  normal          - 1 speed to enter\n"+
+			"  %s  difficult       - 2 speed to enter\n"+
+			"  %s  impassable      - cannot be entered\n"+
+			"  %s  hazardous       - damage on entry or round start\n",
+		dot, diff, greater, haz,
+	)
 }

--- a/internal/game/combat/terrain_render_test.go
+++ b/internal/game/combat/terrain_render_test.go
@@ -1,0 +1,47 @@
+package combat_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+// TestTerrainGlyphs_NormalIsDot verifies that normal terrain renders as a
+// dot-shaped glyph in either Unicode or ASCII mode.
+func TestTerrainGlyphs_NormalIsDot(t *testing.T) {
+	g := combat.TerrainGlyph(combat.TerrainNormal, false)
+	if g != "·" && g != "." {
+		t.Errorf("normal terrain glyph: want · or . got %q", g)
+	}
+}
+
+// TestTerrainGlyphs_DifficultIsHash verifies difficult terrain has a
+// non-empty glyph distinct from normal.
+func TestTerrainGlyphs_DifficultIsHash(t *testing.T) {
+	g := combat.TerrainGlyph(combat.TerrainDifficult, false)
+	if g == "" {
+		t.Error("difficult terrain must have a non-empty glyph")
+	}
+}
+
+// TestTerrainGlyphs_GreaterDifficultIsDense verifies that greater_difficult
+// uses a glyph distinct from difficult.
+func TestTerrainGlyphs_GreaterDifficultIsDense(t *testing.T) {
+	g := combat.TerrainGlyph(combat.TerrainGreaterDifficult, false)
+	gd := combat.TerrainGlyph(combat.TerrainDifficult, false)
+	if g == gd {
+		t.Error("greater_difficult and difficult must have distinct glyphs")
+	}
+}
+
+// TestTerrainLegendOutput verifies the terrain legend mentions all four
+// terrain type keywords.
+func TestTerrainLegendOutput(t *testing.T) {
+	legend := combat.TerrainLegendText(false)
+	for _, keyword := range []string{"normal", "difficult", "impassable", "hazardous"} {
+		if !strings.Contains(legend, keyword) {
+			t.Errorf("terrain legend must mention %q", keyword)
+		}
+	}
+}

--- a/internal/game/combat/terrain_test.go
+++ b/internal/game/combat/terrain_test.go
@@ -74,3 +74,24 @@ func TestProperty_EntryCost_NormalCostsOne(t *testing.T) {
 		}
 	})
 }
+
+func TestProperty_SpeedBudget_EqualsSpeedSquares(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		c := &combat.Combatant{
+			SpeedFt: rapid.IntRange(0, 100).Draw(rt, "speedFt"),
+		}
+		if c.SpeedBudget() != c.SpeedSquares() {
+			rt.Fatalf("SpeedBudget %d != SpeedSquares %d for SpeedFt %d",
+				c.SpeedBudget(), c.SpeedSquares(), c.SpeedFt)
+		}
+	})
+}
+
+func TestProperty_SpeedBudget_MinOne(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		c := &combat.Combatant{SpeedFt: 0}
+		if c.SpeedBudget() < 1 {
+			rt.Fatalf("SpeedBudget must be >= 1, got %d", c.SpeedBudget())
+		}
+	})
+}

--- a/internal/game/combat/terrain_test.go
+++ b/internal/game/combat/terrain_test.go
@@ -1,0 +1,76 @@
+package combat_test
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+func TestProperty_TerrainAt_AbsentCellIsNormal(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		cbt := &combat.Combat{Terrain: nil, GridWidth: 10, GridHeight: 10}
+		x := rapid.IntRange(0, 9).Draw(rt, "x")
+		y := rapid.IntRange(0, 9).Draw(rt, "y")
+		tc := cbt.TerrainAt(x, y)
+		if tc.Type != combat.TerrainNormal {
+			rt.Fatalf("absent cell (%d,%d): want normal got %v", x, y, tc.Type)
+		}
+	})
+}
+
+func TestProperty_EntryCost_GreaterDifficultImpassable(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		cbt := &combat.Combat{GridWidth: 10, GridHeight: 10}
+		cbt.Terrain = map[combat.GridCell]*combat.TerrainCell{
+			{X: 3, Y: 3}: {X: 3, Y: 3, Type: combat.TerrainGreaterDifficult},
+		}
+		_, ok := cbt.EntryCost(3, 3)
+		if ok {
+			rt.Fatal("greater_difficult must be impassable (ok=false)")
+		}
+	})
+}
+
+func TestProperty_EntryCost_DifficultCostsTwo(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		cbt := &combat.Combat{GridWidth: 10, GridHeight: 10}
+		cbt.Terrain = map[combat.GridCell]*combat.TerrainCell{
+			{X: 1, Y: 1}: {X: 1, Y: 1, Type: combat.TerrainDifficult},
+		}
+		cost, ok := cbt.EntryCost(1, 1)
+		if !ok {
+			rt.Fatal("difficult must be passable")
+		}
+		if cost != 2 {
+			rt.Fatalf("difficult: want cost=2 got %d", cost)
+		}
+	})
+}
+
+func TestProperty_EntryCost_HazardousWithDifficultOverlayCostsTwo(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		cbt := &combat.Combat{GridWidth: 10, GridHeight: 10}
+		cbt.Terrain = map[combat.GridCell]*combat.TerrainCell{
+			{X: 2, Y: 2}: {X: 2, Y: 2, Type: combat.TerrainHazardous, DifficultOverlay: true},
+		}
+		cost, ok := cbt.EntryCost(2, 2)
+		if !ok {
+			rt.Fatal("hazardous must be passable")
+		}
+		if cost != 2 {
+			rt.Fatalf("hazardous+difficult: want cost=2 got %d", cost)
+		}
+	})
+}
+
+func TestProperty_EntryCost_NormalCostsOne(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		cbt := &combat.Combat{GridWidth: 10, GridHeight: 10}
+		cost, ok := cbt.EntryCost(0, 0)
+		if !ok || cost != 1 {
+			rt.Fatalf("normal: want (1, true) got (%d, %v)", cost, ok)
+		}
+	})
+}

--- a/internal/game/command/commands.go
+++ b/internal/game/command/commands.go
@@ -158,6 +158,7 @@ const (
 	HandlerLoot               = "loot"
 	HandlerInspect            = "inspect"
 	HandlerEffects            = "effects"
+	HandlerTerrain            = "terrain"
 )
 
 // Command defines a player-invocable command.
@@ -199,6 +200,7 @@ func BuiltinCommands() []Command {
 		{Name: "strike", Aliases: []string{"st"}, Help: "Full attack routine (2 AP, two hits with MAP) against target.", Category: CategoryCombat, Handler: HandlerStrike},
 		{Name: "status", Aliases: []string{"cond"}, Help: "Show your active conditions.", Category: CategoryCombat, Handler: HandlerStatus},
 		{Name: "effects", Aliases: []string{"eff"}, Help: "Show active effects and which typed bonuses are suppressed.", Category: CategoryCombat, Handler: HandlerEffects},
+		{Name: "terrain", Aliases: []string{"terr"}, Help: "Show the combat-map terrain legend (glyphs and movement costs).", Category: CategoryCombat, Handler: HandlerTerrain},
 		{Name: "equip", Aliases: []string{"eq"}, Help: "Equip a weapon (equip <weapon_id> [slot])", Category: CategoryCombat, Handler: HandlerEquip},
 		{Name: "loadout", Aliases: []string{"lo", "prep", "kit"}, Help: "Display or swap weapon presets (loadout [1|2])", Category: CategoryCombat, Handler: HandlerLoadout},
 		{Name: "unequip", Aliases: []string{"ueq"}, Help: "Unequip an item from a slot (unequip <slot>)", Category: CategoryCombat, Handler: HandlerUnequip},

--- a/internal/game/world/model.go
+++ b/internal/game/world/model.go
@@ -206,6 +206,8 @@ type Room struct {
 	Indoor bool `yaml:"indoor,omitempty"`
 	// Hazards lists environmental hazards that fire on player entry or each combat round.
 	Hazards []HazardDef `yaml:"hazards,omitempty"`
+	// CombatTerrain holds the authored per-cell terrain configuration for tactical combat.
+	CombatTerrain *CombatTerrainConfig `yaml:"combat_terrain,omitempty"`
 	// MinFactionTierID is the minimum faction tier ID required to enter this room.
 	// Empty string means no gating.
 	MinFactionTierID string `yaml:"min_faction_tier_id"`
@@ -501,4 +503,47 @@ func (z *Zone) Validate() error {
 		coordSeen[key] = r.ID
 	}
 	return nil
+}
+
+// CombatTerrainConfig holds the authored per-cell terrain configuration for a room.
+// Exactly one of Grid (shape A) or Cells (shape B) must be set.
+type CombatTerrainConfig struct {
+	Grid    []string                      `yaml:"grid,omitempty"`
+	Legend  map[string]TerrainLegendEntry `yaml:"legend,omitempty"`
+	Default string                        `yaml:"default,omitempty"`
+	Cells   []TerrainCellDef              `yaml:"cells,omitempty"`
+}
+
+// TerrainLegendEntry is a legend value in shape-A terrain authoring.
+type TerrainLegendEntry struct {
+	Type      string     `yaml:"type"`
+	Difficult bool       `yaml:"difficult,omitempty"`
+	HazardID  string     `yaml:"hazard_id,omitempty"`
+	Hazard    *HazardDef `yaml:"hazard,omitempty"`
+}
+
+// UnmarshalYAML for TerrainLegendEntry supports both bare-string and object forms.
+func (e *TerrainLegendEntry) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err == nil {
+		e.Type = s
+		return nil
+	}
+	type plain TerrainLegendEntry
+	var obj plain
+	if err := unmarshal(&obj); err != nil {
+		return err
+	}
+	*e = TerrainLegendEntry(obj)
+	return nil
+}
+
+// TerrainCellDef is a single per-cell override entry in shape-B terrain authoring.
+type TerrainCellDef struct {
+	X         int        `yaml:"x"`
+	Y         int        `yaml:"y"`
+	Type      string     `yaml:"type"`
+	Difficult bool       `yaml:"difficult,omitempty"`
+	HazardID  string     `yaml:"hazard_id,omitempty"`
+	Hazard    *HazardDef `yaml:"hazard,omitempty"`
 }

--- a/internal/game/world/terrain_load.go
+++ b/internal/game/world/terrain_load.go
@@ -1,0 +1,146 @@
+package world
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CellKey is the world-package equivalent of combat.GridCell, used as a map key.
+type CellKey struct{ X, Y int }
+
+// ResolvedTerrainCell is the normalised per-cell result.
+type ResolvedTerrainCell struct {
+	Type             string
+	DifficultOverlay bool
+	Hazard           *ResolvedCellHazard
+}
+
+// ResolvedCellHazard carries the resolved hazard for a hazardous cell.
+type ResolvedCellHazard struct {
+	HazardID string
+	Def      *HazardDef
+}
+
+// LoadCombatTerrain normalises a CombatTerrainConfig into a sparse map.
+// Only non-normal cells are present in the result.
+func LoadCombatTerrain(cfg *CombatTerrainConfig, gridWidth, gridHeight int, hazards []HazardDef) (map[CellKey]*ResolvedTerrainCell, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("terrain config must not be nil")
+	}
+	hasGrid := len(cfg.Grid) > 0
+	hasCells := len(cfg.Cells) > 0
+	if hasGrid && hasCells {
+		return nil, fmt.Errorf("combat_terrain: cannot declare both grid and cells in the same room (TERRAIN-3)")
+	}
+	hazardMap := make(map[string]*HazardDef, len(hazards))
+	for i := range hazards {
+		hazardMap[hazards[i].ID] = &hazards[i]
+	}
+	if hasGrid {
+		return loadShapeA(cfg, gridWidth, gridHeight, hazardMap)
+	}
+	return loadShapeB(cfg, hazardMap)
+}
+
+var defaultLegend = map[string]TerrainLegendEntry{
+	".": {Type: "normal"},
+	"#": {Type: "difficult"},
+	"X": {Type: "greater_difficult"},
+	"H": {Type: "hazardous"},
+}
+
+func loadShapeA(cfg *CombatTerrainConfig, gridWidth, gridHeight int, hazards map[string]*HazardDef) (map[CellKey]*ResolvedTerrainCell, error) {
+	if len(cfg.Grid) != gridHeight {
+		return nil, fmt.Errorf("combat_terrain.grid: %d rows declared but grid height is %d", len(cfg.Grid), gridHeight)
+	}
+	legend := make(map[string]TerrainLegendEntry, len(defaultLegend)+len(cfg.Legend))
+	for k, v := range defaultLegend {
+		legend[k] = v
+	}
+	for k, v := range cfg.Legend {
+		legend[k] = v
+	}
+	result := make(map[CellKey]*ResolvedTerrainCell)
+	for y, row := range cfg.Grid {
+		runes := []rune(row)
+		if len(runes) != gridWidth {
+			return nil, fmt.Errorf("combat_terrain.grid: row %d has %d columns, expected %d", y, len(runes), gridWidth)
+		}
+		for x, ch := range runes {
+			glyph := string(ch)
+			entry, ok := legend[glyph]
+			if !ok {
+				return nil, fmt.Errorf("combat_terrain.grid: unknown glyph %q at (%d,%d) — add it to the legend", glyph, x, y)
+			}
+			if entry.Type == "normal" {
+				continue
+			}
+			tc, err := resolveCell(entry.Type, entry.Difficult, entry.HazardID, entry.Hazard, hazards)
+			if err != nil {
+				return nil, fmt.Errorf("combat_terrain.grid row %d col %d: %w", y, x, err)
+			}
+			result[CellKey{X: x, Y: y}] = tc
+		}
+	}
+	return result, nil
+}
+
+func loadShapeB(cfg *CombatTerrainConfig, hazards map[string]*HazardDef) (map[CellKey]*ResolvedTerrainCell, error) {
+	result := make(map[CellKey]*ResolvedTerrainCell)
+	seen := make(map[CellKey]bool)
+	for _, cd := range cfg.Cells {
+		key := CellKey{X: cd.X, Y: cd.Y}
+		if seen[key] {
+			return nil, fmt.Errorf("combat_terrain.cells: duplicate entry for (%d,%d) (TERRAIN-3)", cd.X, cd.Y)
+		}
+		seen[key] = true
+		if cd.Type == "normal" {
+			continue
+		}
+		tc, err := resolveCell(cd.Type, cd.Difficult, cd.HazardID, cd.Hazard, hazards)
+		if err != nil {
+			return nil, fmt.Errorf("combat_terrain.cells (%d,%d): %w", cd.X, cd.Y, err)
+		}
+		result[key] = tc
+	}
+	return result, nil
+}
+
+func resolveCell(typ string, difficult bool, hazardID string, inlineHazard *HazardDef, hazards map[string]*HazardDef) (*ResolvedTerrainCell, error) {
+	tc := &ResolvedTerrainCell{Type: typ}
+	switch typ {
+	case "greater_difficult":
+		if hazardID != "" || inlineHazard != nil {
+			return nil, fmt.Errorf("greater_difficult must not carry a hazard (TERRAIN-5)")
+		}
+		if difficult {
+			return nil, fmt.Errorf("greater_difficult must not combine with difficult (TERRAIN-5)")
+		}
+	case "hazardous":
+		if hazardID == "" && inlineHazard == nil {
+			return nil, fmt.Errorf("hazardous cell must declare hazard_id or hazard (TERRAIN-4)")
+		}
+		if hazardID != "" && inlineHazard != nil {
+			return nil, fmt.Errorf("hazardous cell may not declare both hazard_id and inline hazard (TERRAIN-4)")
+		}
+		tc.DifficultOverlay = difficult
+		rch := &ResolvedCellHazard{HazardID: hazardID}
+		if inlineHazard != nil {
+			if err := inlineHazard.Validate(); err != nil {
+				return nil, fmt.Errorf("inline hazard invalid: %w", err)
+			}
+			rch.Def = inlineHazard
+		} else if def, ok := hazards[hazardID]; ok {
+			rch.Def = def
+		}
+		tc.Hazard = rch
+	case "difficult", "normal":
+		if hazardID != "" || inlineHazard != nil {
+			return nil, fmt.Errorf("non-hazardous cell type %q must not carry a hazard (TERRAIN-4)", typ)
+		}
+	default:
+		return nil, fmt.Errorf("unknown terrain type %q; valid: normal difficult greater_difficult hazardous", typ)
+	}
+	tc.Type = strings.TrimSpace(typ)
+	return tc, nil
+}

--- a/internal/game/world/terrain_load_test.go
+++ b/internal/game/world/terrain_load_test.go
@@ -1,0 +1,117 @@
+package world_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/world"
+)
+
+func TestLoadTerrainShapeA_ExplicitGrid(t *testing.T) {
+	cfg := &world.CombatTerrainConfig{
+		Grid: []string{
+			"....",
+			".##.",
+			"....",
+		},
+		Legend: map[string]world.TerrainLegendEntry{
+			".": {Type: "normal"},
+			"#": {Type: "difficult"},
+		},
+	}
+	cells, err := world.LoadCombatTerrain(cfg, 4, 3, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cells[world.CellKey{X: 1, Y: 1}].Type != "difficult" {
+		t.Error("(1,1) should be difficult")
+	}
+	if cells[world.CellKey{X: 2, Y: 1}].Type != "difficult" {
+		t.Error("(2,1) should be difficult")
+	}
+	if _, ok := cells[world.CellKey{X: 0, Y: 0}]; ok {
+		t.Error("(0,0) should be absent (normal, not stored)")
+	}
+}
+
+func TestLoadTerrainShapeB_DefaultPlusOverrides(t *testing.T) {
+	cfg := &world.CombatTerrainConfig{
+		Default: "normal",
+		Cells: []world.TerrainCellDef{
+			{X: 2, Y: 2, Type: "difficult"},
+			{X: 3, Y: 3, Type: "hazardous", HazardID: "fire_vent"},
+		},
+	}
+	hazards := []world.HazardDef{{ID: "fire_vent", Trigger: "on_enter", DamageExpr: "1d6", DamageType: "fire"}}
+	cells, err := world.LoadCombatTerrain(cfg, 10, 10, hazards)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cells[world.CellKey{X: 2, Y: 2}].Type != "difficult" {
+		t.Error("(2,2) should be difficult")
+	}
+	h := cells[world.CellKey{X: 3, Y: 3}]
+	if h.Type != "hazardous" {
+		t.Errorf("(3,3) should be hazardous, got %v", h.Type)
+	}
+	if h.Hazard == nil || h.Hazard.Def == nil {
+		t.Error("(3,3) hazard must be resolved to HazardDef")
+	}
+}
+
+func TestLoadTerrain_BothShapesError(t *testing.T) {
+	cfg := &world.CombatTerrainConfig{
+		Grid:  []string{"."},
+		Cells: []world.TerrainCellDef{{X: 0, Y: 0, Type: "difficult"}},
+	}
+	_, err := world.LoadCombatTerrain(cfg, 1, 1, nil)
+	if err == nil {
+		t.Error("declaring both grid and cells must be a load error")
+	}
+}
+
+func TestLoadTerrain_HazardousWithoutHazardError(t *testing.T) {
+	cfg := &world.CombatTerrainConfig{
+		Cells: []world.TerrainCellDef{
+			{X: 0, Y: 0, Type: "hazardous"},
+		},
+	}
+	_, err := world.LoadCombatTerrain(cfg, 10, 10, nil)
+	if err == nil {
+		t.Error("hazardous cell without a hazard must be a load error")
+	}
+}
+
+func TestLoadTerrain_GreaterDifficultWithHazardError(t *testing.T) {
+	cfg := &world.CombatTerrainConfig{
+		Cells: []world.TerrainCellDef{
+			{X: 0, Y: 0, Type: "greater_difficult", HazardID: "fire_vent"},
+		},
+	}
+	_, err := world.LoadCombatTerrain(cfg, 10, 10, nil)
+	if err == nil {
+		t.Error("greater_difficult with hazard must be a load error")
+	}
+}
+
+func TestLoadTerrain_DuplicateCellError(t *testing.T) {
+	cfg := &world.CombatTerrainConfig{
+		Cells: []world.TerrainCellDef{
+			{X: 1, Y: 1, Type: "difficult"},
+			{X: 1, Y: 1, Type: "normal"},
+		},
+	}
+	_, err := world.LoadCombatTerrain(cfg, 10, 10, nil)
+	if err == nil {
+		t.Error("duplicate (x,y) entries must be a load error")
+	}
+}
+
+func TestLoadTerrain_GridDimensionMismatchError(t *testing.T) {
+	cfg := &world.CombatTerrainConfig{
+		Grid: []string{"....", "...."},
+	}
+	_, err := world.LoadCombatTerrain(cfg, 3, 2, nil)
+	if err == nil {
+		t.Error("grid row length mismatch must be a load error")
+	}
+}

--- a/internal/gameserver/combat_handler.go
+++ b/internal/gameserver/combat_handler.go
@@ -2102,6 +2102,7 @@ func (h *CombatHandler) startPursuitCombatLocked(playerSess *session.PlayerSessi
 			GridWidth:        int32(cbt.GridWidth),
 			GridHeight:       int32(cbt.GridHeight),
 			CoverObjects:     coverObjects,
+			Terrain:          terrainToProto(cbt.Terrain),
 		})
 	}
 
@@ -3083,6 +3084,7 @@ func (h *CombatHandler) resolveAndAdvanceLocked(roomID string, cbt *combat.Comba
 			InitialPositions: initialPositions,
 			GridWidth:        int32(cbt.GridWidth),
 			GridHeight:       int32(cbt.GridHeight),
+			Terrain:          terrainToProto(cbt.Terrain),
 		})
 	}
 
@@ -3467,6 +3469,7 @@ func (h *CombatHandler) startCombatLocked(sess *session.PlayerSession, inst *npc
 			GridWidth:        int32(cbt.GridWidth),
 			GridHeight:       int32(cbt.GridHeight),
 			CoverObjects:     coverObjects,
+			Terrain:          terrainToProto(cbt.Terrain),
 		})
 	}
 
@@ -4489,6 +4492,38 @@ func computeCoverObjects(room *world.Room) []combat.CoverObject {
 			GridX:       xPositions[i%len(xPositions)],
 			GridY:       yStart[i%len(yStart)],
 		})
+	}
+	return out
+}
+
+// terrainToProto converts a Combat's terrain map to []*gamev1.TerrainCell for
+// transmission to the client. Cells of TerrainNormal are omitted (the client
+// treats absent cells as normal). For TerrainHazardous cells, the hazard
+// definition ID is included so the client can render a tooltip.
+//
+// Precondition: terrain may be nil or empty.
+// Postcondition: returned slice contains only non-normal cells; nil if none.
+func terrainToProto(terrain map[combat.GridCell]*combat.TerrainCell) []*gamev1.TerrainCell {
+	if len(terrain) == 0 {
+		return nil
+	}
+	out := make([]*gamev1.TerrainCell, 0, len(terrain))
+	for _, tc := range terrain {
+		if tc == nil || tc.Type == combat.TerrainNormal {
+			continue
+		}
+		cell := &gamev1.TerrainCell{
+			X:    int32(tc.X),
+			Y:    int32(tc.Y),
+			Type: string(tc.Type),
+		}
+		if tc.Type == combat.TerrainHazardous && tc.Hazard != nil && tc.Hazard.Def != nil {
+			cell.HazardName = tc.Hazard.Def.ID
+		}
+		out = append(out, cell)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/gameserver/gamev1/game.pb.go
+++ b/internal/gameserver/gamev1/game.pb.go
@@ -9975,6 +9975,76 @@ func (x *CoverObjectPosition) GetCoverTier() string {
 	return ""
 }
 
+// TerrainCell describes one non-normal cell in the combat grid's terrain layer.
+// Cells absent from the repeated terrain field are TerrainNormal by default.
+type TerrainCell struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	X             int32                  `protobuf:"varint,1,opt,name=x,proto3" json:"x,omitempty"`                                    // grid column (0-based)
+	Y             int32                  `protobuf:"varint,2,opt,name=y,proto3" json:"y,omitempty"`                                    // grid row (0-based)
+	Type          string                 `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`                               // "difficult", "greater_difficult", or "hazardous"
+	HazardName    string                 `protobuf:"bytes,4,opt,name=hazard_name,json=hazardName,proto3" json:"hazard_name,omitempty"` // populated for hazardous cells (HazardDef.ID); empty otherwise
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerrainCell) Reset() {
+	*x = TerrainCell{}
+	mi := &file_game_v1_game_proto_msgTypes[113]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerrainCell) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerrainCell) ProtoMessage() {}
+
+func (x *TerrainCell) ProtoReflect() protoreflect.Message {
+	mi := &file_game_v1_game_proto_msgTypes[113]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerrainCell.ProtoReflect.Descriptor instead.
+func (*TerrainCell) Descriptor() ([]byte, []int) {
+	return file_game_v1_game_proto_rawDescGZIP(), []int{113}
+}
+
+func (x *TerrainCell) GetX() int32 {
+	if x != nil {
+		return x.X
+	}
+	return 0
+}
+
+func (x *TerrainCell) GetY() int32 {
+	if x != nil {
+		return x.Y
+	}
+	return 0
+}
+
+func (x *TerrainCell) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *TerrainCell) GetHazardName() string {
+	if x != nil {
+		return x.HazardName
+	}
+	return ""
+}
+
 // RoundStartEvent is broadcast to all combatants when a new round begins.
 type RoundStartEvent struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
@@ -9986,13 +10056,14 @@ type RoundStartEvent struct {
 	GridWidth        int32                  `protobuf:"varint,6,opt,name=grid_width,json=gridWidth,proto3" json:"grid_width,omitempty"`
 	GridHeight       int32                  `protobuf:"varint,7,opt,name=grid_height,json=gridHeight,proto3" json:"grid_height,omitempty"`
 	CoverObjects     []*CoverObjectPosition `protobuf:"bytes,8,rep,name=cover_objects,json=coverObjects,proto3" json:"cover_objects,omitempty"`
+	Terrain          []*TerrainCell         `protobuf:"bytes,9,rep,name=terrain,proto3" json:"terrain,omitempty"` // non-normal cells only
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
 
 func (x *RoundStartEvent) Reset() {
 	*x = RoundStartEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[113]
+	mi := &file_game_v1_game_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10004,7 +10075,7 @@ func (x *RoundStartEvent) String() string {
 func (*RoundStartEvent) ProtoMessage() {}
 
 func (x *RoundStartEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[113]
+	mi := &file_game_v1_game_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10017,7 +10088,7 @@ func (x *RoundStartEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundStartEvent.ProtoReflect.Descriptor instead.
 func (*RoundStartEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{113}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *RoundStartEvent) GetRound() int32 {
@@ -10076,6 +10147,13 @@ func (x *RoundStartEvent) GetCoverObjects() []*CoverObjectPosition {
 	return nil
 }
 
+func (x *RoundStartEvent) GetTerrain() []*TerrainCell {
+	if x != nil {
+		return x.Terrain
+	}
+	return nil
+}
+
 // RoundEndEvent is broadcast when a round's actions have resolved.
 type RoundEndEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -10086,7 +10164,7 @@ type RoundEndEvent struct {
 
 func (x *RoundEndEvent) Reset() {
 	*x = RoundEndEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[114]
+	mi := &file_game_v1_game_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10098,7 +10176,7 @@ func (x *RoundEndEvent) String() string {
 func (*RoundEndEvent) ProtoMessage() {}
 
 func (x *RoundEndEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[114]
+	mi := &file_game_v1_game_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10111,7 +10189,7 @@ func (x *RoundEndEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundEndEvent.ProtoReflect.Descriptor instead.
 func (*RoundEndEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{114}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *RoundEndEvent) GetRound() int32 {
@@ -10137,7 +10215,7 @@ type APUpdateEvent struct {
 
 func (x *APUpdateEvent) Reset() {
 	*x = APUpdateEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[115]
+	mi := &file_game_v1_game_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10149,7 +10227,7 @@ func (x *APUpdateEvent) String() string {
 func (*APUpdateEvent) ProtoMessage() {}
 
 func (x *APUpdateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[115]
+	mi := &file_game_v1_game_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10162,7 +10240,7 @@ func (x *APUpdateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use APUpdateEvent.ProtoReflect.Descriptor instead.
 func (*APUpdateEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{115}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *APUpdateEvent) GetName() string {
@@ -10232,7 +10310,7 @@ type CombatEvent struct {
 
 func (x *CombatEvent) Reset() {
 	*x = CombatEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[116]
+	mi := &file_game_v1_game_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10244,7 +10322,7 @@ func (x *CombatEvent) String() string {
 func (*CombatEvent) ProtoMessage() {}
 
 func (x *CombatEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[116]
+	mi := &file_game_v1_game_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10257,7 +10335,7 @@ func (x *CombatEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombatEvent.ProtoReflect.Descriptor instead.
 func (*CombatEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{116}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *CombatEvent) GetType() CombatEventType {
@@ -10375,7 +10453,7 @@ type StatusRequest struct {
 
 func (x *StatusRequest) Reset() {
 	*x = StatusRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[117]
+	mi := &file_game_v1_game_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10387,7 +10465,7 @@ func (x *StatusRequest) String() string {
 func (*StatusRequest) ProtoMessage() {}
 
 func (x *StatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[117]
+	mi := &file_game_v1_game_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10400,7 +10478,7 @@ func (x *StatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusRequest.ProtoReflect.Descriptor instead.
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{117}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{118}
 }
 
 // ConditionEvent reports a condition being applied to or removed from an entity.
@@ -10418,7 +10496,7 @@ type ConditionEvent struct {
 
 func (x *ConditionEvent) Reset() {
 	*x = ConditionEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[118]
+	mi := &file_game_v1_game_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10430,7 +10508,7 @@ func (x *ConditionEvent) String() string {
 func (*ConditionEvent) ProtoMessage() {}
 
 func (x *ConditionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[118]
+	mi := &file_game_v1_game_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10443,7 +10521,7 @@ func (x *ConditionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConditionEvent.ProtoReflect.Descriptor instead.
 func (*ConditionEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{118}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *ConditionEvent) GetTargetUid() string {
@@ -10499,7 +10577,7 @@ type WearRequest struct {
 
 func (x *WearRequest) Reset() {
 	*x = WearRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[119]
+	mi := &file_game_v1_game_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10511,7 +10589,7 @@ func (x *WearRequest) String() string {
 func (*WearRequest) ProtoMessage() {}
 
 func (x *WearRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[119]
+	mi := &file_game_v1_game_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10524,7 +10602,7 @@ func (x *WearRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WearRequest.ProtoReflect.Descriptor instead.
 func (*WearRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{119}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *WearRequest) GetItemId() string {
@@ -10551,7 +10629,7 @@ type RemoveArmorRequest struct {
 
 func (x *RemoveArmorRequest) Reset() {
 	*x = RemoveArmorRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[120]
+	mi := &file_game_v1_game_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10563,7 +10641,7 @@ func (x *RemoveArmorRequest) String() string {
 func (*RemoveArmorRequest) ProtoMessage() {}
 
 func (x *RemoveArmorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[120]
+	mi := &file_game_v1_game_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10576,7 +10654,7 @@ func (x *RemoveArmorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveArmorRequest.ProtoReflect.Descriptor instead.
 func (*RemoveArmorRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{120}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *RemoveArmorRequest) GetSlot() string {
@@ -10600,7 +10678,7 @@ type ConditionInfo struct {
 
 func (x *ConditionInfo) Reset() {
 	*x = ConditionInfo{}
-	mi := &file_game_v1_game_proto_msgTypes[121]
+	mi := &file_game_v1_game_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10612,7 +10690,7 @@ func (x *ConditionInfo) String() string {
 func (*ConditionInfo) ProtoMessage() {}
 
 func (x *ConditionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[121]
+	mi := &file_game_v1_game_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10625,7 +10703,7 @@ func (x *ConditionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConditionInfo.ProtoReflect.Descriptor instead.
 func (*ConditionInfo) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{121}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *ConditionInfo) GetId() string {
@@ -10672,7 +10750,7 @@ type CharacterSheetRequest struct {
 
 func (x *CharacterSheetRequest) Reset() {
 	*x = CharacterSheetRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[122]
+	mi := &file_game_v1_game_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10684,7 +10762,7 @@ func (x *CharacterSheetRequest) String() string {
 func (*CharacterSheetRequest) ProtoMessage() {}
 
 func (x *CharacterSheetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[122]
+	mi := &file_game_v1_game_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10697,7 +10775,7 @@ func (x *CharacterSheetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CharacterSheetRequest.ProtoReflect.Descriptor instead.
 func (*CharacterSheetRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{122}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{123}
 }
 
 // ArchetypeSelectionRequest asks the server to assign an archetype to the player's character.
@@ -10710,7 +10788,7 @@ type ArchetypeSelectionRequest struct {
 
 func (x *ArchetypeSelectionRequest) Reset() {
 	*x = ArchetypeSelectionRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[123]
+	mi := &file_game_v1_game_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10722,7 +10800,7 @@ func (x *ArchetypeSelectionRequest) String() string {
 func (*ArchetypeSelectionRequest) ProtoMessage() {}
 
 func (x *ArchetypeSelectionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[123]
+	mi := &file_game_v1_game_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10735,7 +10813,7 @@ func (x *ArchetypeSelectionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchetypeSelectionRequest.ProtoReflect.Descriptor instead.
 func (*ArchetypeSelectionRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{123}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *ArchetypeSelectionRequest) GetArchetypeId() string {
@@ -10754,7 +10832,7 @@ type FeatsRequest struct {
 
 func (x *FeatsRequest) Reset() {
 	*x = FeatsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[124]
+	mi := &file_game_v1_game_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10766,7 +10844,7 @@ func (x *FeatsRequest) String() string {
 func (*FeatsRequest) ProtoMessage() {}
 
 func (x *FeatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[124]
+	mi := &file_game_v1_game_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10779,7 +10857,7 @@ func (x *FeatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeatsRequest.ProtoReflect.Descriptor instead.
 func (*FeatsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{124}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{125}
 }
 
 // FeatEntry represents one feat with its details.
@@ -10800,7 +10878,7 @@ type FeatEntry struct {
 
 func (x *FeatEntry) Reset() {
 	*x = FeatEntry{}
-	mi := &file_game_v1_game_proto_msgTypes[125]
+	mi := &file_game_v1_game_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10812,7 +10890,7 @@ func (x *FeatEntry) String() string {
 func (*FeatEntry) ProtoMessage() {}
 
 func (x *FeatEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[125]
+	mi := &file_game_v1_game_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10825,7 +10903,7 @@ func (x *FeatEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeatEntry.ProtoReflect.Descriptor instead.
 func (*FeatEntry) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{125}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *FeatEntry) GetFeatId() string {
@@ -10901,7 +10979,7 @@ type FeatsResponse struct {
 
 func (x *FeatsResponse) Reset() {
 	*x = FeatsResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[126]
+	mi := &file_game_v1_game_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10913,7 +10991,7 @@ func (x *FeatsResponse) String() string {
 func (*FeatsResponse) ProtoMessage() {}
 
 func (x *FeatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[126]
+	mi := &file_game_v1_game_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10926,7 +11004,7 @@ func (x *FeatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeatsResponse.ProtoReflect.Descriptor instead.
 func (*FeatsResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{126}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *FeatsResponse) GetFeats() []*FeatEntry {
@@ -10945,7 +11023,7 @@ type ClassFeaturesRequest struct {
 
 func (x *ClassFeaturesRequest) Reset() {
 	*x = ClassFeaturesRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[127]
+	mi := &file_game_v1_game_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10957,7 +11035,7 @@ func (x *ClassFeaturesRequest) String() string {
 func (*ClassFeaturesRequest) ProtoMessage() {}
 
 func (x *ClassFeaturesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[127]
+	mi := &file_game_v1_game_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10970,7 +11048,7 @@ func (x *ClassFeaturesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassFeaturesRequest.ProtoReflect.Descriptor instead.
 func (*ClassFeaturesRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{127}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{128}
 }
 
 // ClassFeatureEntry represents one class feature with its details.
@@ -10989,7 +11067,7 @@ type ClassFeatureEntry struct {
 
 func (x *ClassFeatureEntry) Reset() {
 	*x = ClassFeatureEntry{}
-	mi := &file_game_v1_game_proto_msgTypes[128]
+	mi := &file_game_v1_game_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11001,7 +11079,7 @@ func (x *ClassFeatureEntry) String() string {
 func (*ClassFeatureEntry) ProtoMessage() {}
 
 func (x *ClassFeatureEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[128]
+	mi := &file_game_v1_game_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11014,7 +11092,7 @@ func (x *ClassFeatureEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassFeatureEntry.ProtoReflect.Descriptor instead.
 func (*ClassFeatureEntry) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{128}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *ClassFeatureEntry) GetFeatureId() string {
@@ -11077,7 +11155,7 @@ type ClassFeaturesResponse struct {
 
 func (x *ClassFeaturesResponse) Reset() {
 	*x = ClassFeaturesResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[129]
+	mi := &file_game_v1_game_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11089,7 +11167,7 @@ func (x *ClassFeaturesResponse) String() string {
 func (*ClassFeaturesResponse) ProtoMessage() {}
 
 func (x *ClassFeaturesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[129]
+	mi := &file_game_v1_game_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11102,7 +11180,7 @@ func (x *ClassFeaturesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassFeaturesResponse.ProtoReflect.Descriptor instead.
 func (*ClassFeaturesResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{129}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *ClassFeaturesResponse) GetArchetypeFeatures() []*ClassFeatureEntry {
@@ -11129,7 +11207,7 @@ type InteractRequest struct {
 
 func (x *InteractRequest) Reset() {
 	*x = InteractRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[130]
+	mi := &file_game_v1_game_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11141,7 +11219,7 @@ func (x *InteractRequest) String() string {
 func (*InteractRequest) ProtoMessage() {}
 
 func (x *InteractRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[130]
+	mi := &file_game_v1_game_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11154,7 +11232,7 @@ func (x *InteractRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InteractRequest.ProtoReflect.Descriptor instead.
 func (*InteractRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{130}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *InteractRequest) GetInstanceId() string {
@@ -11174,7 +11252,7 @@ type InteractResponse struct {
 
 func (x *InteractResponse) Reset() {
 	*x = InteractResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[131]
+	mi := &file_game_v1_game_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11186,7 +11264,7 @@ func (x *InteractResponse) String() string {
 func (*InteractResponse) ProtoMessage() {}
 
 func (x *InteractResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[131]
+	mi := &file_game_v1_game_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11199,7 +11277,7 @@ func (x *InteractResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InteractResponse.ProtoReflect.Descriptor instead.
 func (*InteractResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{131}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *InteractResponse) GetMessage() string {
@@ -11223,7 +11301,7 @@ type UseRequest struct {
 
 func (x *UseRequest) Reset() {
 	*x = UseRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[132]
+	mi := &file_game_v1_game_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11235,7 +11313,7 @@ func (x *UseRequest) String() string {
 func (*UseRequest) ProtoMessage() {}
 
 func (x *UseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[132]
+	mi := &file_game_v1_game_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11248,7 +11326,7 @@ func (x *UseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UseRequest.ProtoReflect.Descriptor instead.
 func (*UseRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{132}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *UseRequest) GetFeatId() string {
@@ -11290,7 +11368,7 @@ type UseResponse struct {
 
 func (x *UseResponse) Reset() {
 	*x = UseResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[133]
+	mi := &file_game_v1_game_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11302,7 +11380,7 @@ func (x *UseResponse) String() string {
 func (*UseResponse) ProtoMessage() {}
 
 func (x *UseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[133]
+	mi := &file_game_v1_game_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11315,7 +11393,7 @@ func (x *UseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UseResponse.ProtoReflect.Descriptor instead.
 func (*UseResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{133}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *UseResponse) GetMessage() string {
@@ -11348,7 +11426,7 @@ type PreparedSlotView struct {
 
 func (x *PreparedSlotView) Reset() {
 	*x = PreparedSlotView{}
-	mi := &file_game_v1_game_proto_msgTypes[134]
+	mi := &file_game_v1_game_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11360,7 +11438,7 @@ func (x *PreparedSlotView) String() string {
 func (*PreparedSlotView) ProtoMessage() {}
 
 func (x *PreparedSlotView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[134]
+	mi := &file_game_v1_game_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11373,7 +11451,7 @@ func (x *PreparedSlotView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedSlotView.ProtoReflect.Descriptor instead.
 func (*PreparedSlotView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{134}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *PreparedSlotView) GetTechId() string {
@@ -11440,7 +11518,7 @@ type HardwiredSlotView struct {
 
 func (x *HardwiredSlotView) Reset() {
 	*x = HardwiredSlotView{}
-	mi := &file_game_v1_game_proto_msgTypes[135]
+	mi := &file_game_v1_game_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11452,7 +11530,7 @@ func (x *HardwiredSlotView) String() string {
 func (*HardwiredSlotView) ProtoMessage() {}
 
 func (x *HardwiredSlotView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[135]
+	mi := &file_game_v1_game_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11465,7 +11543,7 @@ func (x *HardwiredSlotView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HardwiredSlotView.ProtoReflect.Descriptor instead.
 func (*HardwiredSlotView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{135}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *HardwiredSlotView) GetTechId() string {
@@ -11525,7 +11603,7 @@ type SpontaneousKnownEntry struct {
 
 func (x *SpontaneousKnownEntry) Reset() {
 	*x = SpontaneousKnownEntry{}
-	mi := &file_game_v1_game_proto_msgTypes[136]
+	mi := &file_game_v1_game_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11537,7 +11615,7 @@ func (x *SpontaneousKnownEntry) String() string {
 func (*SpontaneousKnownEntry) ProtoMessage() {}
 
 func (x *SpontaneousKnownEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[136]
+	mi := &file_game_v1_game_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11550,7 +11628,7 @@ func (x *SpontaneousKnownEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpontaneousKnownEntry.ProtoReflect.Descriptor instead.
 func (*SpontaneousKnownEntry) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{136}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *SpontaneousKnownEntry) GetTechId() string {
@@ -11676,7 +11754,7 @@ type CharacterSheetView struct {
 
 func (x *CharacterSheetView) Reset() {
 	*x = CharacterSheetView{}
-	mi := &file_game_v1_game_proto_msgTypes[137]
+	mi := &file_game_v1_game_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11688,7 +11766,7 @@ func (x *CharacterSheetView) String() string {
 func (*CharacterSheetView) ProtoMessage() {}
 
 func (x *CharacterSheetView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[137]
+	mi := &file_game_v1_game_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11701,7 +11779,7 @@ func (x *CharacterSheetView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CharacterSheetView.ProtoReflect.Descriptor instead.
 func (*CharacterSheetView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{137}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *CharacterSheetView) GetName() string {
@@ -12178,7 +12256,7 @@ type InnateSlotView struct {
 
 func (x *InnateSlotView) Reset() {
 	*x = InnateSlotView{}
-	mi := &file_game_v1_game_proto_msgTypes[138]
+	mi := &file_game_v1_game_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12190,7 +12268,7 @@ func (x *InnateSlotView) String() string {
 func (*InnateSlotView) ProtoMessage() {}
 
 func (x *InnateSlotView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[138]
+	mi := &file_game_v1_game_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12203,7 +12281,7 @@ func (x *InnateSlotView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InnateSlotView.ProtoReflect.Descriptor instead.
 func (*InnateSlotView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{138}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *InnateSlotView) GetTechId() string {
@@ -12288,7 +12366,7 @@ type SpontaneousUsePoolView struct {
 
 func (x *SpontaneousUsePoolView) Reset() {
 	*x = SpontaneousUsePoolView{}
-	mi := &file_game_v1_game_proto_msgTypes[139]
+	mi := &file_game_v1_game_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12300,7 +12378,7 @@ func (x *SpontaneousUsePoolView) String() string {
 func (*SpontaneousUsePoolView) ProtoMessage() {}
 
 func (x *SpontaneousUsePoolView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[139]
+	mi := &file_game_v1_game_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12313,7 +12391,7 @@ func (x *SpontaneousUsePoolView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpontaneousUsePoolView.ProtoReflect.Descriptor instead.
 func (*SpontaneousUsePoolView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{139}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *SpontaneousUsePoolView) GetTechLevel() int32 {
@@ -12348,7 +12426,7 @@ type ResistanceEntry struct {
 
 func (x *ResistanceEntry) Reset() {
 	*x = ResistanceEntry{}
-	mi := &file_game_v1_game_proto_msgTypes[140]
+	mi := &file_game_v1_game_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12360,7 +12438,7 @@ func (x *ResistanceEntry) String() string {
 func (*ResistanceEntry) ProtoMessage() {}
 
 func (x *ResistanceEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[140]
+	mi := &file_game_v1_game_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12373,7 +12451,7 @@ func (x *ResistanceEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResistanceEntry.ProtoReflect.Descriptor instead.
 func (*ResistanceEntry) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{140}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *ResistanceEntry) GetDamageType() string {
@@ -12399,7 +12477,7 @@ type ProficienciesRequest struct {
 
 func (x *ProficienciesRequest) Reset() {
 	*x = ProficienciesRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[141]
+	mi := &file_game_v1_game_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12411,7 +12489,7 @@ func (x *ProficienciesRequest) String() string {
 func (*ProficienciesRequest) ProtoMessage() {}
 
 func (x *ProficienciesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[141]
+	mi := &file_game_v1_game_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12424,7 +12502,7 @@ func (x *ProficienciesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProficienciesRequest.ProtoReflect.Descriptor instead.
 func (*ProficienciesRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{141}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{142}
 }
 
 // ProficiencyEntry represents one proficiency category with its rank and bonus.
@@ -12441,7 +12519,7 @@ type ProficiencyEntry struct {
 
 func (x *ProficiencyEntry) Reset() {
 	*x = ProficiencyEntry{}
-	mi := &file_game_v1_game_proto_msgTypes[142]
+	mi := &file_game_v1_game_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12453,7 +12531,7 @@ func (x *ProficiencyEntry) String() string {
 func (*ProficiencyEntry) ProtoMessage() {}
 
 func (x *ProficiencyEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[142]
+	mi := &file_game_v1_game_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12466,7 +12544,7 @@ func (x *ProficiencyEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProficiencyEntry.ProtoReflect.Descriptor instead.
 func (*ProficiencyEntry) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{142}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *ProficiencyEntry) GetCategory() string {
@@ -12514,7 +12592,7 @@ type ProficienciesResponse struct {
 
 func (x *ProficienciesResponse) Reset() {
 	*x = ProficienciesResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[143]
+	mi := &file_game_v1_game_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12526,7 +12604,7 @@ func (x *ProficienciesResponse) String() string {
 func (*ProficienciesResponse) ProtoMessage() {}
 
 func (x *ProficienciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[143]
+	mi := &file_game_v1_game_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12539,7 +12617,7 @@ func (x *ProficienciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProficienciesResponse.ProtoReflect.Descriptor instead.
 func (*ProficienciesResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{143}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *ProficienciesResponse) GetProficiencies() []*ProficiencyEntry {
@@ -12559,7 +12637,7 @@ type LevelUpRequest struct {
 
 func (x *LevelUpRequest) Reset() {
 	*x = LevelUpRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[144]
+	mi := &file_game_v1_game_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12571,7 +12649,7 @@ func (x *LevelUpRequest) String() string {
 func (*LevelUpRequest) ProtoMessage() {}
 
 func (x *LevelUpRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[144]
+	mi := &file_game_v1_game_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12584,7 +12662,7 @@ func (x *LevelUpRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LevelUpRequest.ProtoReflect.Descriptor instead.
 func (*LevelUpRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{144}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *LevelUpRequest) GetAbility() string {
@@ -12604,7 +12682,7 @@ type CombatDefaultRequest struct {
 
 func (x *CombatDefaultRequest) Reset() {
 	*x = CombatDefaultRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[145]
+	mi := &file_game_v1_game_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12616,7 +12694,7 @@ func (x *CombatDefaultRequest) String() string {
 func (*CombatDefaultRequest) ProtoMessage() {}
 
 func (x *CombatDefaultRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[145]
+	mi := &file_game_v1_game_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12629,7 +12707,7 @@ func (x *CombatDefaultRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombatDefaultRequest.ProtoReflect.Descriptor instead.
 func (*CombatDefaultRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{145}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *CombatDefaultRequest) GetAction() string {
@@ -12649,7 +12727,7 @@ type TrainSkillRequest struct {
 
 func (x *TrainSkillRequest) Reset() {
 	*x = TrainSkillRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[146]
+	mi := &file_game_v1_game_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12661,7 +12739,7 @@ func (x *TrainSkillRequest) String() string {
 func (*TrainSkillRequest) ProtoMessage() {}
 
 func (x *TrainSkillRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[146]
+	mi := &file_game_v1_game_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12674,7 +12752,7 @@ func (x *TrainSkillRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TrainSkillRequest.ProtoReflect.Descriptor instead.
 func (*TrainSkillRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{146}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *TrainSkillRequest) GetSkillId() string {
@@ -12696,7 +12774,7 @@ type ActionRequest struct {
 
 func (x *ActionRequest) Reset() {
 	*x = ActionRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[147]
+	mi := &file_game_v1_game_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12708,7 +12786,7 @@ func (x *ActionRequest) String() string {
 func (*ActionRequest) ProtoMessage() {}
 
 func (x *ActionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[147]
+	mi := &file_game_v1_game_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12721,7 +12799,7 @@ func (x *ActionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActionRequest.ProtoReflect.Descriptor instead.
 func (*ActionRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{147}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *ActionRequest) GetName() string {
@@ -12747,7 +12825,7 @@ type RaiseShieldRequest struct {
 
 func (x *RaiseShieldRequest) Reset() {
 	*x = RaiseShieldRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[148]
+	mi := &file_game_v1_game_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12759,7 +12837,7 @@ func (x *RaiseShieldRequest) String() string {
 func (*RaiseShieldRequest) ProtoMessage() {}
 
 func (x *RaiseShieldRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[148]
+	mi := &file_game_v1_game_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12772,7 +12850,7 @@ func (x *RaiseShieldRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RaiseShieldRequest.ProtoReflect.Descriptor instead.
 func (*RaiseShieldRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{148}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{149}
 }
 
 // TakeCoverRequest asks the server to have the player take cover.
@@ -12784,7 +12862,7 @@ type TakeCoverRequest struct {
 
 func (x *TakeCoverRequest) Reset() {
 	*x = TakeCoverRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[149]
+	mi := &file_game_v1_game_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12796,7 +12874,7 @@ func (x *TakeCoverRequest) String() string {
 func (*TakeCoverRequest) ProtoMessage() {}
 
 func (x *TakeCoverRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[149]
+	mi := &file_game_v1_game_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12809,7 +12887,7 @@ func (x *TakeCoverRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TakeCoverRequest.ProtoReflect.Descriptor instead.
 func (*TakeCoverRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{149}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{150}
 }
 
 // FirstAidRequest asks the server to apply first aid to the player.
@@ -12821,7 +12899,7 @@ type FirstAidRequest struct {
 
 func (x *FirstAidRequest) Reset() {
 	*x = FirstAidRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[150]
+	mi := &file_game_v1_game_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12833,7 +12911,7 @@ func (x *FirstAidRequest) String() string {
 func (*FirstAidRequest) ProtoMessage() {}
 
 func (x *FirstAidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[150]
+	mi := &file_game_v1_game_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12846,7 +12924,7 @@ func (x *FirstAidRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirstAidRequest.ProtoReflect.Descriptor instead.
 func (*FirstAidRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{150}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{151}
 }
 
 // FeintRequest asks the server to feint against a target NPC.
@@ -12859,7 +12937,7 @@ type FeintRequest struct {
 
 func (x *FeintRequest) Reset() {
 	*x = FeintRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[151]
+	mi := &file_game_v1_game_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12871,7 +12949,7 @@ func (x *FeintRequest) String() string {
 func (*FeintRequest) ProtoMessage() {}
 
 func (x *FeintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[151]
+	mi := &file_game_v1_game_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12884,7 +12962,7 @@ func (x *FeintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeintRequest.ProtoReflect.Descriptor instead.
 func (*FeintRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{151}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *FeintRequest) GetTarget() string {
@@ -12904,7 +12982,7 @@ type DemoralizeRequest struct {
 
 func (x *DemoralizeRequest) Reset() {
 	*x = DemoralizeRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[152]
+	mi := &file_game_v1_game_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12916,7 +12994,7 @@ func (x *DemoralizeRequest) String() string {
 func (*DemoralizeRequest) ProtoMessage() {}
 
 func (x *DemoralizeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[152]
+	mi := &file_game_v1_game_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12929,7 +13007,7 @@ func (x *DemoralizeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DemoralizeRequest.ProtoReflect.Descriptor instead.
 func (*DemoralizeRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{152}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *DemoralizeRequest) GetTarget() string {
@@ -12949,7 +13027,7 @@ type GrappleRequest struct {
 
 func (x *GrappleRequest) Reset() {
 	*x = GrappleRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[153]
+	mi := &file_game_v1_game_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12961,7 +13039,7 @@ func (x *GrappleRequest) String() string {
 func (*GrappleRequest) ProtoMessage() {}
 
 func (x *GrappleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[153]
+	mi := &file_game_v1_game_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12974,7 +13052,7 @@ func (x *GrappleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GrappleRequest.ProtoReflect.Descriptor instead.
 func (*GrappleRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{153}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *GrappleRequest) GetTarget() string {
@@ -12994,7 +13072,7 @@ type TripRequest struct {
 
 func (x *TripRequest) Reset() {
 	*x = TripRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[154]
+	mi := &file_game_v1_game_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13006,7 +13084,7 @@ func (x *TripRequest) String() string {
 func (*TripRequest) ProtoMessage() {}
 
 func (x *TripRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[154]
+	mi := &file_game_v1_game_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13019,7 +13097,7 @@ func (x *TripRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TripRequest.ProtoReflect.Descriptor instead.
 func (*TripRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{154}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *TripRequest) GetTarget() string {
@@ -13039,7 +13117,7 @@ type DisarmRequest struct {
 
 func (x *DisarmRequest) Reset() {
 	*x = DisarmRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[155]
+	mi := &file_game_v1_game_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13051,7 +13129,7 @@ func (x *DisarmRequest) String() string {
 func (*DisarmRequest) ProtoMessage() {}
 
 func (x *DisarmRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[155]
+	mi := &file_game_v1_game_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13064,7 +13142,7 @@ func (x *DisarmRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DisarmRequest.ProtoReflect.Descriptor instead.
 func (*DisarmRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{155}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *DisarmRequest) GetTarget() string {
@@ -13084,7 +13162,7 @@ type StrideRequest struct {
 
 func (x *StrideRequest) Reset() {
 	*x = StrideRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[156]
+	mi := &file_game_v1_game_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13096,7 +13174,7 @@ func (x *StrideRequest) String() string {
 func (*StrideRequest) ProtoMessage() {}
 
 func (x *StrideRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[156]
+	mi := &file_game_v1_game_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13109,7 +13187,7 @@ func (x *StrideRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StrideRequest.ProtoReflect.Descriptor instead.
 func (*StrideRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{156}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *StrideRequest) GetDirection() string {
@@ -13132,7 +13210,7 @@ type MoveToRequest struct {
 
 func (x *MoveToRequest) Reset() {
 	*x = MoveToRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[157]
+	mi := &file_game_v1_game_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13144,7 +13222,7 @@ func (x *MoveToRequest) String() string {
 func (*MoveToRequest) ProtoMessage() {}
 
 func (x *MoveToRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[157]
+	mi := &file_game_v1_game_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13157,7 +13235,7 @@ func (x *MoveToRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveToRequest.ProtoReflect.Descriptor instead.
 func (*MoveToRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{157}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *MoveToRequest) GetTargetX() int32 {
@@ -13184,7 +13262,7 @@ type ShoveRequest struct {
 
 func (x *ShoveRequest) Reset() {
 	*x = ShoveRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[158]
+	mi := &file_game_v1_game_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13196,7 +13274,7 @@ func (x *ShoveRequest) String() string {
 func (*ShoveRequest) ProtoMessage() {}
 
 func (x *ShoveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[158]
+	mi := &file_game_v1_game_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13209,7 +13287,7 @@ func (x *ShoveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShoveRequest.ProtoReflect.Descriptor instead.
 func (*ShoveRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{158}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *ShoveRequest) GetTarget() string {
@@ -13230,7 +13308,7 @@ type StepRequest struct {
 
 func (x *StepRequest) Reset() {
 	*x = StepRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[159]
+	mi := &file_game_v1_game_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13242,7 +13320,7 @@ func (x *StepRequest) String() string {
 func (*StepRequest) ProtoMessage() {}
 
 func (x *StepRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[159]
+	mi := &file_game_v1_game_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13255,7 +13333,7 @@ func (x *StepRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepRequest.ProtoReflect.Descriptor instead.
 func (*StepRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{159}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *StepRequest) GetDirection() string {
@@ -13274,7 +13352,7 @@ type HideRequest struct {
 
 func (x *HideRequest) Reset() {
 	*x = HideRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[160]
+	mi := &file_game_v1_game_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13286,7 +13364,7 @@ func (x *HideRequest) String() string {
 func (*HideRequest) ProtoMessage() {}
 
 func (x *HideRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[160]
+	mi := &file_game_v1_game_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13299,7 +13377,7 @@ func (x *HideRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HideRequest.ProtoReflect.Descriptor instead.
 func (*HideRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{160}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{161}
 }
 
 // SneakRequest asks the server to attempt to sneak while hidden.
@@ -13311,7 +13389,7 @@ type SneakRequest struct {
 
 func (x *SneakRequest) Reset() {
 	*x = SneakRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[161]
+	mi := &file_game_v1_game_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13323,7 +13401,7 @@ func (x *SneakRequest) String() string {
 func (*SneakRequest) ProtoMessage() {}
 
 func (x *SneakRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[161]
+	mi := &file_game_v1_game_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13336,7 +13414,7 @@ func (x *SneakRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SneakRequest.ProtoReflect.Descriptor instead.
 func (*SneakRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{161}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{162}
 }
 
 // DivertRequest asks the server to create a diversion to hide the player.
@@ -13348,7 +13426,7 @@ type DivertRequest struct {
 
 func (x *DivertRequest) Reset() {
 	*x = DivertRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[162]
+	mi := &file_game_v1_game_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13360,7 +13438,7 @@ func (x *DivertRequest) String() string {
 func (*DivertRequest) ProtoMessage() {}
 
 func (x *DivertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[162]
+	mi := &file_game_v1_game_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13373,7 +13451,7 @@ func (x *DivertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DivertRequest.ProtoReflect.Descriptor instead.
 func (*DivertRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{162}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{163}
 }
 
 // EscapeRequest asks the server to escape from the grabbed condition.
@@ -13385,7 +13463,7 @@ type EscapeRequest struct {
 
 func (x *EscapeRequest) Reset() {
 	*x = EscapeRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[163]
+	mi := &file_game_v1_game_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13397,7 +13475,7 @@ func (x *EscapeRequest) String() string {
 func (*EscapeRequest) ProtoMessage() {}
 
 func (x *EscapeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[163]
+	mi := &file_game_v1_game_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13410,7 +13488,7 @@ func (x *EscapeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscapeRequest.ProtoReflect.Descriptor instead.
 func (*EscapeRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{163}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{164}
 }
 
 // TumbleRequest asks the server to tumble through the target NPC's space (Acrobatics vs Hustle DC).
@@ -13423,7 +13501,7 @@ type TumbleRequest struct {
 
 func (x *TumbleRequest) Reset() {
 	*x = TumbleRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[164]
+	mi := &file_game_v1_game_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13435,7 +13513,7 @@ func (x *TumbleRequest) String() string {
 func (*TumbleRequest) ProtoMessage() {}
 
 func (x *TumbleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[164]
+	mi := &file_game_v1_game_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13448,7 +13526,7 @@ func (x *TumbleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TumbleRequest.ProtoReflect.Descriptor instead.
 func (*TumbleRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{164}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *TumbleRequest) GetTarget() string {
@@ -13467,7 +13545,7 @@ type SeekRequest struct {
 
 func (x *SeekRequest) Reset() {
 	*x = SeekRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[165]
+	mi := &file_game_v1_game_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13479,7 +13557,7 @@ func (x *SeekRequest) String() string {
 func (*SeekRequest) ProtoMessage() {}
 
 func (x *SeekRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[165]
+	mi := &file_game_v1_game_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13492,7 +13570,7 @@ func (x *SeekRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SeekRequest.ProtoReflect.Descriptor instead.
 func (*SeekRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{165}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{166}
 }
 
 // ClimbRequest asks the server to attempt climbing a climbable surface.
@@ -13505,7 +13583,7 @@ type ClimbRequest struct {
 
 func (x *ClimbRequest) Reset() {
 	*x = ClimbRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[166]
+	mi := &file_game_v1_game_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13517,7 +13595,7 @@ func (x *ClimbRequest) String() string {
 func (*ClimbRequest) ProtoMessage() {}
 
 func (x *ClimbRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[166]
+	mi := &file_game_v1_game_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13530,7 +13608,7 @@ func (x *ClimbRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClimbRequest.ProtoReflect.Descriptor instead.
 func (*ClimbRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{166}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{167}
 }
 
 func (x *ClimbRequest) GetDirection() string {
@@ -13550,7 +13628,7 @@ type SwimRequest struct {
 
 func (x *SwimRequest) Reset() {
 	*x = SwimRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[167]
+	mi := &file_game_v1_game_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13562,7 +13640,7 @@ func (x *SwimRequest) String() string {
 func (*SwimRequest) ProtoMessage() {}
 
 func (x *SwimRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[167]
+	mi := &file_game_v1_game_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13575,7 +13653,7 @@ func (x *SwimRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwimRequest.ProtoReflect.Descriptor instead.
 func (*SwimRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{167}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{168}
 }
 
 func (x *SwimRequest) GetDirection() string {
@@ -13594,7 +13672,7 @@ type CalmRequest struct {
 
 func (x *CalmRequest) Reset() {
 	*x = CalmRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[168]
+	mi := &file_game_v1_game_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13606,7 +13684,7 @@ func (x *CalmRequest) String() string {
 func (*CalmRequest) ProtoMessage() {}
 
 func (x *CalmRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[168]
+	mi := &file_game_v1_game_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13619,7 +13697,7 @@ func (x *CalmRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CalmRequest.ProtoReflect.Descriptor instead.
 func (*CalmRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{168}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{169}
 }
 
 // HeroPointRequest asks the server to spend a hero point.
@@ -13632,7 +13710,7 @@ type HeroPointRequest struct {
 
 func (x *HeroPointRequest) Reset() {
 	*x = HeroPointRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[169]
+	mi := &file_game_v1_game_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13644,7 +13722,7 @@ func (x *HeroPointRequest) String() string {
 func (*HeroPointRequest) ProtoMessage() {}
 
 func (x *HeroPointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[169]
+	mi := &file_game_v1_game_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13657,7 +13735,7 @@ func (x *HeroPointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeroPointRequest.ProtoReflect.Descriptor instead.
 func (*HeroPointRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{169}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{170}
 }
 
 func (x *HeroPointRequest) GetSubcommand() string {
@@ -13676,7 +13754,7 @@ type DelayRequest struct {
 
 func (x *DelayRequest) Reset() {
 	*x = DelayRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[170]
+	mi := &file_game_v1_game_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13688,7 +13766,7 @@ func (x *DelayRequest) String() string {
 func (*DelayRequest) ProtoMessage() {}
 
 func (x *DelayRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[170]
+	mi := &file_game_v1_game_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13701,7 +13779,7 @@ func (x *DelayRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DelayRequest.ProtoReflect.Descriptor instead.
 func (*DelayRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{170}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{171}
 }
 
 // JoinRequest asks the server to join active combat in the current room.
@@ -13713,7 +13791,7 @@ type JoinRequest struct {
 
 func (x *JoinRequest) Reset() {
 	*x = JoinRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[171]
+	mi := &file_game_v1_game_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13725,7 +13803,7 @@ func (x *JoinRequest) String() string {
 func (*JoinRequest) ProtoMessage() {}
 
 func (x *JoinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[171]
+	mi := &file_game_v1_game_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13738,7 +13816,7 @@ func (x *JoinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRequest.ProtoReflect.Descriptor instead.
 func (*JoinRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{171}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{172}
 }
 
 // DeclineRequest asks the server to decline joining active combat.
@@ -13750,7 +13828,7 @@ type DeclineRequest struct {
 
 func (x *DeclineRequest) Reset() {
 	*x = DeclineRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[172]
+	mi := &file_game_v1_game_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13762,7 +13840,7 @@ func (x *DeclineRequest) String() string {
 func (*DeclineRequest) ProtoMessage() {}
 
 func (x *DeclineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[172]
+	mi := &file_game_v1_game_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13775,7 +13853,7 @@ func (x *DeclineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeclineRequest.ProtoReflect.Descriptor instead.
 func (*DeclineRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{172}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{173}
 }
 
 // GroupRequest asks the server to create a group or show group info.
@@ -13789,7 +13867,7 @@ type GroupRequest struct {
 
 func (x *GroupRequest) Reset() {
 	*x = GroupRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[173]
+	mi := &file_game_v1_game_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13801,7 +13879,7 @@ func (x *GroupRequest) String() string {
 func (*GroupRequest) ProtoMessage() {}
 
 func (x *GroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[173]
+	mi := &file_game_v1_game_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13814,7 +13892,7 @@ func (x *GroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupRequest.ProtoReflect.Descriptor instead.
 func (*GroupRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{173}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{174}
 }
 
 func (x *GroupRequest) GetArgs() string {
@@ -13834,7 +13912,7 @@ type InviteRequest struct {
 
 func (x *InviteRequest) Reset() {
 	*x = InviteRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[174]
+	mi := &file_game_v1_game_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13846,7 +13924,7 @@ func (x *InviteRequest) String() string {
 func (*InviteRequest) ProtoMessage() {}
 
 func (x *InviteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[174]
+	mi := &file_game_v1_game_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13859,7 +13937,7 @@ func (x *InviteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InviteRequest.ProtoReflect.Descriptor instead.
 func (*InviteRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{174}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{175}
 }
 
 func (x *InviteRequest) GetPlayer() string {
@@ -13878,7 +13956,7 @@ type AcceptGroupRequest struct {
 
 func (x *AcceptGroupRequest) Reset() {
 	*x = AcceptGroupRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[175]
+	mi := &file_game_v1_game_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13890,7 +13968,7 @@ func (x *AcceptGroupRequest) String() string {
 func (*AcceptGroupRequest) ProtoMessage() {}
 
 func (x *AcceptGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[175]
+	mi := &file_game_v1_game_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13903,7 +13981,7 @@ func (x *AcceptGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AcceptGroupRequest.ProtoReflect.Descriptor instead.
 func (*AcceptGroupRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{175}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{176}
 }
 
 // DeclineGroupRequest asks the server to decline a pending group invitation.
@@ -13915,7 +13993,7 @@ type DeclineGroupRequest struct {
 
 func (x *DeclineGroupRequest) Reset() {
 	*x = DeclineGroupRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[176]
+	mi := &file_game_v1_game_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13927,7 +14005,7 @@ func (x *DeclineGroupRequest) String() string {
 func (*DeclineGroupRequest) ProtoMessage() {}
 
 func (x *DeclineGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[176]
+	mi := &file_game_v1_game_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13940,7 +14018,7 @@ func (x *DeclineGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeclineGroupRequest.ProtoReflect.Descriptor instead.
 func (*DeclineGroupRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{176}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{177}
 }
 
 // UngroupRequest asks the server to leave (or disband) the sender's group.
@@ -13952,7 +14030,7 @@ type UngroupRequest struct {
 
 func (x *UngroupRequest) Reset() {
 	*x = UngroupRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[177]
+	mi := &file_game_v1_game_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13964,7 +14042,7 @@ func (x *UngroupRequest) String() string {
 func (*UngroupRequest) ProtoMessage() {}
 
 func (x *UngroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[177]
+	mi := &file_game_v1_game_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13977,7 +14055,7 @@ func (x *UngroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UngroupRequest.ProtoReflect.Descriptor instead.
 func (*UngroupRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{177}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{178}
 }
 
 // KickRequest asks the server to remove a player from the sender's group.
@@ -13990,7 +14068,7 @@ type KickRequest struct {
 
 func (x *KickRequest) Reset() {
 	*x = KickRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[178]
+	mi := &file_game_v1_game_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14002,7 +14080,7 @@ func (x *KickRequest) String() string {
 func (*KickRequest) ProtoMessage() {}
 
 func (x *KickRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[178]
+	mi := &file_game_v1_game_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14015,7 +14093,7 @@ func (x *KickRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KickRequest.ProtoReflect.Descriptor instead.
 func (*KickRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{178}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{179}
 }
 
 func (x *KickRequest) GetPlayer() string {
@@ -14035,7 +14113,7 @@ type MotiveRequest struct {
 
 func (x *MotiveRequest) Reset() {
 	*x = MotiveRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[179]
+	mi := &file_game_v1_game_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14047,7 +14125,7 @@ func (x *MotiveRequest) String() string {
 func (*MotiveRequest) ProtoMessage() {}
 
 func (x *MotiveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[179]
+	mi := &file_game_v1_game_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14060,7 +14138,7 @@ func (x *MotiveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MotiveRequest.ProtoReflect.Descriptor instead.
 func (*MotiveRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{179}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{180}
 }
 
 func (x *MotiveRequest) GetTarget() string {
@@ -14083,7 +14161,7 @@ type GrantRequest struct {
 
 func (x *GrantRequest) Reset() {
 	*x = GrantRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[180]
+	mi := &file_game_v1_game_proto_msgTypes[181]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14095,7 +14173,7 @@ func (x *GrantRequest) String() string {
 func (*GrantRequest) ProtoMessage() {}
 
 func (x *GrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[180]
+	mi := &file_game_v1_game_proto_msgTypes[181]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14108,7 +14186,7 @@ func (x *GrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GrantRequest.ProtoReflect.Descriptor instead.
 func (*GrantRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{180}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{181}
 }
 
 func (x *GrantRequest) GetGrantType() string {
@@ -14150,7 +14228,7 @@ type SpawnNPCRequest struct {
 
 func (x *SpawnNPCRequest) Reset() {
 	*x = SpawnNPCRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[181]
+	mi := &file_game_v1_game_proto_msgTypes[182]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14162,7 +14240,7 @@ func (x *SpawnNPCRequest) String() string {
 func (*SpawnNPCRequest) ProtoMessage() {}
 
 func (x *SpawnNPCRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[181]
+	mi := &file_game_v1_game_proto_msgTypes[182]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14175,7 +14253,7 @@ func (x *SpawnNPCRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpawnNPCRequest.ProtoReflect.Descriptor instead.
 func (*SpawnNPCRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{181}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{182}
 }
 
 func (x *SpawnNPCRequest) GetTemplateId() string {
@@ -14202,7 +14280,7 @@ type KillNPCRequest struct {
 
 func (x *KillNPCRequest) Reset() {
 	*x = KillNPCRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[182]
+	mi := &file_game_v1_game_proto_msgTypes[183]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14214,7 +14292,7 @@ func (x *KillNPCRequest) String() string {
 func (*KillNPCRequest) ProtoMessage() {}
 
 func (x *KillNPCRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[182]
+	mi := &file_game_v1_game_proto_msgTypes[183]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14227,7 +14305,7 @@ func (x *KillNPCRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KillNPCRequest.ProtoReflect.Descriptor instead.
 func (*KillNPCRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{182}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{183}
 }
 
 func (x *KillNPCRequest) GetTemplateId() string {
@@ -14249,7 +14327,7 @@ type AddRoomRequest struct {
 
 func (x *AddRoomRequest) Reset() {
 	*x = AddRoomRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[183]
+	mi := &file_game_v1_game_proto_msgTypes[184]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14261,7 +14339,7 @@ func (x *AddRoomRequest) String() string {
 func (*AddRoomRequest) ProtoMessage() {}
 
 func (x *AddRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[183]
+	mi := &file_game_v1_game_proto_msgTypes[184]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14274,7 +14352,7 @@ func (x *AddRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddRoomRequest.ProtoReflect.Descriptor instead.
 func (*AddRoomRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{183}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{184}
 }
 
 func (x *AddRoomRequest) GetZoneId() string {
@@ -14310,7 +14388,7 @@ type AddLinkRequest struct {
 
 func (x *AddLinkRequest) Reset() {
 	*x = AddLinkRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[184]
+	mi := &file_game_v1_game_proto_msgTypes[185]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14322,7 +14400,7 @@ func (x *AddLinkRequest) String() string {
 func (*AddLinkRequest) ProtoMessage() {}
 
 func (x *AddLinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[184]
+	mi := &file_game_v1_game_proto_msgTypes[185]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14335,7 +14413,7 @@ func (x *AddLinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddLinkRequest.ProtoReflect.Descriptor instead.
 func (*AddLinkRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{184}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{185}
 }
 
 func (x *AddLinkRequest) GetFromRoomId() string {
@@ -14370,7 +14448,7 @@ type RemoveLinkRequest struct {
 
 func (x *RemoveLinkRequest) Reset() {
 	*x = RemoveLinkRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[185]
+	mi := &file_game_v1_game_proto_msgTypes[186]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14382,7 +14460,7 @@ func (x *RemoveLinkRequest) String() string {
 func (*RemoveLinkRequest) ProtoMessage() {}
 
 func (x *RemoveLinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[185]
+	mi := &file_game_v1_game_proto_msgTypes[186]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14395,7 +14473,7 @@ func (x *RemoveLinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveLinkRequest.ProtoReflect.Descriptor instead.
 func (*RemoveLinkRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{185}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{186}
 }
 
 func (x *RemoveLinkRequest) GetRoomId() string {
@@ -14423,7 +14501,7 @@ type SetRoomRequest struct {
 
 func (x *SetRoomRequest) Reset() {
 	*x = SetRoomRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[186]
+	mi := &file_game_v1_game_proto_msgTypes[187]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14435,7 +14513,7 @@ func (x *SetRoomRequest) String() string {
 func (*SetRoomRequest) ProtoMessage() {}
 
 func (x *SetRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[186]
+	mi := &file_game_v1_game_proto_msgTypes[187]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14448,7 +14526,7 @@ func (x *SetRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetRoomRequest.ProtoReflect.Descriptor instead.
 func (*SetRoomRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{186}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{187}
 }
 
 func (x *SetRoomRequest) GetField() string {
@@ -14474,7 +14552,7 @@ type EditorCmdsRequest struct {
 
 func (x *EditorCmdsRequest) Reset() {
 	*x = EditorCmdsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[187]
+	mi := &file_game_v1_game_proto_msgTypes[188]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14486,7 +14564,7 @@ func (x *EditorCmdsRequest) String() string {
 func (*EditorCmdsRequest) ProtoMessage() {}
 
 func (x *EditorCmdsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[187]
+	mi := &file_game_v1_game_proto_msgTypes[188]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14499,7 +14577,7 @@ func (x *EditorCmdsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditorCmdsRequest.ProtoReflect.Descriptor instead.
 func (*EditorCmdsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{187}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{188}
 }
 
 // SpawnCharRequest asks the server to create a test character for the claude_player account.
@@ -14512,7 +14590,7 @@ type SpawnCharRequest struct {
 
 func (x *SpawnCharRequest) Reset() {
 	*x = SpawnCharRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[188]
+	mi := &file_game_v1_game_proto_msgTypes[189]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14524,7 +14602,7 @@ func (x *SpawnCharRequest) String() string {
 func (*SpawnCharRequest) ProtoMessage() {}
 
 func (x *SpawnCharRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[188]
+	mi := &file_game_v1_game_proto_msgTypes[189]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14537,7 +14615,7 @@ func (x *SpawnCharRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpawnCharRequest.ProtoReflect.Descriptor instead.
 func (*SpawnCharRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{188}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{189}
 }
 
 func (x *SpawnCharRequest) GetName() string {
@@ -14557,7 +14635,7 @@ type DeleteCharRequest struct {
 
 func (x *DeleteCharRequest) Reset() {
 	*x = DeleteCharRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[189]
+	mi := &file_game_v1_game_proto_msgTypes[190]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14569,7 +14647,7 @@ func (x *DeleteCharRequest) String() string {
 func (*DeleteCharRequest) ProtoMessage() {}
 
 func (x *DeleteCharRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[189]
+	mi := &file_game_v1_game_proto_msgTypes[190]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14582,7 +14660,7 @@ func (x *DeleteCharRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteCharRequest.ProtoReflect.Descriptor instead.
 func (*DeleteCharRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{189}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{190}
 }
 
 func (x *DeleteCharRequest) GetName() string {
@@ -14601,7 +14679,7 @@ type FactionRequest struct {
 
 func (x *FactionRequest) Reset() {
 	*x = FactionRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[190]
+	mi := &file_game_v1_game_proto_msgTypes[191]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14613,7 +14691,7 @@ func (x *FactionRequest) String() string {
 func (*FactionRequest) ProtoMessage() {}
 
 func (x *FactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[190]
+	mi := &file_game_v1_game_proto_msgTypes[191]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14626,7 +14704,7 @@ func (x *FactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FactionRequest.ProtoReflect.Descriptor instead.
 func (*FactionRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{190}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{191}
 }
 
 // FactionInfoRequest asks the server for public information about a specific faction.
@@ -14639,7 +14717,7 @@ type FactionInfoRequest struct {
 
 func (x *FactionInfoRequest) Reset() {
 	*x = FactionInfoRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[191]
+	mi := &file_game_v1_game_proto_msgTypes[192]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14651,7 +14729,7 @@ func (x *FactionInfoRequest) String() string {
 func (*FactionInfoRequest) ProtoMessage() {}
 
 func (x *FactionInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[191]
+	mi := &file_game_v1_game_proto_msgTypes[192]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14664,7 +14742,7 @@ func (x *FactionInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FactionInfoRequest.ProtoReflect.Descriptor instead.
 func (*FactionInfoRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{191}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{192}
 }
 
 func (x *FactionInfoRequest) GetFactionId() string {
@@ -14683,7 +14761,7 @@ type FactionStandingRequest struct {
 
 func (x *FactionStandingRequest) Reset() {
 	*x = FactionStandingRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[192]
+	mi := &file_game_v1_game_proto_msgTypes[193]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14695,7 +14773,7 @@ func (x *FactionStandingRequest) String() string {
 func (*FactionStandingRequest) ProtoMessage() {}
 
 func (x *FactionStandingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[192]
+	mi := &file_game_v1_game_proto_msgTypes[193]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14708,7 +14786,7 @@ func (x *FactionStandingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FactionStandingRequest.ProtoReflect.Descriptor instead.
 func (*FactionStandingRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{192}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{193}
 }
 
 // ChangeRepRequest asks a Fixer NPC to improve the player's faction standing for currency.
@@ -14721,7 +14799,7 @@ type ChangeRepRequest struct {
 
 func (x *ChangeRepRequest) Reset() {
 	*x = ChangeRepRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[193]
+	mi := &file_game_v1_game_proto_msgTypes[194]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14733,7 +14811,7 @@ func (x *ChangeRepRequest) String() string {
 func (*ChangeRepRequest) ProtoMessage() {}
 
 func (x *ChangeRepRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[193]
+	mi := &file_game_v1_game_proto_msgTypes[194]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14746,7 +14824,7 @@ func (x *ChangeRepRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeRepRequest.ProtoReflect.Descriptor instead.
 func (*ChangeRepRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{193}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{194}
 }
 
 func (x *ChangeRepRequest) GetFactionId() string {
@@ -14766,7 +14844,7 @@ type TabCompleteRequest struct {
 
 func (x *TabCompleteRequest) Reset() {
 	*x = TabCompleteRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[194]
+	mi := &file_game_v1_game_proto_msgTypes[195]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14778,7 +14856,7 @@ func (x *TabCompleteRequest) String() string {
 func (*TabCompleteRequest) ProtoMessage() {}
 
 func (x *TabCompleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[194]
+	mi := &file_game_v1_game_proto_msgTypes[195]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14791,7 +14869,7 @@ func (x *TabCompleteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TabCompleteRequest.ProtoReflect.Descriptor instead.
 func (*TabCompleteRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{194}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{195}
 }
 
 func (x *TabCompleteRequest) GetPrefix() string {
@@ -14811,7 +14889,7 @@ type TabCompleteResponse struct {
 
 func (x *TabCompleteResponse) Reset() {
 	*x = TabCompleteResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[195]
+	mi := &file_game_v1_game_proto_msgTypes[196]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14823,7 +14901,7 @@ func (x *TabCompleteResponse) String() string {
 func (*TabCompleteResponse) ProtoMessage() {}
 
 func (x *TabCompleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[195]
+	mi := &file_game_v1_game_proto_msgTypes[196]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14836,7 +14914,7 @@ func (x *TabCompleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TabCompleteResponse.ProtoReflect.Descriptor instead.
 func (*TabCompleteResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{195}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{196}
 }
 
 func (x *TabCompleteResponse) GetCompletions() []string {
@@ -14856,7 +14934,7 @@ type MaterialsRequest struct {
 
 func (x *MaterialsRequest) Reset() {
 	*x = MaterialsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[196]
+	mi := &file_game_v1_game_proto_msgTypes[197]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14868,7 +14946,7 @@ func (x *MaterialsRequest) String() string {
 func (*MaterialsRequest) ProtoMessage() {}
 
 func (x *MaterialsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[196]
+	mi := &file_game_v1_game_proto_msgTypes[197]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14881,7 +14959,7 @@ func (x *MaterialsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MaterialsRequest.ProtoReflect.Descriptor instead.
 func (*MaterialsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{196}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{197}
 }
 
 func (x *MaterialsRequest) GetCategory() string {
@@ -14901,7 +14979,7 @@ type CraftListRequest struct {
 
 func (x *CraftListRequest) Reset() {
 	*x = CraftListRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[197]
+	mi := &file_game_v1_game_proto_msgTypes[198]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14913,7 +14991,7 @@ func (x *CraftListRequest) String() string {
 func (*CraftListRequest) ProtoMessage() {}
 
 func (x *CraftListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[197]
+	mi := &file_game_v1_game_proto_msgTypes[198]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14926,7 +15004,7 @@ func (x *CraftListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftListRequest.ProtoReflect.Descriptor instead.
 func (*CraftListRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{197}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{198}
 }
 
 func (x *CraftListRequest) GetCategory() string {
@@ -14946,7 +15024,7 @@ type CraftRequest struct {
 
 func (x *CraftRequest) Reset() {
 	*x = CraftRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[198]
+	mi := &file_game_v1_game_proto_msgTypes[199]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14958,7 +15036,7 @@ func (x *CraftRequest) String() string {
 func (*CraftRequest) ProtoMessage() {}
 
 func (x *CraftRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[198]
+	mi := &file_game_v1_game_proto_msgTypes[199]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14971,7 +15049,7 @@ func (x *CraftRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftRequest.ProtoReflect.Descriptor instead.
 func (*CraftRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{198}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{199}
 }
 
 func (x *CraftRequest) GetRecipeId() string {
@@ -14990,7 +15068,7 @@ type CraftConfirmRequest struct {
 
 func (x *CraftConfirmRequest) Reset() {
 	*x = CraftConfirmRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[199]
+	mi := &file_game_v1_game_proto_msgTypes[200]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15002,7 +15080,7 @@ func (x *CraftConfirmRequest) String() string {
 func (*CraftConfirmRequest) ProtoMessage() {}
 
 func (x *CraftConfirmRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[199]
+	mi := &file_game_v1_game_proto_msgTypes[200]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15015,7 +15093,7 @@ func (x *CraftConfirmRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftConfirmRequest.ProtoReflect.Descriptor instead.
 func (*CraftConfirmRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{199}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{200}
 }
 
 // ScavengeRequest asks the server to scavenge the current room for materials.
@@ -15027,7 +15105,7 @@ type ScavengeRequest struct {
 
 func (x *ScavengeRequest) Reset() {
 	*x = ScavengeRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[200]
+	mi := &file_game_v1_game_proto_msgTypes[201]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15039,7 +15117,7 @@ func (x *ScavengeRequest) String() string {
 func (*ScavengeRequest) ProtoMessage() {}
 
 func (x *ScavengeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[200]
+	mi := &file_game_v1_game_proto_msgTypes[201]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15052,7 +15130,7 @@ func (x *ScavengeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScavengeRequest.ProtoReflect.Descriptor instead.
 func (*ScavengeRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{200}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{201}
 }
 
 // AffixRequest asks the server to affix a precious material to an equipped item.
@@ -15066,7 +15144,7 @@ type AffixRequest struct {
 
 func (x *AffixRequest) Reset() {
 	*x = AffixRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[201]
+	mi := &file_game_v1_game_proto_msgTypes[202]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15078,7 +15156,7 @@ func (x *AffixRequest) String() string {
 func (*AffixRequest) ProtoMessage() {}
 
 func (x *AffixRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[201]
+	mi := &file_game_v1_game_proto_msgTypes[202]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15091,7 +15169,7 @@ func (x *AffixRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AffixRequest.ProtoReflect.Descriptor instead.
 func (*AffixRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{201}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{202}
 }
 
 func (x *AffixRequest) GetMaterialQuery() string {
@@ -15124,7 +15202,7 @@ type ExploreRequest struct {
 
 func (x *ExploreRequest) Reset() {
 	*x = ExploreRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[202]
+	mi := &file_game_v1_game_proto_msgTypes[203]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15136,7 +15214,7 @@ func (x *ExploreRequest) String() string {
 func (*ExploreRequest) ProtoMessage() {}
 
 func (x *ExploreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[202]
+	mi := &file_game_v1_game_proto_msgTypes[203]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15149,7 +15227,7 @@ func (x *ExploreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploreRequest.ProtoReflect.Descriptor instead.
 func (*ExploreRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{202}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{203}
 }
 
 func (x *ExploreRequest) GetMode() string {
@@ -15175,7 +15253,7 @@ type RefocusRequest struct {
 
 func (x *RefocusRequest) Reset() {
 	*x = RefocusRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[203]
+	mi := &file_game_v1_game_proto_msgTypes[204]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15187,7 +15265,7 @@ func (x *RefocusRequest) String() string {
 func (*RefocusRequest) ProtoMessage() {}
 
 func (x *RefocusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[203]
+	mi := &file_game_v1_game_proto_msgTypes[204]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15200,7 +15278,7 @@ func (x *RefocusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefocusRequest.ProtoReflect.Descriptor instead.
 func (*RefocusRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{203}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{204}
 }
 
 // SeduceRequest asks the server to attempt to seduce a target NPC (REQ-ZN-7).
@@ -15213,7 +15291,7 @@ type SeduceRequest struct {
 
 func (x *SeduceRequest) Reset() {
 	*x = SeduceRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[204]
+	mi := &file_game_v1_game_proto_msgTypes[205]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15225,7 +15303,7 @@ func (x *SeduceRequest) String() string {
 func (*SeduceRequest) ProtoMessage() {}
 
 func (x *SeduceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[204]
+	mi := &file_game_v1_game_proto_msgTypes[205]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15238,7 +15316,7 @@ func (x *SeduceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SeduceRequest.ProtoReflect.Descriptor instead.
 func (*SeduceRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{204}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{205}
 }
 
 func (x *SeduceRequest) GetTarget() string {
@@ -15273,7 +15351,7 @@ type HotbarSlot struct {
 
 func (x *HotbarSlot) Reset() {
 	*x = HotbarSlot{}
-	mi := &file_game_v1_game_proto_msgTypes[205]
+	mi := &file_game_v1_game_proto_msgTypes[206]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15285,7 +15363,7 @@ func (x *HotbarSlot) String() string {
 func (*HotbarSlot) ProtoMessage() {}
 
 func (x *HotbarSlot) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[205]
+	mi := &file_game_v1_game_proto_msgTypes[206]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15298,7 +15376,7 @@ func (x *HotbarSlot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HotbarSlot.ProtoReflect.Descriptor instead.
 func (*HotbarSlot) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{205}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{206}
 }
 
 func (x *HotbarSlot) GetKind() string {
@@ -15381,7 +15459,7 @@ type HotbarRequest struct {
 
 func (x *HotbarRequest) Reset() {
 	*x = HotbarRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[206]
+	mi := &file_game_v1_game_proto_msgTypes[207]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15393,7 +15471,7 @@ func (x *HotbarRequest) String() string {
 func (*HotbarRequest) ProtoMessage() {}
 
 func (x *HotbarRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[206]
+	mi := &file_game_v1_game_proto_msgTypes[207]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15406,7 +15484,7 @@ func (x *HotbarRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HotbarRequest.ProtoReflect.Descriptor instead.
 func (*HotbarRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{206}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{207}
 }
 
 func (x *HotbarRequest) GetAction() string {
@@ -15466,7 +15544,7 @@ type HotbarUpdateEvent struct {
 
 func (x *HotbarUpdateEvent) Reset() {
 	*x = HotbarUpdateEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[207]
+	mi := &file_game_v1_game_proto_msgTypes[208]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15478,7 +15556,7 @@ func (x *HotbarUpdateEvent) String() string {
 func (*HotbarUpdateEvent) ProtoMessage() {}
 
 func (x *HotbarUpdateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[207]
+	mi := &file_game_v1_game_proto_msgTypes[208]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15491,7 +15569,7 @@ func (x *HotbarUpdateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HotbarUpdateEvent.ProtoReflect.Descriptor instead.
 func (*HotbarUpdateEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{207}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{208}
 }
 
 func (x *HotbarUpdateEvent) GetSlots() []*HotbarSlot {
@@ -15533,7 +15611,7 @@ type DowntimeRequest struct {
 
 func (x *DowntimeRequest) Reset() {
 	*x = DowntimeRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[208]
+	mi := &file_game_v1_game_proto_msgTypes[209]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15545,7 +15623,7 @@ func (x *DowntimeRequest) String() string {
 func (*DowntimeRequest) ProtoMessage() {}
 
 func (x *DowntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[208]
+	mi := &file_game_v1_game_proto_msgTypes[209]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15558,7 +15636,7 @@ func (x *DowntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DowntimeRequest.ProtoReflect.Descriptor instead.
 func (*DowntimeRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{208}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{209}
 }
 
 func (x *DowntimeRequest) GetSubcommand() string {
@@ -15586,7 +15664,7 @@ type QuestRequest struct {
 
 func (x *QuestRequest) Reset() {
 	*x = QuestRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[209]
+	mi := &file_game_v1_game_proto_msgTypes[210]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15598,7 +15676,7 @@ func (x *QuestRequest) String() string {
 func (*QuestRequest) ProtoMessage() {}
 
 func (x *QuestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[209]
+	mi := &file_game_v1_game_proto_msgTypes[210]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15611,7 +15689,7 @@ func (x *QuestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuestRequest.ProtoReflect.Descriptor instead.
 func (*QuestRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{209}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{210}
 }
 
 func (x *QuestRequest) GetArgs() string {
@@ -15632,7 +15710,7 @@ type MaterialLoss struct {
 
 func (x *MaterialLoss) Reset() {
 	*x = MaterialLoss{}
-	mi := &file_game_v1_game_proto_msgTypes[210]
+	mi := &file_game_v1_game_proto_msgTypes[211]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15644,7 +15722,7 @@ func (x *MaterialLoss) String() string {
 func (*MaterialLoss) ProtoMessage() {}
 
 func (x *MaterialLoss) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[210]
+	mi := &file_game_v1_game_proto_msgTypes[211]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15657,7 +15735,7 @@ func (x *MaterialLoss) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MaterialLoss.ProtoReflect.Descriptor instead.
 func (*MaterialLoss) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{210}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{211}
 }
 
 func (x *MaterialLoss) GetMaterialId() string {
@@ -15687,7 +15765,7 @@ type CraftResultEvent struct {
 
 func (x *CraftResultEvent) Reset() {
 	*x = CraftResultEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[211]
+	mi := &file_game_v1_game_proto_msgTypes[212]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15699,7 +15777,7 @@ func (x *CraftResultEvent) String() string {
 func (*CraftResultEvent) ProtoMessage() {}
 
 func (x *CraftResultEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[211]
+	mi := &file_game_v1_game_proto_msgTypes[212]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15712,7 +15790,7 @@ func (x *CraftResultEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftResultEvent.ProtoReflect.Descriptor instead.
 func (*CraftResultEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{211}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{212}
 }
 
 func (x *CraftResultEvent) GetSuccess() bool {
@@ -15754,7 +15832,7 @@ type UncurseRequest struct {
 
 func (x *UncurseRequest) Reset() {
 	*x = UncurseRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[212]
+	mi := &file_game_v1_game_proto_msgTypes[213]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15766,7 +15844,7 @@ func (x *UncurseRequest) String() string {
 func (*UncurseRequest) ProtoMessage() {}
 
 func (x *UncurseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[212]
+	mi := &file_game_v1_game_proto_msgTypes[213]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15779,7 +15857,7 @@ func (x *UncurseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UncurseRequest.ProtoReflect.Descriptor instead.
 func (*UncurseRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{212}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{213}
 }
 
 func (x *UncurseRequest) GetNpcName() string {
@@ -15808,7 +15886,7 @@ type WeatherEvent struct {
 
 func (x *WeatherEvent) Reset() {
 	*x = WeatherEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[213]
+	mi := &file_game_v1_game_proto_msgTypes[214]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15820,7 +15898,7 @@ func (x *WeatherEvent) String() string {
 func (*WeatherEvent) ProtoMessage() {}
 
 func (x *WeatherEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[213]
+	mi := &file_game_v1_game_proto_msgTypes[214]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15833,7 +15911,7 @@ func (x *WeatherEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WeatherEvent.ProtoReflect.Descriptor instead.
 func (*WeatherEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{213}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{214}
 }
 
 func (x *WeatherEvent) GetWeatherName() string {
@@ -15866,7 +15944,7 @@ type JobGrantsRequest struct {
 
 func (x *JobGrantsRequest) Reset() {
 	*x = JobGrantsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[214]
+	mi := &file_game_v1_game_proto_msgTypes[215]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15878,7 +15956,7 @@ func (x *JobGrantsRequest) String() string {
 func (*JobGrantsRequest) ProtoMessage() {}
 
 func (x *JobGrantsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[214]
+	mi := &file_game_v1_game_proto_msgTypes[215]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15891,7 +15969,7 @@ func (x *JobGrantsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobGrantsRequest.ProtoReflect.Descriptor instead.
 func (*JobGrantsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{214}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{215}
 }
 
 // JobFeatGrant describes a single feat granted by the job at a specific level.
@@ -15906,7 +15984,7 @@ type JobFeatGrant struct {
 
 func (x *JobFeatGrant) Reset() {
 	*x = JobFeatGrant{}
-	mi := &file_game_v1_game_proto_msgTypes[215]
+	mi := &file_game_v1_game_proto_msgTypes[216]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15918,7 +15996,7 @@ func (x *JobFeatGrant) String() string {
 func (*JobFeatGrant) ProtoMessage() {}
 
 func (x *JobFeatGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[215]
+	mi := &file_game_v1_game_proto_msgTypes[216]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15931,7 +16009,7 @@ func (x *JobFeatGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobFeatGrant.ProtoReflect.Descriptor instead.
 func (*JobFeatGrant) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{215}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{216}
 }
 
 func (x *JobFeatGrant) GetGrantLevel() int32 {
@@ -15969,7 +16047,7 @@ type JobTechGrant struct {
 
 func (x *JobTechGrant) Reset() {
 	*x = JobTechGrant{}
-	mi := &file_game_v1_game_proto_msgTypes[216]
+	mi := &file_game_v1_game_proto_msgTypes[217]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15981,7 +16059,7 @@ func (x *JobTechGrant) String() string {
 func (*JobTechGrant) ProtoMessage() {}
 
 func (x *JobTechGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[216]
+	mi := &file_game_v1_game_proto_msgTypes[217]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15994,7 +16072,7 @@ func (x *JobTechGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobTechGrant.ProtoReflect.Descriptor instead.
 func (*JobTechGrant) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{216}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{217}
 }
 
 func (x *JobTechGrant) GetGrantLevel() int32 {
@@ -16044,7 +16122,7 @@ type JobGrantsResponse struct {
 
 func (x *JobGrantsResponse) Reset() {
 	*x = JobGrantsResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[217]
+	mi := &file_game_v1_game_proto_msgTypes[218]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16056,7 +16134,7 @@ func (x *JobGrantsResponse) String() string {
 func (*JobGrantsResponse) ProtoMessage() {}
 
 func (x *JobGrantsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[217]
+	mi := &file_game_v1_game_proto_msgTypes[218]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16069,7 +16147,7 @@ func (x *JobGrantsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobGrantsResponse.ProtoReflect.Descriptor instead.
 func (*JobGrantsResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{217}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{218}
 }
 
 func (x *JobGrantsResponse) GetFeatGrants() []*JobFeatGrant {
@@ -16108,7 +16186,7 @@ type FeatOption struct {
 
 func (x *FeatOption) Reset() {
 	*x = FeatOption{}
-	mi := &file_game_v1_game_proto_msgTypes[218]
+	mi := &file_game_v1_game_proto_msgTypes[219]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16120,7 +16198,7 @@ func (x *FeatOption) String() string {
 func (*FeatOption) ProtoMessage() {}
 
 func (x *FeatOption) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[218]
+	mi := &file_game_v1_game_proto_msgTypes[219]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16133,7 +16211,7 @@ func (x *FeatOption) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeatOption.ProtoReflect.Descriptor instead.
 func (*FeatOption) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{218}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{219}
 }
 
 func (x *FeatOption) GetFeatId() string {
@@ -16178,7 +16256,7 @@ type PendingFeatChoice struct {
 
 func (x *PendingFeatChoice) Reset() {
 	*x = PendingFeatChoice{}
-	mi := &file_game_v1_game_proto_msgTypes[219]
+	mi := &file_game_v1_game_proto_msgTypes[220]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16190,7 +16268,7 @@ func (x *PendingFeatChoice) String() string {
 func (*PendingFeatChoice) ProtoMessage() {}
 
 func (x *PendingFeatChoice) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[219]
+	mi := &file_game_v1_game_proto_msgTypes[220]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16203,7 +16281,7 @@ func (x *PendingFeatChoice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PendingFeatChoice.ProtoReflect.Descriptor instead.
 func (*PendingFeatChoice) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{219}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{220}
 }
 
 func (x *PendingFeatChoice) GetGrantLevel() int32 {
@@ -16240,7 +16318,7 @@ type ChooseFeatRequest struct {
 
 func (x *ChooseFeatRequest) Reset() {
 	*x = ChooseFeatRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[220]
+	mi := &file_game_v1_game_proto_msgTypes[221]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16252,7 +16330,7 @@ func (x *ChooseFeatRequest) String() string {
 func (*ChooseFeatRequest) ProtoMessage() {}
 
 func (x *ChooseFeatRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[220]
+	mi := &file_game_v1_game_proto_msgTypes[221]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16265,7 +16343,7 @@ func (x *ChooseFeatRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChooseFeatRequest.ProtoReflect.Descriptor instead.
 func (*ChooseFeatRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{220}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{221}
 }
 
 func (x *ChooseFeatRequest) GetGrantLevel() int32 {
@@ -16298,7 +16376,7 @@ type AdminSessionInfo struct {
 
 func (x *AdminSessionInfo) Reset() {
 	*x = AdminSessionInfo{}
-	mi := &file_game_v1_game_proto_msgTypes[221]
+	mi := &file_game_v1_game_proto_msgTypes[222]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16310,7 +16388,7 @@ func (x *AdminSessionInfo) String() string {
 func (*AdminSessionInfo) ProtoMessage() {}
 
 func (x *AdminSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[221]
+	mi := &file_game_v1_game_proto_msgTypes[222]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16323,7 +16401,7 @@ func (x *AdminSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminSessionInfo.ProtoReflect.Descriptor instead.
 func (*AdminSessionInfo) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{221}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{222}
 }
 
 func (x *AdminSessionInfo) GetCharId() int64 {
@@ -16383,7 +16461,7 @@ type AdminListSessionsRequest struct {
 
 func (x *AdminListSessionsRequest) Reset() {
 	*x = AdminListSessionsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[222]
+	mi := &file_game_v1_game_proto_msgTypes[223]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16395,7 +16473,7 @@ func (x *AdminListSessionsRequest) String() string {
 func (*AdminListSessionsRequest) ProtoMessage() {}
 
 func (x *AdminListSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[222]
+	mi := &file_game_v1_game_proto_msgTypes[223]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16408,7 +16486,7 @@ func (x *AdminListSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListSessionsRequest.ProtoReflect.Descriptor instead.
 func (*AdminListSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{222}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{223}
 }
 
 type AdminListSessionsResponse struct {
@@ -16420,7 +16498,7 @@ type AdminListSessionsResponse struct {
 
 func (x *AdminListSessionsResponse) Reset() {
 	*x = AdminListSessionsResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[223]
+	mi := &file_game_v1_game_proto_msgTypes[224]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16432,7 +16510,7 @@ func (x *AdminListSessionsResponse) String() string {
 func (*AdminListSessionsResponse) ProtoMessage() {}
 
 func (x *AdminListSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[223]
+	mi := &file_game_v1_game_proto_msgTypes[224]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16445,7 +16523,7 @@ func (x *AdminListSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListSessionsResponse.ProtoReflect.Descriptor instead.
 func (*AdminListSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{223}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{224}
 }
 
 func (x *AdminListSessionsResponse) GetSessions() []*AdminSessionInfo {
@@ -16464,7 +16542,7 @@ type AdminKickRequest struct {
 
 func (x *AdminKickRequest) Reset() {
 	*x = AdminKickRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[224]
+	mi := &file_game_v1_game_proto_msgTypes[225]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16476,7 +16554,7 @@ func (x *AdminKickRequest) String() string {
 func (*AdminKickRequest) ProtoMessage() {}
 
 func (x *AdminKickRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[224]
+	mi := &file_game_v1_game_proto_msgTypes[225]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16489,7 +16567,7 @@ func (x *AdminKickRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminKickRequest.ProtoReflect.Descriptor instead.
 func (*AdminKickRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{224}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{225}
 }
 
 func (x *AdminKickRequest) GetCharId() int64 {
@@ -16507,7 +16585,7 @@ type AdminKickResponse struct {
 
 func (x *AdminKickResponse) Reset() {
 	*x = AdminKickResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[225]
+	mi := &file_game_v1_game_proto_msgTypes[226]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16519,7 +16597,7 @@ func (x *AdminKickResponse) String() string {
 func (*AdminKickResponse) ProtoMessage() {}
 
 func (x *AdminKickResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[225]
+	mi := &file_game_v1_game_proto_msgTypes[226]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16532,7 +16610,7 @@ func (x *AdminKickResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminKickResponse.ProtoReflect.Descriptor instead.
 func (*AdminKickResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{225}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{226}
 }
 
 type AdminMessageRequest struct {
@@ -16545,7 +16623,7 @@ type AdminMessageRequest struct {
 
 func (x *AdminMessageRequest) Reset() {
 	*x = AdminMessageRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[226]
+	mi := &file_game_v1_game_proto_msgTypes[227]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16557,7 +16635,7 @@ func (x *AdminMessageRequest) String() string {
 func (*AdminMessageRequest) ProtoMessage() {}
 
 func (x *AdminMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[226]
+	mi := &file_game_v1_game_proto_msgTypes[227]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16570,7 +16648,7 @@ func (x *AdminMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminMessageRequest.ProtoReflect.Descriptor instead.
 func (*AdminMessageRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{226}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{227}
 }
 
 func (x *AdminMessageRequest) GetCharId() int64 {
@@ -16595,7 +16673,7 @@ type AdminMessageResponse struct {
 
 func (x *AdminMessageResponse) Reset() {
 	*x = AdminMessageResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[227]
+	mi := &file_game_v1_game_proto_msgTypes[228]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16607,7 +16685,7 @@ func (x *AdminMessageResponse) String() string {
 func (*AdminMessageResponse) ProtoMessage() {}
 
 func (x *AdminMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[227]
+	mi := &file_game_v1_game_proto_msgTypes[228]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16620,7 +16698,7 @@ func (x *AdminMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminMessageResponse.ProtoReflect.Descriptor instead.
 func (*AdminMessageResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{227}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{228}
 }
 
 type AdminTeleportRequest struct {
@@ -16633,7 +16711,7 @@ type AdminTeleportRequest struct {
 
 func (x *AdminTeleportRequest) Reset() {
 	*x = AdminTeleportRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[228]
+	mi := &file_game_v1_game_proto_msgTypes[229]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16645,7 +16723,7 @@ func (x *AdminTeleportRequest) String() string {
 func (*AdminTeleportRequest) ProtoMessage() {}
 
 func (x *AdminTeleportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[228]
+	mi := &file_game_v1_game_proto_msgTypes[229]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16658,7 +16736,7 @@ func (x *AdminTeleportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminTeleportRequest.ProtoReflect.Descriptor instead.
 func (*AdminTeleportRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{228}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{229}
 }
 
 func (x *AdminTeleportRequest) GetCharId() int64 {
@@ -16683,7 +16761,7 @@ type AdminTeleportResponse struct {
 
 func (x *AdminTeleportResponse) Reset() {
 	*x = AdminTeleportResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[229]
+	mi := &file_game_v1_game_proto_msgTypes[230]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16695,7 +16773,7 @@ func (x *AdminTeleportResponse) String() string {
 func (*AdminTeleportResponse) ProtoMessage() {}
 
 func (x *AdminTeleportResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[229]
+	mi := &file_game_v1_game_proto_msgTypes[230]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16708,7 +16786,7 @@ func (x *AdminTeleportResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminTeleportResponse.ProtoReflect.Descriptor instead.
 func (*AdminTeleportResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{229}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{230}
 }
 
 type AdminListZonesRequest struct {
@@ -16719,7 +16797,7 @@ type AdminListZonesRequest struct {
 
 func (x *AdminListZonesRequest) Reset() {
 	*x = AdminListZonesRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[230]
+	mi := &file_game_v1_game_proto_msgTypes[231]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16731,7 +16809,7 @@ func (x *AdminListZonesRequest) String() string {
 func (*AdminListZonesRequest) ProtoMessage() {}
 
 func (x *AdminListZonesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[230]
+	mi := &file_game_v1_game_proto_msgTypes[231]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16744,7 +16822,7 @@ func (x *AdminListZonesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListZonesRequest.ProtoReflect.Descriptor instead.
 func (*AdminListZonesRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{230}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{231}
 }
 
 type AdminZoneSummary struct {
@@ -16759,7 +16837,7 @@ type AdminZoneSummary struct {
 
 func (x *AdminZoneSummary) Reset() {
 	*x = AdminZoneSummary{}
-	mi := &file_game_v1_game_proto_msgTypes[231]
+	mi := &file_game_v1_game_proto_msgTypes[232]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16771,7 +16849,7 @@ func (x *AdminZoneSummary) String() string {
 func (*AdminZoneSummary) ProtoMessage() {}
 
 func (x *AdminZoneSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[231]
+	mi := &file_game_v1_game_proto_msgTypes[232]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16784,7 +16862,7 @@ func (x *AdminZoneSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminZoneSummary.ProtoReflect.Descriptor instead.
 func (*AdminZoneSummary) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{231}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{232}
 }
 
 func (x *AdminZoneSummary) GetId() string {
@@ -16824,7 +16902,7 @@ type AdminListZonesResponse struct {
 
 func (x *AdminListZonesResponse) Reset() {
 	*x = AdminListZonesResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[232]
+	mi := &file_game_v1_game_proto_msgTypes[233]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16836,7 +16914,7 @@ func (x *AdminListZonesResponse) String() string {
 func (*AdminListZonesResponse) ProtoMessage() {}
 
 func (x *AdminListZonesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[232]
+	mi := &file_game_v1_game_proto_msgTypes[233]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16849,7 +16927,7 @@ func (x *AdminListZonesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListZonesResponse.ProtoReflect.Descriptor instead.
 func (*AdminListZonesResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{232}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{233}
 }
 
 func (x *AdminListZonesResponse) GetZones() []*AdminZoneSummary {
@@ -16868,7 +16946,7 @@ type AdminListRoomsRequest struct {
 
 func (x *AdminListRoomsRequest) Reset() {
 	*x = AdminListRoomsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[233]
+	mi := &file_game_v1_game_proto_msgTypes[234]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16880,7 +16958,7 @@ func (x *AdminListRoomsRequest) String() string {
 func (*AdminListRoomsRequest) ProtoMessage() {}
 
 func (x *AdminListRoomsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[233]
+	mi := &file_game_v1_game_proto_msgTypes[234]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16893,7 +16971,7 @@ func (x *AdminListRoomsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListRoomsRequest.ProtoReflect.Descriptor instead.
 func (*AdminListRoomsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{233}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{234}
 }
 
 func (x *AdminListRoomsRequest) GetZoneId() string {
@@ -16915,7 +16993,7 @@ type AdminRoomSummary struct {
 
 func (x *AdminRoomSummary) Reset() {
 	*x = AdminRoomSummary{}
-	mi := &file_game_v1_game_proto_msgTypes[234]
+	mi := &file_game_v1_game_proto_msgTypes[235]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16927,7 +17005,7 @@ func (x *AdminRoomSummary) String() string {
 func (*AdminRoomSummary) ProtoMessage() {}
 
 func (x *AdminRoomSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[234]
+	mi := &file_game_v1_game_proto_msgTypes[235]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16940,7 +17018,7 @@ func (x *AdminRoomSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminRoomSummary.ProtoReflect.Descriptor instead.
 func (*AdminRoomSummary) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{234}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{235}
 }
 
 func (x *AdminRoomSummary) GetId() string {
@@ -16980,7 +17058,7 @@ type AdminListRoomsResponse struct {
 
 func (x *AdminListRoomsResponse) Reset() {
 	*x = AdminListRoomsResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[235]
+	mi := &file_game_v1_game_proto_msgTypes[236]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16992,7 +17070,7 @@ func (x *AdminListRoomsResponse) String() string {
 func (*AdminListRoomsResponse) ProtoMessage() {}
 
 func (x *AdminListRoomsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[235]
+	mi := &file_game_v1_game_proto_msgTypes[236]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17005,7 +17083,7 @@ func (x *AdminListRoomsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListRoomsResponse.ProtoReflect.Descriptor instead.
 func (*AdminListRoomsResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{235}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{236}
 }
 
 func (x *AdminListRoomsResponse) GetRooms() []*AdminRoomSummary {
@@ -17027,7 +17105,7 @@ type AdminUpdateRoomRequest struct {
 
 func (x *AdminUpdateRoomRequest) Reset() {
 	*x = AdminUpdateRoomRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[236]
+	mi := &file_game_v1_game_proto_msgTypes[237]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17039,7 +17117,7 @@ func (x *AdminUpdateRoomRequest) String() string {
 func (*AdminUpdateRoomRequest) ProtoMessage() {}
 
 func (x *AdminUpdateRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[236]
+	mi := &file_game_v1_game_proto_msgTypes[237]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17052,7 +17130,7 @@ func (x *AdminUpdateRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminUpdateRoomRequest.ProtoReflect.Descriptor instead.
 func (*AdminUpdateRoomRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{236}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{237}
 }
 
 func (x *AdminUpdateRoomRequest) GetRoomId() string {
@@ -17091,7 +17169,7 @@ type AdminUpdateRoomResponse struct {
 
 func (x *AdminUpdateRoomResponse) Reset() {
 	*x = AdminUpdateRoomResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[237]
+	mi := &file_game_v1_game_proto_msgTypes[238]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17103,7 +17181,7 @@ func (x *AdminUpdateRoomResponse) String() string {
 func (*AdminUpdateRoomResponse) ProtoMessage() {}
 
 func (x *AdminUpdateRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[237]
+	mi := &file_game_v1_game_proto_msgTypes[238]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17116,7 +17194,7 @@ func (x *AdminUpdateRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminUpdateRoomResponse.ProtoReflect.Descriptor instead.
 func (*AdminUpdateRoomResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{237}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{238}
 }
 
 type AdminListNPCTemplatesRequest struct {
@@ -17127,7 +17205,7 @@ type AdminListNPCTemplatesRequest struct {
 
 func (x *AdminListNPCTemplatesRequest) Reset() {
 	*x = AdminListNPCTemplatesRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[238]
+	mi := &file_game_v1_game_proto_msgTypes[239]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17139,7 +17217,7 @@ func (x *AdminListNPCTemplatesRequest) String() string {
 func (*AdminListNPCTemplatesRequest) ProtoMessage() {}
 
 func (x *AdminListNPCTemplatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[238]
+	mi := &file_game_v1_game_proto_msgTypes[239]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17152,7 +17230,7 @@ func (x *AdminListNPCTemplatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListNPCTemplatesRequest.ProtoReflect.Descriptor instead.
 func (*AdminListNPCTemplatesRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{238}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{239}
 }
 
 type AdminNPCTemplateSummary struct {
@@ -17167,7 +17245,7 @@ type AdminNPCTemplateSummary struct {
 
 func (x *AdminNPCTemplateSummary) Reset() {
 	*x = AdminNPCTemplateSummary{}
-	mi := &file_game_v1_game_proto_msgTypes[239]
+	mi := &file_game_v1_game_proto_msgTypes[240]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17179,7 +17257,7 @@ func (x *AdminNPCTemplateSummary) String() string {
 func (*AdminNPCTemplateSummary) ProtoMessage() {}
 
 func (x *AdminNPCTemplateSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[239]
+	mi := &file_game_v1_game_proto_msgTypes[240]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17192,7 +17270,7 @@ func (x *AdminNPCTemplateSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminNPCTemplateSummary.ProtoReflect.Descriptor instead.
 func (*AdminNPCTemplateSummary) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{239}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{240}
 }
 
 func (x *AdminNPCTemplateSummary) GetId() string {
@@ -17232,7 +17310,7 @@ type AdminListNPCTemplatesResponse struct {
 
 func (x *AdminListNPCTemplatesResponse) Reset() {
 	*x = AdminListNPCTemplatesResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[240]
+	mi := &file_game_v1_game_proto_msgTypes[241]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17244,7 +17322,7 @@ func (x *AdminListNPCTemplatesResponse) String() string {
 func (*AdminListNPCTemplatesResponse) ProtoMessage() {}
 
 func (x *AdminListNPCTemplatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[240]
+	mi := &file_game_v1_game_proto_msgTypes[241]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17257,7 +17335,7 @@ func (x *AdminListNPCTemplatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListNPCTemplatesResponse.ProtoReflect.Descriptor instead.
 func (*AdminListNPCTemplatesResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{240}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{241}
 }
 
 func (x *AdminListNPCTemplatesResponse) GetTemplates() []*AdminNPCTemplateSummary {
@@ -17278,7 +17356,7 @@ type AdminSpawnNPCRequest struct {
 
 func (x *AdminSpawnNPCRequest) Reset() {
 	*x = AdminSpawnNPCRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[241]
+	mi := &file_game_v1_game_proto_msgTypes[242]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17290,7 +17368,7 @@ func (x *AdminSpawnNPCRequest) String() string {
 func (*AdminSpawnNPCRequest) ProtoMessage() {}
 
 func (x *AdminSpawnNPCRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[241]
+	mi := &file_game_v1_game_proto_msgTypes[242]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17303,7 +17381,7 @@ func (x *AdminSpawnNPCRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminSpawnNPCRequest.ProtoReflect.Descriptor instead.
 func (*AdminSpawnNPCRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{241}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{242}
 }
 
 func (x *AdminSpawnNPCRequest) GetTemplateId() string {
@@ -17336,7 +17414,7 @@ type AdminSpawnNPCResponse struct {
 
 func (x *AdminSpawnNPCResponse) Reset() {
 	*x = AdminSpawnNPCResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[242]
+	mi := &file_game_v1_game_proto_msgTypes[243]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17348,7 +17426,7 @@ func (x *AdminSpawnNPCResponse) String() string {
 func (*AdminSpawnNPCResponse) ProtoMessage() {}
 
 func (x *AdminSpawnNPCResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[242]
+	mi := &file_game_v1_game_proto_msgTypes[243]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17361,7 +17439,7 @@ func (x *AdminSpawnNPCResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminSpawnNPCResponse.ProtoReflect.Descriptor instead.
 func (*AdminSpawnNPCResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{242}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{243}
 }
 
 func (x *AdminSpawnNPCResponse) GetSpawnedCount() int32 {
@@ -17382,7 +17460,7 @@ type AdminGiveItemRequest struct {
 
 func (x *AdminGiveItemRequest) Reset() {
 	*x = AdminGiveItemRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[243]
+	mi := &file_game_v1_game_proto_msgTypes[244]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17394,7 +17472,7 @@ func (x *AdminGiveItemRequest) String() string {
 func (*AdminGiveItemRequest) ProtoMessage() {}
 
 func (x *AdminGiveItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[243]
+	mi := &file_game_v1_game_proto_msgTypes[244]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17407,7 +17485,7 @@ func (x *AdminGiveItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminGiveItemRequest.ProtoReflect.Descriptor instead.
 func (*AdminGiveItemRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{243}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{244}
 }
 
 func (x *AdminGiveItemRequest) GetCharId() int64 {
@@ -17439,7 +17517,7 @@ type AdminGiveItemResponse struct {
 
 func (x *AdminGiveItemResponse) Reset() {
 	*x = AdminGiveItemResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[244]
+	mi := &file_game_v1_game_proto_msgTypes[245]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17451,7 +17529,7 @@ func (x *AdminGiveItemResponse) String() string {
 func (*AdminGiveItemResponse) ProtoMessage() {}
 
 func (x *AdminGiveItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[244]
+	mi := &file_game_v1_game_proto_msgTypes[245]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17464,7 +17542,7 @@ func (x *AdminGiveItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminGiveItemResponse.ProtoReflect.Descriptor instead.
 func (*AdminGiveItemResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{244}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{245}
 }
 
 type AdminGiveCurrencyRequest struct {
@@ -17477,7 +17555,7 @@ type AdminGiveCurrencyRequest struct {
 
 func (x *AdminGiveCurrencyRequest) Reset() {
 	*x = AdminGiveCurrencyRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[245]
+	mi := &file_game_v1_game_proto_msgTypes[246]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17489,7 +17567,7 @@ func (x *AdminGiveCurrencyRequest) String() string {
 func (*AdminGiveCurrencyRequest) ProtoMessage() {}
 
 func (x *AdminGiveCurrencyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[245]
+	mi := &file_game_v1_game_proto_msgTypes[246]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17502,7 +17580,7 @@ func (x *AdminGiveCurrencyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminGiveCurrencyRequest.ProtoReflect.Descriptor instead.
 func (*AdminGiveCurrencyRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{245}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{246}
 }
 
 func (x *AdminGiveCurrencyRequest) GetCharId() int64 {
@@ -17527,7 +17605,7 @@ type AdminGiveCurrencyResponse struct {
 
 func (x *AdminGiveCurrencyResponse) Reset() {
 	*x = AdminGiveCurrencyResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[246]
+	mi := &file_game_v1_game_proto_msgTypes[247]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17539,7 +17617,7 @@ func (x *AdminGiveCurrencyResponse) String() string {
 func (*AdminGiveCurrencyResponse) ProtoMessage() {}
 
 func (x *AdminGiveCurrencyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[246]
+	mi := &file_game_v1_game_proto_msgTypes[247]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17552,7 +17630,7 @@ func (x *AdminGiveCurrencyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminGiveCurrencyResponse.ProtoReflect.Descriptor instead.
 func (*AdminGiveCurrencyResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{246}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{247}
 }
 
 var File_game_v1_game_proto protoreflect.FileDescriptor
@@ -18271,7 +18349,13 @@ const file_game_v1_game_proto_rawDesc = "" +
 	"\x01x\x18\x03 \x01(\x05R\x01x\x12\f\n" +
 	"\x01y\x18\x04 \x01(\x05R\x01y\x12\x1d\n" +
 	"\n" +
-	"cover_tier\x18\x05 \x01(\tR\tcoverTier\"\xdd\x02\n" +
+	"cover_tier\x18\x05 \x01(\tR\tcoverTier\"^\n" +
+	"\vTerrainCell\x12\f\n" +
+	"\x01x\x18\x01 \x01(\x05R\x01x\x12\f\n" +
+	"\x01y\x18\x02 \x01(\x05R\x01y\x12\x12\n" +
+	"\x04type\x18\x03 \x01(\tR\x04type\x12\x1f\n" +
+	"\vhazard_name\x18\x04 \x01(\tR\n" +
+	"hazardName\"\x8d\x03\n" +
 	"\x0fRoundStartEvent\x12\x14\n" +
 	"\x05round\x18\x01 \x01(\x05R\x05round\x12(\n" +
 	"\x10actions_per_turn\x18\x02 \x01(\x05R\x0eactionsPerTurn\x12\x1f\n" +
@@ -18284,7 +18368,8 @@ const file_game_v1_game_proto_rawDesc = "" +
 	"grid_width\x18\x06 \x01(\x05R\tgridWidth\x12\x1f\n" +
 	"\vgrid_height\x18\a \x01(\x05R\n" +
 	"gridHeight\x12A\n" +
-	"\rcover_objects\x18\b \x03(\v2\x1c.game.v1.CoverObjectPositionR\fcoverObjects\"%\n" +
+	"\rcover_objects\x18\b \x03(\v2\x1c.game.v1.CoverObjectPositionR\fcoverObjects\x12.\n" +
+	"\aterrain\x18\t \x03(\v2\x14.game.v1.TerrainCellR\aterrain\"%\n" +
 	"\rRoundEndEvent\x12\x14\n" +
 	"\x05round\x18\x01 \x01(\x05R\x05round\"\xdf\x01\n" +
 	"\rAPUpdateEvent\x12\x12\n" +
@@ -18856,7 +18941,7 @@ func file_game_v1_game_proto_rawDescGZIP() []byte {
 }
 
 var file_game_v1_game_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_game_v1_game_proto_msgTypes = make([]protoimpl.MessageInfo, 251)
+var file_game_v1_game_proto_msgTypes = make([]protoimpl.MessageInfo, 252)
 var file_game_v1_game_proto_goTypes = []any{
 	(MessageType)(0),                      // 0: game.v1.MessageType
 	(RoomEventType)(0),                    // 1: game.v1.RoomEventType
@@ -18975,144 +19060,145 @@ var file_game_v1_game_proto_goTypes = []any{
 	(*InventoryView)(nil),                 // 114: game.v1.InventoryView
 	(*CombatantPosition)(nil),             // 115: game.v1.CombatantPosition
 	(*CoverObjectPosition)(nil),           // 116: game.v1.CoverObjectPosition
-	(*RoundStartEvent)(nil),               // 117: game.v1.RoundStartEvent
-	(*RoundEndEvent)(nil),                 // 118: game.v1.RoundEndEvent
-	(*APUpdateEvent)(nil),                 // 119: game.v1.APUpdateEvent
-	(*CombatEvent)(nil),                   // 120: game.v1.CombatEvent
-	(*StatusRequest)(nil),                 // 121: game.v1.StatusRequest
-	(*ConditionEvent)(nil),                // 122: game.v1.ConditionEvent
-	(*WearRequest)(nil),                   // 123: game.v1.WearRequest
-	(*RemoveArmorRequest)(nil),            // 124: game.v1.RemoveArmorRequest
-	(*ConditionInfo)(nil),                 // 125: game.v1.ConditionInfo
-	(*CharacterSheetRequest)(nil),         // 126: game.v1.CharacterSheetRequest
-	(*ArchetypeSelectionRequest)(nil),     // 127: game.v1.ArchetypeSelectionRequest
-	(*FeatsRequest)(nil),                  // 128: game.v1.FeatsRequest
-	(*FeatEntry)(nil),                     // 129: game.v1.FeatEntry
-	(*FeatsResponse)(nil),                 // 130: game.v1.FeatsResponse
-	(*ClassFeaturesRequest)(nil),          // 131: game.v1.ClassFeaturesRequest
-	(*ClassFeatureEntry)(nil),             // 132: game.v1.ClassFeatureEntry
-	(*ClassFeaturesResponse)(nil),         // 133: game.v1.ClassFeaturesResponse
-	(*InteractRequest)(nil),               // 134: game.v1.InteractRequest
-	(*InteractResponse)(nil),              // 135: game.v1.InteractResponse
-	(*UseRequest)(nil),                    // 136: game.v1.UseRequest
-	(*UseResponse)(nil),                   // 137: game.v1.UseResponse
-	(*PreparedSlotView)(nil),              // 138: game.v1.PreparedSlotView
-	(*HardwiredSlotView)(nil),             // 139: game.v1.HardwiredSlotView
-	(*SpontaneousKnownEntry)(nil),         // 140: game.v1.SpontaneousKnownEntry
-	(*CharacterSheetView)(nil),            // 141: game.v1.CharacterSheetView
-	(*InnateSlotView)(nil),                // 142: game.v1.InnateSlotView
-	(*SpontaneousUsePoolView)(nil),        // 143: game.v1.SpontaneousUsePoolView
-	(*ResistanceEntry)(nil),               // 144: game.v1.ResistanceEntry
-	(*ProficienciesRequest)(nil),          // 145: game.v1.ProficienciesRequest
-	(*ProficiencyEntry)(nil),              // 146: game.v1.ProficiencyEntry
-	(*ProficienciesResponse)(nil),         // 147: game.v1.ProficienciesResponse
-	(*LevelUpRequest)(nil),                // 148: game.v1.LevelUpRequest
-	(*CombatDefaultRequest)(nil),          // 149: game.v1.CombatDefaultRequest
-	(*TrainSkillRequest)(nil),             // 150: game.v1.TrainSkillRequest
-	(*ActionRequest)(nil),                 // 151: game.v1.ActionRequest
-	(*RaiseShieldRequest)(nil),            // 152: game.v1.RaiseShieldRequest
-	(*TakeCoverRequest)(nil),              // 153: game.v1.TakeCoverRequest
-	(*FirstAidRequest)(nil),               // 154: game.v1.FirstAidRequest
-	(*FeintRequest)(nil),                  // 155: game.v1.FeintRequest
-	(*DemoralizeRequest)(nil),             // 156: game.v1.DemoralizeRequest
-	(*GrappleRequest)(nil),                // 157: game.v1.GrappleRequest
-	(*TripRequest)(nil),                   // 158: game.v1.TripRequest
-	(*DisarmRequest)(nil),                 // 159: game.v1.DisarmRequest
-	(*StrideRequest)(nil),                 // 160: game.v1.StrideRequest
-	(*MoveToRequest)(nil),                 // 161: game.v1.MoveToRequest
-	(*ShoveRequest)(nil),                  // 162: game.v1.ShoveRequest
-	(*StepRequest)(nil),                   // 163: game.v1.StepRequest
-	(*HideRequest)(nil),                   // 164: game.v1.HideRequest
-	(*SneakRequest)(nil),                  // 165: game.v1.SneakRequest
-	(*DivertRequest)(nil),                 // 166: game.v1.DivertRequest
-	(*EscapeRequest)(nil),                 // 167: game.v1.EscapeRequest
-	(*TumbleRequest)(nil),                 // 168: game.v1.TumbleRequest
-	(*SeekRequest)(nil),                   // 169: game.v1.SeekRequest
-	(*ClimbRequest)(nil),                  // 170: game.v1.ClimbRequest
-	(*SwimRequest)(nil),                   // 171: game.v1.SwimRequest
-	(*CalmRequest)(nil),                   // 172: game.v1.CalmRequest
-	(*HeroPointRequest)(nil),              // 173: game.v1.HeroPointRequest
-	(*DelayRequest)(nil),                  // 174: game.v1.DelayRequest
-	(*JoinRequest)(nil),                   // 175: game.v1.JoinRequest
-	(*DeclineRequest)(nil),                // 176: game.v1.DeclineRequest
-	(*GroupRequest)(nil),                  // 177: game.v1.GroupRequest
-	(*InviteRequest)(nil),                 // 178: game.v1.InviteRequest
-	(*AcceptGroupRequest)(nil),            // 179: game.v1.AcceptGroupRequest
-	(*DeclineGroupRequest)(nil),           // 180: game.v1.DeclineGroupRequest
-	(*UngroupRequest)(nil),                // 181: game.v1.UngroupRequest
-	(*KickRequest)(nil),                   // 182: game.v1.KickRequest
-	(*MotiveRequest)(nil),                 // 183: game.v1.MotiveRequest
-	(*GrantRequest)(nil),                  // 184: game.v1.GrantRequest
-	(*SpawnNPCRequest)(nil),               // 185: game.v1.SpawnNPCRequest
-	(*KillNPCRequest)(nil),                // 186: game.v1.KillNPCRequest
-	(*AddRoomRequest)(nil),                // 187: game.v1.AddRoomRequest
-	(*AddLinkRequest)(nil),                // 188: game.v1.AddLinkRequest
-	(*RemoveLinkRequest)(nil),             // 189: game.v1.RemoveLinkRequest
-	(*SetRoomRequest)(nil),                // 190: game.v1.SetRoomRequest
-	(*EditorCmdsRequest)(nil),             // 191: game.v1.EditorCmdsRequest
-	(*SpawnCharRequest)(nil),              // 192: game.v1.SpawnCharRequest
-	(*DeleteCharRequest)(nil),             // 193: game.v1.DeleteCharRequest
-	(*FactionRequest)(nil),                // 194: game.v1.FactionRequest
-	(*FactionInfoRequest)(nil),            // 195: game.v1.FactionInfoRequest
-	(*FactionStandingRequest)(nil),        // 196: game.v1.FactionStandingRequest
-	(*ChangeRepRequest)(nil),              // 197: game.v1.ChangeRepRequest
-	(*TabCompleteRequest)(nil),            // 198: game.v1.TabCompleteRequest
-	(*TabCompleteResponse)(nil),           // 199: game.v1.TabCompleteResponse
-	(*MaterialsRequest)(nil),              // 200: game.v1.MaterialsRequest
-	(*CraftListRequest)(nil),              // 201: game.v1.CraftListRequest
-	(*CraftRequest)(nil),                  // 202: game.v1.CraftRequest
-	(*CraftConfirmRequest)(nil),           // 203: game.v1.CraftConfirmRequest
-	(*ScavengeRequest)(nil),               // 204: game.v1.ScavengeRequest
-	(*AffixRequest)(nil),                  // 205: game.v1.AffixRequest
-	(*ExploreRequest)(nil),                // 206: game.v1.ExploreRequest
-	(*RefocusRequest)(nil),                // 207: game.v1.RefocusRequest
-	(*SeduceRequest)(nil),                 // 208: game.v1.SeduceRequest
-	(*HotbarSlot)(nil),                    // 209: game.v1.HotbarSlot
-	(*HotbarRequest)(nil),                 // 210: game.v1.HotbarRequest
-	(*HotbarUpdateEvent)(nil),             // 211: game.v1.HotbarUpdateEvent
-	(*DowntimeRequest)(nil),               // 212: game.v1.DowntimeRequest
-	(*QuestRequest)(nil),                  // 213: game.v1.QuestRequest
-	(*MaterialLoss)(nil),                  // 214: game.v1.MaterialLoss
-	(*CraftResultEvent)(nil),              // 215: game.v1.CraftResultEvent
-	(*UncurseRequest)(nil),                // 216: game.v1.UncurseRequest
-	(*WeatherEvent)(nil),                  // 217: game.v1.WeatherEvent
-	(*JobGrantsRequest)(nil),              // 218: game.v1.JobGrantsRequest
-	(*JobFeatGrant)(nil),                  // 219: game.v1.JobFeatGrant
-	(*JobTechGrant)(nil),                  // 220: game.v1.JobTechGrant
-	(*JobGrantsResponse)(nil),             // 221: game.v1.JobGrantsResponse
-	(*FeatOption)(nil),                    // 222: game.v1.FeatOption
-	(*PendingFeatChoice)(nil),             // 223: game.v1.PendingFeatChoice
-	(*ChooseFeatRequest)(nil),             // 224: game.v1.ChooseFeatRequest
-	(*AdminSessionInfo)(nil),              // 225: game.v1.AdminSessionInfo
-	(*AdminListSessionsRequest)(nil),      // 226: game.v1.AdminListSessionsRequest
-	(*AdminListSessionsResponse)(nil),     // 227: game.v1.AdminListSessionsResponse
-	(*AdminKickRequest)(nil),              // 228: game.v1.AdminKickRequest
-	(*AdminKickResponse)(nil),             // 229: game.v1.AdminKickResponse
-	(*AdminMessageRequest)(nil),           // 230: game.v1.AdminMessageRequest
-	(*AdminMessageResponse)(nil),          // 231: game.v1.AdminMessageResponse
-	(*AdminTeleportRequest)(nil),          // 232: game.v1.AdminTeleportRequest
-	(*AdminTeleportResponse)(nil),         // 233: game.v1.AdminTeleportResponse
-	(*AdminListZonesRequest)(nil),         // 234: game.v1.AdminListZonesRequest
-	(*AdminZoneSummary)(nil),              // 235: game.v1.AdminZoneSummary
-	(*AdminListZonesResponse)(nil),        // 236: game.v1.AdminListZonesResponse
-	(*AdminListRoomsRequest)(nil),         // 237: game.v1.AdminListRoomsRequest
-	(*AdminRoomSummary)(nil),              // 238: game.v1.AdminRoomSummary
-	(*AdminListRoomsResponse)(nil),        // 239: game.v1.AdminListRoomsResponse
-	(*AdminUpdateRoomRequest)(nil),        // 240: game.v1.AdminUpdateRoomRequest
-	(*AdminUpdateRoomResponse)(nil),       // 241: game.v1.AdminUpdateRoomResponse
-	(*AdminListNPCTemplatesRequest)(nil),  // 242: game.v1.AdminListNPCTemplatesRequest
-	(*AdminNPCTemplateSummary)(nil),       // 243: game.v1.AdminNPCTemplateSummary
-	(*AdminListNPCTemplatesResponse)(nil), // 244: game.v1.AdminListNPCTemplatesResponse
-	(*AdminSpawnNPCRequest)(nil),          // 245: game.v1.AdminSpawnNPCRequest
-	(*AdminSpawnNPCResponse)(nil),         // 246: game.v1.AdminSpawnNPCResponse
-	(*AdminGiveItemRequest)(nil),          // 247: game.v1.AdminGiveItemRequest
-	(*AdminGiveItemResponse)(nil),         // 248: game.v1.AdminGiveItemResponse
-	(*AdminGiveCurrencyRequest)(nil),      // 249: game.v1.AdminGiveCurrencyRequest
-	(*AdminGiveCurrencyResponse)(nil),     // 250: game.v1.AdminGiveCurrencyResponse
-	nil,                                   // 251: game.v1.FixerView.BribeCostsEntry
-	nil,                                   // 252: game.v1.CharacterSheetView.ArmorEntry
-	nil,                                   // 253: game.v1.CharacterSheetView.AccessoriesEntry
-	nil,                                   // 254: game.v1.CharacterSheetView.ArmorCategoriesEntry
+	(*TerrainCell)(nil),                   // 117: game.v1.TerrainCell
+	(*RoundStartEvent)(nil),               // 118: game.v1.RoundStartEvent
+	(*RoundEndEvent)(nil),                 // 119: game.v1.RoundEndEvent
+	(*APUpdateEvent)(nil),                 // 120: game.v1.APUpdateEvent
+	(*CombatEvent)(nil),                   // 121: game.v1.CombatEvent
+	(*StatusRequest)(nil),                 // 122: game.v1.StatusRequest
+	(*ConditionEvent)(nil),                // 123: game.v1.ConditionEvent
+	(*WearRequest)(nil),                   // 124: game.v1.WearRequest
+	(*RemoveArmorRequest)(nil),            // 125: game.v1.RemoveArmorRequest
+	(*ConditionInfo)(nil),                 // 126: game.v1.ConditionInfo
+	(*CharacterSheetRequest)(nil),         // 127: game.v1.CharacterSheetRequest
+	(*ArchetypeSelectionRequest)(nil),     // 128: game.v1.ArchetypeSelectionRequest
+	(*FeatsRequest)(nil),                  // 129: game.v1.FeatsRequest
+	(*FeatEntry)(nil),                     // 130: game.v1.FeatEntry
+	(*FeatsResponse)(nil),                 // 131: game.v1.FeatsResponse
+	(*ClassFeaturesRequest)(nil),          // 132: game.v1.ClassFeaturesRequest
+	(*ClassFeatureEntry)(nil),             // 133: game.v1.ClassFeatureEntry
+	(*ClassFeaturesResponse)(nil),         // 134: game.v1.ClassFeaturesResponse
+	(*InteractRequest)(nil),               // 135: game.v1.InteractRequest
+	(*InteractResponse)(nil),              // 136: game.v1.InteractResponse
+	(*UseRequest)(nil),                    // 137: game.v1.UseRequest
+	(*UseResponse)(nil),                   // 138: game.v1.UseResponse
+	(*PreparedSlotView)(nil),              // 139: game.v1.PreparedSlotView
+	(*HardwiredSlotView)(nil),             // 140: game.v1.HardwiredSlotView
+	(*SpontaneousKnownEntry)(nil),         // 141: game.v1.SpontaneousKnownEntry
+	(*CharacterSheetView)(nil),            // 142: game.v1.CharacterSheetView
+	(*InnateSlotView)(nil),                // 143: game.v1.InnateSlotView
+	(*SpontaneousUsePoolView)(nil),        // 144: game.v1.SpontaneousUsePoolView
+	(*ResistanceEntry)(nil),               // 145: game.v1.ResistanceEntry
+	(*ProficienciesRequest)(nil),          // 146: game.v1.ProficienciesRequest
+	(*ProficiencyEntry)(nil),              // 147: game.v1.ProficiencyEntry
+	(*ProficienciesResponse)(nil),         // 148: game.v1.ProficienciesResponse
+	(*LevelUpRequest)(nil),                // 149: game.v1.LevelUpRequest
+	(*CombatDefaultRequest)(nil),          // 150: game.v1.CombatDefaultRequest
+	(*TrainSkillRequest)(nil),             // 151: game.v1.TrainSkillRequest
+	(*ActionRequest)(nil),                 // 152: game.v1.ActionRequest
+	(*RaiseShieldRequest)(nil),            // 153: game.v1.RaiseShieldRequest
+	(*TakeCoverRequest)(nil),              // 154: game.v1.TakeCoverRequest
+	(*FirstAidRequest)(nil),               // 155: game.v1.FirstAidRequest
+	(*FeintRequest)(nil),                  // 156: game.v1.FeintRequest
+	(*DemoralizeRequest)(nil),             // 157: game.v1.DemoralizeRequest
+	(*GrappleRequest)(nil),                // 158: game.v1.GrappleRequest
+	(*TripRequest)(nil),                   // 159: game.v1.TripRequest
+	(*DisarmRequest)(nil),                 // 160: game.v1.DisarmRequest
+	(*StrideRequest)(nil),                 // 161: game.v1.StrideRequest
+	(*MoveToRequest)(nil),                 // 162: game.v1.MoveToRequest
+	(*ShoveRequest)(nil),                  // 163: game.v1.ShoveRequest
+	(*StepRequest)(nil),                   // 164: game.v1.StepRequest
+	(*HideRequest)(nil),                   // 165: game.v1.HideRequest
+	(*SneakRequest)(nil),                  // 166: game.v1.SneakRequest
+	(*DivertRequest)(nil),                 // 167: game.v1.DivertRequest
+	(*EscapeRequest)(nil),                 // 168: game.v1.EscapeRequest
+	(*TumbleRequest)(nil),                 // 169: game.v1.TumbleRequest
+	(*SeekRequest)(nil),                   // 170: game.v1.SeekRequest
+	(*ClimbRequest)(nil),                  // 171: game.v1.ClimbRequest
+	(*SwimRequest)(nil),                   // 172: game.v1.SwimRequest
+	(*CalmRequest)(nil),                   // 173: game.v1.CalmRequest
+	(*HeroPointRequest)(nil),              // 174: game.v1.HeroPointRequest
+	(*DelayRequest)(nil),                  // 175: game.v1.DelayRequest
+	(*JoinRequest)(nil),                   // 176: game.v1.JoinRequest
+	(*DeclineRequest)(nil),                // 177: game.v1.DeclineRequest
+	(*GroupRequest)(nil),                  // 178: game.v1.GroupRequest
+	(*InviteRequest)(nil),                 // 179: game.v1.InviteRequest
+	(*AcceptGroupRequest)(nil),            // 180: game.v1.AcceptGroupRequest
+	(*DeclineGroupRequest)(nil),           // 181: game.v1.DeclineGroupRequest
+	(*UngroupRequest)(nil),                // 182: game.v1.UngroupRequest
+	(*KickRequest)(nil),                   // 183: game.v1.KickRequest
+	(*MotiveRequest)(nil),                 // 184: game.v1.MotiveRequest
+	(*GrantRequest)(nil),                  // 185: game.v1.GrantRequest
+	(*SpawnNPCRequest)(nil),               // 186: game.v1.SpawnNPCRequest
+	(*KillNPCRequest)(nil),                // 187: game.v1.KillNPCRequest
+	(*AddRoomRequest)(nil),                // 188: game.v1.AddRoomRequest
+	(*AddLinkRequest)(nil),                // 189: game.v1.AddLinkRequest
+	(*RemoveLinkRequest)(nil),             // 190: game.v1.RemoveLinkRequest
+	(*SetRoomRequest)(nil),                // 191: game.v1.SetRoomRequest
+	(*EditorCmdsRequest)(nil),             // 192: game.v1.EditorCmdsRequest
+	(*SpawnCharRequest)(nil),              // 193: game.v1.SpawnCharRequest
+	(*DeleteCharRequest)(nil),             // 194: game.v1.DeleteCharRequest
+	(*FactionRequest)(nil),                // 195: game.v1.FactionRequest
+	(*FactionInfoRequest)(nil),            // 196: game.v1.FactionInfoRequest
+	(*FactionStandingRequest)(nil),        // 197: game.v1.FactionStandingRequest
+	(*ChangeRepRequest)(nil),              // 198: game.v1.ChangeRepRequest
+	(*TabCompleteRequest)(nil),            // 199: game.v1.TabCompleteRequest
+	(*TabCompleteResponse)(nil),           // 200: game.v1.TabCompleteResponse
+	(*MaterialsRequest)(nil),              // 201: game.v1.MaterialsRequest
+	(*CraftListRequest)(nil),              // 202: game.v1.CraftListRequest
+	(*CraftRequest)(nil),                  // 203: game.v1.CraftRequest
+	(*CraftConfirmRequest)(nil),           // 204: game.v1.CraftConfirmRequest
+	(*ScavengeRequest)(nil),               // 205: game.v1.ScavengeRequest
+	(*AffixRequest)(nil),                  // 206: game.v1.AffixRequest
+	(*ExploreRequest)(nil),                // 207: game.v1.ExploreRequest
+	(*RefocusRequest)(nil),                // 208: game.v1.RefocusRequest
+	(*SeduceRequest)(nil),                 // 209: game.v1.SeduceRequest
+	(*HotbarSlot)(nil),                    // 210: game.v1.HotbarSlot
+	(*HotbarRequest)(nil),                 // 211: game.v1.HotbarRequest
+	(*HotbarUpdateEvent)(nil),             // 212: game.v1.HotbarUpdateEvent
+	(*DowntimeRequest)(nil),               // 213: game.v1.DowntimeRequest
+	(*QuestRequest)(nil),                  // 214: game.v1.QuestRequest
+	(*MaterialLoss)(nil),                  // 215: game.v1.MaterialLoss
+	(*CraftResultEvent)(nil),              // 216: game.v1.CraftResultEvent
+	(*UncurseRequest)(nil),                // 217: game.v1.UncurseRequest
+	(*WeatherEvent)(nil),                  // 218: game.v1.WeatherEvent
+	(*JobGrantsRequest)(nil),              // 219: game.v1.JobGrantsRequest
+	(*JobFeatGrant)(nil),                  // 220: game.v1.JobFeatGrant
+	(*JobTechGrant)(nil),                  // 221: game.v1.JobTechGrant
+	(*JobGrantsResponse)(nil),             // 222: game.v1.JobGrantsResponse
+	(*FeatOption)(nil),                    // 223: game.v1.FeatOption
+	(*PendingFeatChoice)(nil),             // 224: game.v1.PendingFeatChoice
+	(*ChooseFeatRequest)(nil),             // 225: game.v1.ChooseFeatRequest
+	(*AdminSessionInfo)(nil),              // 226: game.v1.AdminSessionInfo
+	(*AdminListSessionsRequest)(nil),      // 227: game.v1.AdminListSessionsRequest
+	(*AdminListSessionsResponse)(nil),     // 228: game.v1.AdminListSessionsResponse
+	(*AdminKickRequest)(nil),              // 229: game.v1.AdminKickRequest
+	(*AdminKickResponse)(nil),             // 230: game.v1.AdminKickResponse
+	(*AdminMessageRequest)(nil),           // 231: game.v1.AdminMessageRequest
+	(*AdminMessageResponse)(nil),          // 232: game.v1.AdminMessageResponse
+	(*AdminTeleportRequest)(nil),          // 233: game.v1.AdminTeleportRequest
+	(*AdminTeleportResponse)(nil),         // 234: game.v1.AdminTeleportResponse
+	(*AdminListZonesRequest)(nil),         // 235: game.v1.AdminListZonesRequest
+	(*AdminZoneSummary)(nil),              // 236: game.v1.AdminZoneSummary
+	(*AdminListZonesResponse)(nil),        // 237: game.v1.AdminListZonesResponse
+	(*AdminListRoomsRequest)(nil),         // 238: game.v1.AdminListRoomsRequest
+	(*AdminRoomSummary)(nil),              // 239: game.v1.AdminRoomSummary
+	(*AdminListRoomsResponse)(nil),        // 240: game.v1.AdminListRoomsResponse
+	(*AdminUpdateRoomRequest)(nil),        // 241: game.v1.AdminUpdateRoomRequest
+	(*AdminUpdateRoomResponse)(nil),       // 242: game.v1.AdminUpdateRoomResponse
+	(*AdminListNPCTemplatesRequest)(nil),  // 243: game.v1.AdminListNPCTemplatesRequest
+	(*AdminNPCTemplateSummary)(nil),       // 244: game.v1.AdminNPCTemplateSummary
+	(*AdminListNPCTemplatesResponse)(nil), // 245: game.v1.AdminListNPCTemplatesResponse
+	(*AdminSpawnNPCRequest)(nil),          // 246: game.v1.AdminSpawnNPCRequest
+	(*AdminSpawnNPCResponse)(nil),         // 247: game.v1.AdminSpawnNPCResponse
+	(*AdminGiveItemRequest)(nil),          // 248: game.v1.AdminGiveItemRequest
+	(*AdminGiveItemResponse)(nil),         // 249: game.v1.AdminGiveItemResponse
+	(*AdminGiveCurrencyRequest)(nil),      // 250: game.v1.AdminGiveCurrencyRequest
+	(*AdminGiveCurrencyResponse)(nil),     // 251: game.v1.AdminGiveCurrencyResponse
+	nil,                                   // 252: game.v1.FixerView.BribeCostsEntry
+	nil,                                   // 253: game.v1.CharacterSheetView.ArmorEntry
+	nil,                                   // 254: game.v1.CharacterSheetView.AccessoriesEntry
+	nil,                                   // 255: game.v1.CharacterSheetView.ArmorCategoriesEntry
 }
 var file_game_v1_game_proto_depIdxs = []int32{
 	41,  // 0: game.v1.ClientMessage.join_world:type_name -> game.v1.JoinWorldRequest
@@ -19128,7 +19214,7 @@ var file_game_v1_game_proto_depIdxs = []int32{
 	72,  // 10: game.v1.ClientMessage.flee:type_name -> game.v1.FleeRequest
 	73,  // 11: game.v1.ClientMessage.pass:type_name -> game.v1.PassRequest
 	74,  // 12: game.v1.ClientMessage.strike:type_name -> game.v1.StrikeRequest
-	121, // 13: game.v1.ClientMessage.status:type_name -> game.v1.StatusRequest
+	122, // 13: game.v1.ClientMessage.status:type_name -> game.v1.StatusRequest
 	75,  // 14: game.v1.ClientMessage.equip:type_name -> game.v1.EquipRequest
 	76,  // 15: game.v1.ClientMessage.reload:type_name -> game.v1.ReloadRequest
 	77,  // 16: game.v1.ClientMessage.fire_burst:type_name -> game.v1.FireBurstRequest
@@ -19144,56 +19230,56 @@ var file_game_v1_game_proto_depIdxs = []int32{
 	94,  // 26: game.v1.ClientMessage.unequip:type_name -> game.v1.UnequipRequest
 	95,  // 27: game.v1.ClientMessage.equipment:type_name -> game.v1.EquipmentRequest
 	49,  // 28: game.v1.ClientMessage.switch_character:type_name -> game.v1.SwitchCharacterRequest
-	123, // 29: game.v1.ClientMessage.wear:type_name -> game.v1.WearRequest
-	124, // 30: game.v1.ClientMessage.remove_armor:type_name -> game.v1.RemoveArmorRequest
-	126, // 31: game.v1.ClientMessage.char_sheet:type_name -> game.v1.CharacterSheetRequest
-	127, // 32: game.v1.ClientMessage.archetype_selection:type_name -> game.v1.ArchetypeSelectionRequest
+	124, // 29: game.v1.ClientMessage.wear:type_name -> game.v1.WearRequest
+	125, // 30: game.v1.ClientMessage.remove_armor:type_name -> game.v1.RemoveArmorRequest
+	127, // 31: game.v1.ClientMessage.char_sheet:type_name -> game.v1.CharacterSheetRequest
+	128, // 32: game.v1.ClientMessage.archetype_selection:type_name -> game.v1.ArchetypeSelectionRequest
 	100, // 33: game.v1.ClientMessage.use_equipment:type_name -> game.v1.UseEquipmentRequest
 	112, // 34: game.v1.ClientMessage.room_equip:type_name -> game.v1.RoomEquipRequest
 	101, // 35: game.v1.ClientMessage.map:type_name -> game.v1.MapRequest
 	109, // 36: game.v1.ClientMessage.skills_request:type_name -> game.v1.SkillsRequest
-	128, // 37: game.v1.ClientMessage.feats_request:type_name -> game.v1.FeatsRequest
-	134, // 38: game.v1.ClientMessage.interact_request:type_name -> game.v1.InteractRequest
-	136, // 39: game.v1.ClientMessage.use_request:type_name -> game.v1.UseRequest
-	131, // 40: game.v1.ClientMessage.class_features_request:type_name -> game.v1.ClassFeaturesRequest
+	129, // 37: game.v1.ClientMessage.feats_request:type_name -> game.v1.FeatsRequest
+	135, // 38: game.v1.ClientMessage.interact_request:type_name -> game.v1.InteractRequest
+	137, // 39: game.v1.ClientMessage.use_request:type_name -> game.v1.UseRequest
+	132, // 40: game.v1.ClientMessage.class_features_request:type_name -> game.v1.ClassFeaturesRequest
 	97,  // 41: game.v1.ClientMessage.summon_item:type_name -> game.v1.SummonItemRequest
-	145, // 42: game.v1.ClientMessage.proficiencies_request:type_name -> game.v1.ProficienciesRequest
-	148, // 43: game.v1.ClientMessage.level_up:type_name -> game.v1.LevelUpRequest
-	149, // 44: game.v1.ClientMessage.combat_default:type_name -> game.v1.CombatDefaultRequest
-	150, // 45: game.v1.ClientMessage.train_skill:type_name -> game.v1.TrainSkillRequest
-	151, // 46: game.v1.ClientMessage.action:type_name -> game.v1.ActionRequest
-	152, // 47: game.v1.ClientMessage.raise_shield:type_name -> game.v1.RaiseShieldRequest
-	153, // 48: game.v1.ClientMessage.take_cover:type_name -> game.v1.TakeCoverRequest
-	154, // 49: game.v1.ClientMessage.first_aid:type_name -> game.v1.FirstAidRequest
-	155, // 50: game.v1.ClientMessage.feint:type_name -> game.v1.FeintRequest
-	156, // 51: game.v1.ClientMessage.demoralize:type_name -> game.v1.DemoralizeRequest
-	157, // 52: game.v1.ClientMessage.grapple:type_name -> game.v1.GrappleRequest
-	158, // 53: game.v1.ClientMessage.trip:type_name -> game.v1.TripRequest
-	164, // 54: game.v1.ClientMessage.hide:type_name -> game.v1.HideRequest
-	165, // 55: game.v1.ClientMessage.sneak:type_name -> game.v1.SneakRequest
-	166, // 56: game.v1.ClientMessage.divert:type_name -> game.v1.DivertRequest
-	167, // 57: game.v1.ClientMessage.escape:type_name -> game.v1.EscapeRequest
-	184, // 58: game.v1.ClientMessage.grant:type_name -> game.v1.GrantRequest
-	159, // 59: game.v1.ClientMessage.disarm:type_name -> game.v1.DisarmRequest
-	160, // 60: game.v1.ClientMessage.stride:type_name -> game.v1.StrideRequest
-	162, // 61: game.v1.ClientMessage.shove:type_name -> game.v1.ShoveRequest
-	163, // 62: game.v1.ClientMessage.step:type_name -> game.v1.StepRequest
-	168, // 63: game.v1.ClientMessage.tumble:type_name -> game.v1.TumbleRequest
-	169, // 64: game.v1.ClientMessage.seek:type_name -> game.v1.SeekRequest
-	170, // 65: game.v1.ClientMessage.climb:type_name -> game.v1.ClimbRequest
-	171, // 66: game.v1.ClientMessage.swim:type_name -> game.v1.SwimRequest
-	183, // 67: game.v1.ClientMessage.motive:type_name -> game.v1.MotiveRequest
-	172, // 68: game.v1.ClientMessage.calm:type_name -> game.v1.CalmRequest
-	173, // 69: game.v1.ClientMessage.hero_point:type_name -> game.v1.HeroPointRequest
-	174, // 70: game.v1.ClientMessage.delay:type_name -> game.v1.DelayRequest
-	175, // 71: game.v1.ClientMessage.join:type_name -> game.v1.JoinRequest
-	176, // 72: game.v1.ClientMessage.decline:type_name -> game.v1.DeclineRequest
-	177, // 73: game.v1.ClientMessage.group:type_name -> game.v1.GroupRequest
-	178, // 74: game.v1.ClientMessage.invite:type_name -> game.v1.InviteRequest
-	179, // 75: game.v1.ClientMessage.accept_group:type_name -> game.v1.AcceptGroupRequest
-	180, // 76: game.v1.ClientMessage.decline_group:type_name -> game.v1.DeclineGroupRequest
-	181, // 77: game.v1.ClientMessage.ungroup:type_name -> game.v1.UngroupRequest
-	182, // 78: game.v1.ClientMessage.kick:type_name -> game.v1.KickRequest
+	146, // 42: game.v1.ClientMessage.proficiencies_request:type_name -> game.v1.ProficienciesRequest
+	149, // 43: game.v1.ClientMessage.level_up:type_name -> game.v1.LevelUpRequest
+	150, // 44: game.v1.ClientMessage.combat_default:type_name -> game.v1.CombatDefaultRequest
+	151, // 45: game.v1.ClientMessage.train_skill:type_name -> game.v1.TrainSkillRequest
+	152, // 46: game.v1.ClientMessage.action:type_name -> game.v1.ActionRequest
+	153, // 47: game.v1.ClientMessage.raise_shield:type_name -> game.v1.RaiseShieldRequest
+	154, // 48: game.v1.ClientMessage.take_cover:type_name -> game.v1.TakeCoverRequest
+	155, // 49: game.v1.ClientMessage.first_aid:type_name -> game.v1.FirstAidRequest
+	156, // 50: game.v1.ClientMessage.feint:type_name -> game.v1.FeintRequest
+	157, // 51: game.v1.ClientMessage.demoralize:type_name -> game.v1.DemoralizeRequest
+	158, // 52: game.v1.ClientMessage.grapple:type_name -> game.v1.GrappleRequest
+	159, // 53: game.v1.ClientMessage.trip:type_name -> game.v1.TripRequest
+	165, // 54: game.v1.ClientMessage.hide:type_name -> game.v1.HideRequest
+	166, // 55: game.v1.ClientMessage.sneak:type_name -> game.v1.SneakRequest
+	167, // 56: game.v1.ClientMessage.divert:type_name -> game.v1.DivertRequest
+	168, // 57: game.v1.ClientMessage.escape:type_name -> game.v1.EscapeRequest
+	185, // 58: game.v1.ClientMessage.grant:type_name -> game.v1.GrantRequest
+	160, // 59: game.v1.ClientMessage.disarm:type_name -> game.v1.DisarmRequest
+	161, // 60: game.v1.ClientMessage.stride:type_name -> game.v1.StrideRequest
+	163, // 61: game.v1.ClientMessage.shove:type_name -> game.v1.ShoveRequest
+	164, // 62: game.v1.ClientMessage.step:type_name -> game.v1.StepRequest
+	169, // 63: game.v1.ClientMessage.tumble:type_name -> game.v1.TumbleRequest
+	170, // 64: game.v1.ClientMessage.seek:type_name -> game.v1.SeekRequest
+	171, // 65: game.v1.ClientMessage.climb:type_name -> game.v1.ClimbRequest
+	172, // 66: game.v1.ClientMessage.swim:type_name -> game.v1.SwimRequest
+	184, // 67: game.v1.ClientMessage.motive:type_name -> game.v1.MotiveRequest
+	173, // 68: game.v1.ClientMessage.calm:type_name -> game.v1.CalmRequest
+	174, // 69: game.v1.ClientMessage.hero_point:type_name -> game.v1.HeroPointRequest
+	175, // 70: game.v1.ClientMessage.delay:type_name -> game.v1.DelayRequest
+	176, // 71: game.v1.ClientMessage.join:type_name -> game.v1.JoinRequest
+	177, // 72: game.v1.ClientMessage.decline:type_name -> game.v1.DeclineRequest
+	178, // 73: game.v1.ClientMessage.group:type_name -> game.v1.GroupRequest
+	179, // 74: game.v1.ClientMessage.invite:type_name -> game.v1.InviteRequest
+	180, // 75: game.v1.ClientMessage.accept_group:type_name -> game.v1.AcceptGroupRequest
+	181, // 76: game.v1.ClientMessage.decline_group:type_name -> game.v1.DeclineGroupRequest
+	182, // 77: game.v1.ClientMessage.ungroup:type_name -> game.v1.UngroupRequest
+	183, // 78: game.v1.ClientMessage.kick:type_name -> game.v1.KickRequest
 	6,   // 79: game.v1.ClientMessage.rest:type_name -> game.v1.RestRequest
 	7,   // 80: game.v1.ClientMessage.select_tech:type_name -> game.v1.SelectTechRequest
 	8,   // 81: game.v1.ClientMessage.aid:type_name -> game.v1.AidRequest
@@ -19219,41 +19305,41 @@ var file_game_v1_game_proto_depIdxs = []int32{
 	28,  // 101: game.v1.ClientMessage.bribe_confirm_request:type_name -> game.v1.BribeConfirmRequest
 	29,  // 102: game.v1.ClientMessage.surrender_request:type_name -> game.v1.SurrenderRequest
 	30,  // 103: game.v1.ClientMessage.release_request:type_name -> game.v1.ReleaseRequest
-	185, // 104: game.v1.ClientMessage.spawn_npc:type_name -> game.v1.SpawnNPCRequest
-	187, // 105: game.v1.ClientMessage.add_room:type_name -> game.v1.AddRoomRequest
-	188, // 106: game.v1.ClientMessage.add_link:type_name -> game.v1.AddLinkRequest
-	189, // 107: game.v1.ClientMessage.remove_link:type_name -> game.v1.RemoveLinkRequest
-	190, // 108: game.v1.ClientMessage.set_room:type_name -> game.v1.SetRoomRequest
-	191, // 109: game.v1.ClientMessage.editor_cmds:type_name -> game.v1.EditorCmdsRequest
+	186, // 104: game.v1.ClientMessage.spawn_npc:type_name -> game.v1.SpawnNPCRequest
+	188, // 105: game.v1.ClientMessage.add_room:type_name -> game.v1.AddRoomRequest
+	189, // 106: game.v1.ClientMessage.add_link:type_name -> game.v1.AddLinkRequest
+	190, // 107: game.v1.ClientMessage.remove_link:type_name -> game.v1.RemoveLinkRequest
+	191, // 108: game.v1.ClientMessage.set_room:type_name -> game.v1.SetRoomRequest
+	192, // 109: game.v1.ClientMessage.editor_cmds:type_name -> game.v1.EditorCmdsRequest
 	32,  // 110: game.v1.ClientMessage.travel:type_name -> game.v1.TravelRequest
 	33,  // 111: game.v1.ClientMessage.activate_item:type_name -> game.v1.ActivateItemRequest
-	194, // 112: game.v1.ClientMessage.faction_request:type_name -> game.v1.FactionRequest
-	195, // 113: game.v1.ClientMessage.faction_info_request:type_name -> game.v1.FactionInfoRequest
-	196, // 114: game.v1.ClientMessage.faction_standing_request:type_name -> game.v1.FactionStandingRequest
-	197, // 115: game.v1.ClientMessage.change_rep_request:type_name -> game.v1.ChangeRepRequest
-	198, // 116: game.v1.ClientMessage.tab_complete:type_name -> game.v1.TabCompleteRequest
-	200, // 117: game.v1.ClientMessage.materials_request:type_name -> game.v1.MaterialsRequest
-	201, // 118: game.v1.ClientMessage.craft_list_request:type_name -> game.v1.CraftListRequest
-	202, // 119: game.v1.ClientMessage.craft_request:type_name -> game.v1.CraftRequest
-	203, // 120: game.v1.ClientMessage.craft_confirm_request:type_name -> game.v1.CraftConfirmRequest
-	204, // 121: game.v1.ClientMessage.scavenge_request:type_name -> game.v1.ScavengeRequest
-	205, // 122: game.v1.ClientMessage.affix_request:type_name -> game.v1.AffixRequest
-	206, // 123: game.v1.ClientMessage.explore_request:type_name -> game.v1.ExploreRequest
-	213, // 124: game.v1.ClientMessage.quest_request:type_name -> game.v1.QuestRequest
-	216, // 125: game.v1.ClientMessage.uncurse_request:type_name -> game.v1.UncurseRequest
-	212, // 126: game.v1.ClientMessage.downtime_request:type_name -> game.v1.DowntimeRequest
-	207, // 127: game.v1.ClientMessage.refocus_request:type_name -> game.v1.RefocusRequest
-	208, // 128: game.v1.ClientMessage.seduce_request:type_name -> game.v1.SeduceRequest
-	210, // 129: game.v1.ClientMessage.hotbar_request:type_name -> game.v1.HotbarRequest
-	192, // 130: game.v1.ClientMessage.spawn_char_request:type_name -> game.v1.SpawnCharRequest
-	193, // 131: game.v1.ClientMessage.delete_char_request:type_name -> game.v1.DeleteCharRequest
-	186, // 132: game.v1.ClientMessage.kill_npc_request:type_name -> game.v1.KillNPCRequest
+	195, // 112: game.v1.ClientMessage.faction_request:type_name -> game.v1.FactionRequest
+	196, // 113: game.v1.ClientMessage.faction_info_request:type_name -> game.v1.FactionInfoRequest
+	197, // 114: game.v1.ClientMessage.faction_standing_request:type_name -> game.v1.FactionStandingRequest
+	198, // 115: game.v1.ClientMessage.change_rep_request:type_name -> game.v1.ChangeRepRequest
+	199, // 116: game.v1.ClientMessage.tab_complete:type_name -> game.v1.TabCompleteRequest
+	201, // 117: game.v1.ClientMessage.materials_request:type_name -> game.v1.MaterialsRequest
+	202, // 118: game.v1.ClientMessage.craft_list_request:type_name -> game.v1.CraftListRequest
+	203, // 119: game.v1.ClientMessage.craft_request:type_name -> game.v1.CraftRequest
+	204, // 120: game.v1.ClientMessage.craft_confirm_request:type_name -> game.v1.CraftConfirmRequest
+	205, // 121: game.v1.ClientMessage.scavenge_request:type_name -> game.v1.ScavengeRequest
+	206, // 122: game.v1.ClientMessage.affix_request:type_name -> game.v1.AffixRequest
+	207, // 123: game.v1.ClientMessage.explore_request:type_name -> game.v1.ExploreRequest
+	214, // 124: game.v1.ClientMessage.quest_request:type_name -> game.v1.QuestRequest
+	217, // 125: game.v1.ClientMessage.uncurse_request:type_name -> game.v1.UncurseRequest
+	213, // 126: game.v1.ClientMessage.downtime_request:type_name -> game.v1.DowntimeRequest
+	208, // 127: game.v1.ClientMessage.refocus_request:type_name -> game.v1.RefocusRequest
+	209, // 128: game.v1.ClientMessage.seduce_request:type_name -> game.v1.SeduceRequest
+	211, // 129: game.v1.ClientMessage.hotbar_request:type_name -> game.v1.HotbarRequest
+	193, // 130: game.v1.ClientMessage.spawn_char_request:type_name -> game.v1.SpawnCharRequest
+	194, // 131: game.v1.ClientMessage.delete_char_request:type_name -> game.v1.DeleteCharRequest
+	187, // 132: game.v1.ClientMessage.kill_npc_request:type_name -> game.v1.KillNPCRequest
 	5,   // 133: game.v1.ClientMessage.uncover_request:type_name -> game.v1.UncoverRequest
-	218, // 134: game.v1.ClientMessage.job_grants_request:type_name -> game.v1.JobGrantsRequest
+	219, // 134: game.v1.ClientMessage.job_grants_request:type_name -> game.v1.JobGrantsRequest
 	93,  // 135: game.v1.ClientMessage.quest_log_request:type_name -> game.v1.QuestLogRequest
 	21,  // 136: game.v1.ClientMessage.train_tech:type_name -> game.v1.TrainTechRequest
-	224, // 137: game.v1.ClientMessage.choose_feat:type_name -> game.v1.ChooseFeatRequest
-	161, // 138: game.v1.ClientMessage.move_to:type_name -> game.v1.MoveToRequest
+	225, // 137: game.v1.ClientMessage.choose_feat:type_name -> game.v1.ChooseFeatRequest
+	162, // 138: game.v1.ClientMessage.move_to:type_name -> game.v1.MoveToRequest
 	37,  // 139: game.v1.ClientMessage.reaction_response:type_name -> game.v1.ReactionResponse
 	50,  // 140: game.v1.ServerEvent.room_view:type_name -> game.v1.RoomView
 	52,  // 141: game.v1.ServerEvent.message:type_name -> game.v1.MessageEvent
@@ -19264,33 +19350,33 @@ var file_game_v1_game_proto_depIdxs = []int32{
 	58,  // 146: game.v1.ServerEvent.disconnected:type_name -> game.v1.Disconnected
 	60,  // 147: game.v1.ServerEvent.character_info:type_name -> game.v1.CharacterInfo
 	63,  // 148: game.v1.ServerEvent.npc_view:type_name -> game.v1.NpcView
-	120, // 149: game.v1.ServerEvent.combat_event:type_name -> game.v1.CombatEvent
-	117, // 150: game.v1.ServerEvent.round_start:type_name -> game.v1.RoundStartEvent
-	118, // 151: game.v1.ServerEvent.round_end:type_name -> game.v1.RoundEndEvent
-	122, // 152: game.v1.ServerEvent.condition_event:type_name -> game.v1.ConditionEvent
+	121, // 149: game.v1.ServerEvent.combat_event:type_name -> game.v1.CombatEvent
+	118, // 150: game.v1.ServerEvent.round_start:type_name -> game.v1.RoundStartEvent
+	119, // 151: game.v1.ServerEvent.round_end:type_name -> game.v1.RoundEndEvent
+	123, // 152: game.v1.ServerEvent.condition_event:type_name -> game.v1.ConditionEvent
 	114, // 153: game.v1.ServerEvent.inventory_view:type_name -> game.v1.InventoryView
 	59,  // 154: game.v1.ServerEvent.time_of_day:type_name -> game.v1.TimeOfDayEvent
-	141, // 155: game.v1.ServerEvent.character_sheet:type_name -> game.v1.CharacterSheetView
+	142, // 155: game.v1.ServerEvent.character_sheet:type_name -> game.v1.CharacterSheetView
 	108, // 156: game.v1.ServerEvent.map:type_name -> game.v1.MapResponse
 	111, // 157: game.v1.ServerEvent.skills_response:type_name -> game.v1.SkillsResponse
-	130, // 158: game.v1.ServerEvent.feats_response:type_name -> game.v1.FeatsResponse
-	135, // 159: game.v1.ServerEvent.interact_response:type_name -> game.v1.InteractResponse
-	137, // 160: game.v1.ServerEvent.use_response:type_name -> game.v1.UseResponse
-	133, // 161: game.v1.ServerEvent.class_features_response:type_name -> game.v1.ClassFeaturesResponse
-	147, // 162: game.v1.ServerEvent.proficiencies_response:type_name -> game.v1.ProficienciesResponse
+	131, // 158: game.v1.ServerEvent.feats_response:type_name -> game.v1.FeatsResponse
+	136, // 159: game.v1.ServerEvent.interact_response:type_name -> game.v1.InteractResponse
+	138, // 160: game.v1.ServerEvent.use_response:type_name -> game.v1.UseResponse
+	134, // 161: game.v1.ServerEvent.class_features_response:type_name -> game.v1.ClassFeaturesResponse
+	148, // 162: game.v1.ServerEvent.proficiencies_response:type_name -> game.v1.ProficienciesResponse
 	40,  // 163: game.v1.ServerEvent.hp_update:type_name -> game.v1.HpUpdateEvent
-	199, // 164: game.v1.ServerEvent.tab_complete:type_name -> game.v1.TabCompleteResponse
-	215, // 165: game.v1.ServerEvent.craft_result:type_name -> game.v1.CraftResultEvent
-	211, // 166: game.v1.ServerEvent.hotbar_update:type_name -> game.v1.HotbarUpdateEvent
+	200, // 164: game.v1.ServerEvent.tab_complete:type_name -> game.v1.TabCompleteResponse
+	216, // 165: game.v1.ServerEvent.craft_result:type_name -> game.v1.CraftResultEvent
+	212, // 166: game.v1.ServerEvent.hotbar_update:type_name -> game.v1.HotbarUpdateEvent
 	39,  // 167: game.v1.ServerEvent.shop_view:type_name -> game.v1.ShopView
 	64,  // 168: game.v1.ServerEvent.healer_view:type_name -> game.v1.HealerView
 	66,  // 169: game.v1.ServerEvent.trainer_view:type_name -> game.v1.TrainerView
-	217, // 170: game.v1.ServerEvent.weather:type_name -> game.v1.WeatherEvent
+	218, // 170: game.v1.ServerEvent.weather:type_name -> game.v1.WeatherEvent
 	87,  // 171: game.v1.ServerEvent.loadout_view:type_name -> game.v1.LoadoutView
 	69,  // 172: game.v1.ServerEvent.fixer_view:type_name -> game.v1.FixerView
-	221, // 173: game.v1.ServerEvent.job_grants_response:type_name -> game.v1.JobGrantsResponse
+	222, // 173: game.v1.ServerEvent.job_grants_response:type_name -> game.v1.JobGrantsResponse
 	70,  // 174: game.v1.ServerEvent.rest_view:type_name -> game.v1.RestView
-	119, // 175: game.v1.ServerEvent.ap_update:type_name -> game.v1.APUpdateEvent
+	120, // 175: game.v1.ServerEvent.ap_update:type_name -> game.v1.APUpdateEvent
 	90,  // 176: game.v1.ServerEvent.quest_giver_view:type_name -> game.v1.QuestGiverView
 	91,  // 177: game.v1.ServerEvent.quest_log_view:type_name -> game.v1.QuestLogView
 	92,  // 178: game.v1.ServerEvent.quest_complete:type_name -> game.v1.QuestCompleteEvent
@@ -19301,7 +19387,7 @@ var file_game_v1_game_proto_depIdxs = []int32{
 	38,  // 183: game.v1.ShopView.items:type_name -> game.v1.ShopItem
 	51,  // 184: game.v1.RoomView.exits:type_name -> game.v1.ExitInfo
 	61,  // 185: game.v1.RoomView.npcs:type_name -> game.v1.NpcInfo
-	125, // 186: game.v1.RoomView.active_conditions:type_name -> game.v1.ConditionInfo
+	126, // 186: game.v1.RoomView.active_conditions:type_name -> game.v1.ConditionInfo
 	98,  // 187: game.v1.RoomView.floor_items:type_name -> game.v1.FloorItem
 	99,  // 188: game.v1.RoomView.equipment:type_name -> game.v1.RoomEquipmentItem
 	0,   // 189: game.v1.MessageEvent.type:type_name -> game.v1.MessageType
@@ -19311,7 +19397,7 @@ var file_game_v1_game_proto_depIdxs = []int32{
 	51,  // 193: game.v1.ExitList.exits:type_name -> game.v1.ExitInfo
 	65,  // 194: game.v1.TrainerView.jobs:type_name -> game.v1.JobOfferEntry
 	68,  // 195: game.v1.TechTrainerView.offers:type_name -> game.v1.TechOfferEntry
-	251, // 196: game.v1.FixerView.bribe_costs:type_name -> game.v1.FixerView.BribeCostsEntry
+	252, // 196: game.v1.FixerView.bribe_costs:type_name -> game.v1.FixerView.BribeCostsEntry
 	86,  // 197: game.v1.LoadoutView.presets:type_name -> game.v1.LoadoutWeaponPreset
 	88,  // 198: game.v1.QuestEntryView.objectives:type_name -> game.v1.QuestObjectiveView
 	89,  // 199: game.v1.QuestGiverView.quests:type_name -> game.v1.QuestEntryView
@@ -19325,65 +19411,66 @@ var file_game_v1_game_proto_depIdxs = []int32{
 	113, // 207: game.v1.InventoryView.items:type_name -> game.v1.InventoryItem
 	115, // 208: game.v1.RoundStartEvent.initial_positions:type_name -> game.v1.CombatantPosition
 	116, // 209: game.v1.RoundStartEvent.cover_objects:type_name -> game.v1.CoverObjectPosition
-	3,   // 210: game.v1.CombatEvent.type:type_name -> game.v1.CombatEventType
-	129, // 211: game.v1.FeatsResponse.feats:type_name -> game.v1.FeatEntry
-	132, // 212: game.v1.ClassFeaturesResponse.archetype_features:type_name -> game.v1.ClassFeatureEntry
-	132, // 213: game.v1.ClassFeaturesResponse.job_features:type_name -> game.v1.ClassFeatureEntry
-	129, // 214: game.v1.UseResponse.choices:type_name -> game.v1.FeatEntry
-	252, // 215: game.v1.CharacterSheetView.armor:type_name -> game.v1.CharacterSheetView.ArmorEntry
-	253, // 216: game.v1.CharacterSheetView.accessories:type_name -> game.v1.CharacterSheetView.AccessoriesEntry
-	144, // 217: game.v1.CharacterSheetView.player_resistances:type_name -> game.v1.ResistanceEntry
-	144, // 218: game.v1.CharacterSheetView.player_weaknesses:type_name -> game.v1.ResistanceEntry
-	110, // 219: game.v1.CharacterSheetView.skills:type_name -> game.v1.SkillEntry
-	129, // 220: game.v1.CharacterSheetView.feats:type_name -> game.v1.FeatEntry
-	132, // 221: game.v1.CharacterSheetView.class_features:type_name -> game.v1.ClassFeatureEntry
-	146, // 222: game.v1.CharacterSheetView.proficiencies:type_name -> game.v1.ProficiencyEntry
-	138, // 223: game.v1.CharacterSheetView.prepared_slots:type_name -> game.v1.PreparedSlotView
-	143, // 224: game.v1.CharacterSheetView.spontaneous_use_pools:type_name -> game.v1.SpontaneousUsePoolView
-	142, // 225: game.v1.CharacterSheetView.innate_slots:type_name -> game.v1.InnateSlotView
-	139, // 226: game.v1.CharacterSheetView.hardwired_slots:type_name -> game.v1.HardwiredSlotView
-	140, // 227: game.v1.CharacterSheetView.spontaneous_known:type_name -> game.v1.SpontaneousKnownEntry
-	254, // 228: game.v1.CharacterSheetView.armor_categories:type_name -> game.v1.CharacterSheetView.ArmorCategoriesEntry
-	146, // 229: game.v1.ProficienciesResponse.proficiencies:type_name -> game.v1.ProficiencyEntry
-	209, // 230: game.v1.HotbarUpdateEvent.slots:type_name -> game.v1.HotbarSlot
-	214, // 231: game.v1.CraftResultEvent.materials_lost:type_name -> game.v1.MaterialLoss
-	219, // 232: game.v1.JobGrantsResponse.feat_grants:type_name -> game.v1.JobFeatGrant
-	220, // 233: game.v1.JobGrantsResponse.tech_grants:type_name -> game.v1.JobTechGrant
-	223, // 234: game.v1.JobGrantsResponse.pending_feat_choices:type_name -> game.v1.PendingFeatChoice
-	222, // 235: game.v1.PendingFeatChoice.options:type_name -> game.v1.FeatOption
-	225, // 236: game.v1.AdminListSessionsResponse.sessions:type_name -> game.v1.AdminSessionInfo
-	235, // 237: game.v1.AdminListZonesResponse.zones:type_name -> game.v1.AdminZoneSummary
-	238, // 238: game.v1.AdminListRoomsResponse.rooms:type_name -> game.v1.AdminRoomSummary
-	243, // 239: game.v1.AdminListNPCTemplatesResponse.templates:type_name -> game.v1.AdminNPCTemplateSummary
-	4,   // 240: game.v1.GameService.Session:input_type -> game.v1.ClientMessage
-	226, // 241: game.v1.GameService.AdminListSessions:input_type -> game.v1.AdminListSessionsRequest
-	228, // 242: game.v1.GameService.AdminKickPlayer:input_type -> game.v1.AdminKickRequest
-	230, // 243: game.v1.GameService.AdminMessagePlayer:input_type -> game.v1.AdminMessageRequest
-	232, // 244: game.v1.GameService.AdminTeleportPlayer:input_type -> game.v1.AdminTeleportRequest
-	234, // 245: game.v1.GameService.AdminListZones:input_type -> game.v1.AdminListZonesRequest
-	237, // 246: game.v1.GameService.AdminListRooms:input_type -> game.v1.AdminListRoomsRequest
-	240, // 247: game.v1.GameService.AdminUpdateRoom:input_type -> game.v1.AdminUpdateRoomRequest
-	242, // 248: game.v1.GameService.AdminListNPCTemplates:input_type -> game.v1.AdminListNPCTemplatesRequest
-	245, // 249: game.v1.GameService.AdminSpawnNPC:input_type -> game.v1.AdminSpawnNPCRequest
-	247, // 250: game.v1.GameService.AdminGiveItem:input_type -> game.v1.AdminGiveItemRequest
-	249, // 251: game.v1.GameService.AdminGiveCurrency:input_type -> game.v1.AdminGiveCurrencyRequest
-	34,  // 252: game.v1.GameService.Session:output_type -> game.v1.ServerEvent
-	227, // 253: game.v1.GameService.AdminListSessions:output_type -> game.v1.AdminListSessionsResponse
-	229, // 254: game.v1.GameService.AdminKickPlayer:output_type -> game.v1.AdminKickResponse
-	231, // 255: game.v1.GameService.AdminMessagePlayer:output_type -> game.v1.AdminMessageResponse
-	233, // 256: game.v1.GameService.AdminTeleportPlayer:output_type -> game.v1.AdminTeleportResponse
-	236, // 257: game.v1.GameService.AdminListZones:output_type -> game.v1.AdminListZonesResponse
-	239, // 258: game.v1.GameService.AdminListRooms:output_type -> game.v1.AdminListRoomsResponse
-	241, // 259: game.v1.GameService.AdminUpdateRoom:output_type -> game.v1.AdminUpdateRoomResponse
-	244, // 260: game.v1.GameService.AdminListNPCTemplates:output_type -> game.v1.AdminListNPCTemplatesResponse
-	246, // 261: game.v1.GameService.AdminSpawnNPC:output_type -> game.v1.AdminSpawnNPCResponse
-	248, // 262: game.v1.GameService.AdminGiveItem:output_type -> game.v1.AdminGiveItemResponse
-	250, // 263: game.v1.GameService.AdminGiveCurrency:output_type -> game.v1.AdminGiveCurrencyResponse
-	252, // [252:264] is the sub-list for method output_type
-	240, // [240:252] is the sub-list for method input_type
-	240, // [240:240] is the sub-list for extension type_name
-	240, // [240:240] is the sub-list for extension extendee
-	0,   // [0:240] is the sub-list for field type_name
+	117, // 210: game.v1.RoundStartEvent.terrain:type_name -> game.v1.TerrainCell
+	3,   // 211: game.v1.CombatEvent.type:type_name -> game.v1.CombatEventType
+	130, // 212: game.v1.FeatsResponse.feats:type_name -> game.v1.FeatEntry
+	133, // 213: game.v1.ClassFeaturesResponse.archetype_features:type_name -> game.v1.ClassFeatureEntry
+	133, // 214: game.v1.ClassFeaturesResponse.job_features:type_name -> game.v1.ClassFeatureEntry
+	130, // 215: game.v1.UseResponse.choices:type_name -> game.v1.FeatEntry
+	253, // 216: game.v1.CharacterSheetView.armor:type_name -> game.v1.CharacterSheetView.ArmorEntry
+	254, // 217: game.v1.CharacterSheetView.accessories:type_name -> game.v1.CharacterSheetView.AccessoriesEntry
+	145, // 218: game.v1.CharacterSheetView.player_resistances:type_name -> game.v1.ResistanceEntry
+	145, // 219: game.v1.CharacterSheetView.player_weaknesses:type_name -> game.v1.ResistanceEntry
+	110, // 220: game.v1.CharacterSheetView.skills:type_name -> game.v1.SkillEntry
+	130, // 221: game.v1.CharacterSheetView.feats:type_name -> game.v1.FeatEntry
+	133, // 222: game.v1.CharacterSheetView.class_features:type_name -> game.v1.ClassFeatureEntry
+	147, // 223: game.v1.CharacterSheetView.proficiencies:type_name -> game.v1.ProficiencyEntry
+	139, // 224: game.v1.CharacterSheetView.prepared_slots:type_name -> game.v1.PreparedSlotView
+	144, // 225: game.v1.CharacterSheetView.spontaneous_use_pools:type_name -> game.v1.SpontaneousUsePoolView
+	143, // 226: game.v1.CharacterSheetView.innate_slots:type_name -> game.v1.InnateSlotView
+	140, // 227: game.v1.CharacterSheetView.hardwired_slots:type_name -> game.v1.HardwiredSlotView
+	141, // 228: game.v1.CharacterSheetView.spontaneous_known:type_name -> game.v1.SpontaneousKnownEntry
+	255, // 229: game.v1.CharacterSheetView.armor_categories:type_name -> game.v1.CharacterSheetView.ArmorCategoriesEntry
+	147, // 230: game.v1.ProficienciesResponse.proficiencies:type_name -> game.v1.ProficiencyEntry
+	210, // 231: game.v1.HotbarUpdateEvent.slots:type_name -> game.v1.HotbarSlot
+	215, // 232: game.v1.CraftResultEvent.materials_lost:type_name -> game.v1.MaterialLoss
+	220, // 233: game.v1.JobGrantsResponse.feat_grants:type_name -> game.v1.JobFeatGrant
+	221, // 234: game.v1.JobGrantsResponse.tech_grants:type_name -> game.v1.JobTechGrant
+	224, // 235: game.v1.JobGrantsResponse.pending_feat_choices:type_name -> game.v1.PendingFeatChoice
+	223, // 236: game.v1.PendingFeatChoice.options:type_name -> game.v1.FeatOption
+	226, // 237: game.v1.AdminListSessionsResponse.sessions:type_name -> game.v1.AdminSessionInfo
+	236, // 238: game.v1.AdminListZonesResponse.zones:type_name -> game.v1.AdminZoneSummary
+	239, // 239: game.v1.AdminListRoomsResponse.rooms:type_name -> game.v1.AdminRoomSummary
+	244, // 240: game.v1.AdminListNPCTemplatesResponse.templates:type_name -> game.v1.AdminNPCTemplateSummary
+	4,   // 241: game.v1.GameService.Session:input_type -> game.v1.ClientMessage
+	227, // 242: game.v1.GameService.AdminListSessions:input_type -> game.v1.AdminListSessionsRequest
+	229, // 243: game.v1.GameService.AdminKickPlayer:input_type -> game.v1.AdminKickRequest
+	231, // 244: game.v1.GameService.AdminMessagePlayer:input_type -> game.v1.AdminMessageRequest
+	233, // 245: game.v1.GameService.AdminTeleportPlayer:input_type -> game.v1.AdminTeleportRequest
+	235, // 246: game.v1.GameService.AdminListZones:input_type -> game.v1.AdminListZonesRequest
+	238, // 247: game.v1.GameService.AdminListRooms:input_type -> game.v1.AdminListRoomsRequest
+	241, // 248: game.v1.GameService.AdminUpdateRoom:input_type -> game.v1.AdminUpdateRoomRequest
+	243, // 249: game.v1.GameService.AdminListNPCTemplates:input_type -> game.v1.AdminListNPCTemplatesRequest
+	246, // 250: game.v1.GameService.AdminSpawnNPC:input_type -> game.v1.AdminSpawnNPCRequest
+	248, // 251: game.v1.GameService.AdminGiveItem:input_type -> game.v1.AdminGiveItemRequest
+	250, // 252: game.v1.GameService.AdminGiveCurrency:input_type -> game.v1.AdminGiveCurrencyRequest
+	34,  // 253: game.v1.GameService.Session:output_type -> game.v1.ServerEvent
+	228, // 254: game.v1.GameService.AdminListSessions:output_type -> game.v1.AdminListSessionsResponse
+	230, // 255: game.v1.GameService.AdminKickPlayer:output_type -> game.v1.AdminKickResponse
+	232, // 256: game.v1.GameService.AdminMessagePlayer:output_type -> game.v1.AdminMessageResponse
+	234, // 257: game.v1.GameService.AdminTeleportPlayer:output_type -> game.v1.AdminTeleportResponse
+	237, // 258: game.v1.GameService.AdminListZones:output_type -> game.v1.AdminListZonesResponse
+	240, // 259: game.v1.GameService.AdminListRooms:output_type -> game.v1.AdminListRoomsResponse
+	242, // 260: game.v1.GameService.AdminUpdateRoom:output_type -> game.v1.AdminUpdateRoomResponse
+	245, // 261: game.v1.GameService.AdminListNPCTemplates:output_type -> game.v1.AdminListNPCTemplatesResponse
+	247, // 262: game.v1.GameService.AdminSpawnNPC:output_type -> game.v1.AdminSpawnNPCResponse
+	249, // 263: game.v1.GameService.AdminGiveItem:output_type -> game.v1.AdminGiveItemResponse
+	251, // 264: game.v1.GameService.AdminGiveCurrency:output_type -> game.v1.AdminGiveCurrencyResponse
+	253, // [253:265] is the sub-list for method output_type
+	241, // [241:253] is the sub-list for method input_type
+	241, // [241:241] is the sub-list for extension type_name
+	241, // [241:241] is the sub-list for extension extendee
+	0,   // [0:241] is the sub-list for field type_name
 }
 
 func init() { file_game_v1_game_proto_init() }
@@ -19583,7 +19670,7 @@ func file_game_v1_game_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_game_v1_game_proto_rawDesc), len(file_game_v1_game_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   251,
+			NumMessages:   252,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/gameserver/grpc_service.go
+++ b/internal/gameserver/grpc_service.go
@@ -1027,6 +1027,7 @@ func (s *GameServiceServer) Session(stream gamev1.GameService_SessionServer) err
 							DurationMs:       int32(s.combatH.roundDuration.Milliseconds()),
 							TurnOrder:        turnOrder,
 							InitialPositions: positions,
+							Terrain:          terrainToProto(cbt.Terrain),
 						},
 					},
 				})


### PR DESCRIPTION
## Summary

Per-cell terrain layer with movement penalties and hazard damage routed through #246's \`ResolveDamage\` pipeline. Issue #248. Follow-up #312 for narrative propagation + combat-start placement wiring.

- **Core**: \`internal/game/combat/terrain.go\` — \`GridCell\`, \`TerrainType\` (Normal/Difficult/GreaterDifficult/Hazardous), \`TerrainCell\`, \`CellHazard\`, \`TerrainAt\`, \`EntryCost\`, \`TerrainGlyph\`, \`TerrainLegendText\`.
- **Speed budget**: \`Combatant.SpeedBudget()\` replaces \`SpeedSquares()\` (deprecated forwarder retained). Stride loop rewritten to consume budget per-cell using \`EntryCost\`.
- **Authoring**: Room YAML accepts \`combat_terrain\` in shape A (explicit grid + legend) or shape B (default + per-cell overrides). Loader rejects both-shapes, hazardous-without-hazard, greater_difficult-with-hazard, etc.
- **Hazards**: \`applyCellHazard\` routes through \`ResolveDamage\` (#246). Stride fires \`on_enter\`; \`StartRoundWithSrc\` fires \`round_start\` for occupants of hazardous cells. \`skipHazardRoundStart\` (and exported \`SkipHazardRoundStart\` setter) prevents round-1 double-fire after combat-start placement.
- **Telnet**: \`terrain\` command lists the legend.
- **Web**: \`TerrainCell\` proto added to \`RoundStartEvent\`; gameserver populates from \`cbt.Terrain\`; \`MapPanel.tsx\` applies \`terrain-{type}\` className with CSS background tints.
- **Docs**: \`docs/architecture/combat.md\` Terrain section.

Plan: \`docs/superpowers/plans/2026-04-22-terrain-type-penalties.md\` (8 tasks).

## Test plan

- [ ] Full Go suite green (\`go test ./...\`)
- [ ] Web suite green (\`npx vitest run\`)
- [ ] Smoke: room with \`combat_terrain\` config loads; entering a difficult cell consumes 2 budget; greater_difficult blocks
- [ ] Hazardous cell deals damage on entry via stride
- [ ] \`terrain\` telnet command prints legend
- [ ] Web map shows terrain CSS tints
- [ ] Follow-up: hazard narrative propagation + combat-start placement (#312)

🤖 Generated with [Claude Code](https://claude.com/claude-code)