### PR TITLE
feat(aoe): AoE drawing in combat — typed templates + resolver (#250)

### DIFF
--- a/api/proto/game/v1/game.proto
+++ b/api/proto/game/v1/game.proto
@@ -1188,6 +1188,36 @@ message InteractResponse {
   string message = 1;
 }
 
+// AoeTemplate describes a placed area-of-effect template for a Use action.
+// The client populates shape, anchor, and (for cones/lines) facing on inbound
+// requests; the server populates cells on outbound combat events.
+message AoeTemplate {
+  enum Shape {
+    SHAPE_UNSPECIFIED = 0;
+    SHAPE_BURST = 1;
+    SHAPE_CONE = 2;
+    SHAPE_LINE = 3;
+  }
+  enum Direction {
+    DIR_UNSPECIFIED = 0;
+    DIR_N  = 1;
+    DIR_NE = 2;
+    DIR_E  = 3;
+    DIR_SE = 4;
+    DIR_S  = 5;
+    DIR_SW = 6;
+    DIR_W  = 7;
+    DIR_NW = 8;
+  }
+  message Cell { int32 x = 1; int32 y = 2; }
+
+  Shape     shape    = 1;
+  int32     anchor_x = 2;
+  int32     anchor_y = 3;
+  Direction facing   = 4;
+  repeated Cell cells = 5; // server-populated on outbound; ignored on inbound
+}
+
 // UseRequest asks the server to activate an active feat.
 // An empty feat_id causes the server to return the list of available active feats.
 message UseRequest {
@@ -1195,6 +1225,7 @@ message UseRequest {
   string target   = 2;
   int32  target_x = 3; // 0-based grid column (0–9); -1 means unset / no AoE; ignored unless feat has aoe_radius > 0
   int32  target_y = 4; // 0-based grid row (0–9); -1 means unset / no AoE; ignored unless feat has aoe_radius > 0
+  AoeTemplate template = 5; // optional; required for cone/line content (AOE-13)
 }
 
 // UseResponse carries the result of a feat activation or a list of active feats.

--- a/cmd/webclient/ui/src/proto/index.ts
+++ b/cmd/webclient/ui/src/proto/index.ts
@@ -817,12 +817,54 @@ export interface ConditionEvent {
   applied?: boolean
 }
 
+// AoeTemplate.Shape — numeric proto enum mirroring api/proto/game/v1/game.proto.
+export const AoeTemplateShape = {
+  SHAPE_UNSPECIFIED: 0,
+  SHAPE_BURST: 1,
+  SHAPE_CONE: 2,
+  SHAPE_LINE: 3,
+} as const
+export type AoeTemplateShape = (typeof AoeTemplateShape)[keyof typeof AoeTemplateShape]
+
+// AoeTemplate.Direction — numeric proto enum mirroring api/proto/game/v1/game.proto.
+export const AoeTemplateDirection = {
+  DIR_UNSPECIFIED: 0,
+  DIR_N: 1,
+  DIR_NE: 2,
+  DIR_E: 3,
+  DIR_SE: 4,
+  DIR_S: 5,
+  DIR_SW: 6,
+  DIR_W: 7,
+  DIR_NW: 8,
+} as const
+export type AoeTemplateDirection = (typeof AoeTemplateDirection)[keyof typeof AoeTemplateDirection]
+
+export interface AoeTemplateCell {
+  x?: number
+  y?: number
+}
+
+// AoeTemplate — placed area-of-effect template payload.
+// Inbound: client sets shape, anchor_x/y, and (for cone/line) facing.
+// Outbound: server populates cells.
+export interface AoeTemplate {
+  shape?: AoeTemplateShape
+  anchorX?: number
+  anchor_x?: number
+  anchorY?: number
+  anchor_y?: number
+  facing?: AoeTemplateDirection
+  cells?: AoeTemplateCell[]
+}
+
 export interface UseRequest {
   itemRef?: string
   targetName?: string
   target_name?: string
   target_x?: number // 0-based grid column; -1 (or omit) means unset / no AoE
   target_y?: number // 0-based grid row; -1 (or omit) means unset / no AoE
+  template?: AoeTemplate // required for cone/line content (AOE-13)
 }
 
 export type ServerEvent =

--- a/content/class_features.yaml
+++ b/content/class_features.yaml
@@ -74,6 +74,7 @@ class_features:
     pf2e: inspire_courage
     active: true
     action_cost: 1
+    aoe_shape: burst
     aoe_radius: 30
     activate_text: "You raise your voice and all eyes snap to you."
     condition_id: command_attention_active
@@ -90,6 +91,7 @@ class_features:
     pf2e: inspire_defense
     active: true
     action_cost: 1
+    aoe_shape: burst
     aoe_radius: 30
     activate_text: "You spin a rapid web of distracting chatter."
     description: "Grant allies within earshot +1 AC and saving throws for the current encounter."
@@ -377,6 +379,7 @@ class_features:
     pf2e: sudden_charge
     active: true
     action_cost: 1
+    aoe_shape: burst
     aoe_radius: 30
     activate_text: "You break into a full sprint before anyone can react."
     description: "Once per encounter, before your first turn begins, move up to your speed and make one melee or ranged attack."
@@ -660,6 +663,7 @@ class_features:
     pf2e: demoralize
     active: true
     action_cost: 2
+    aoe_shape: burst
     aoe_radius: 15
     activate_text: "You invoke fire and damnation against your enemies."
     description: "Once per encounter, make a single Intimidate check against all enemies within 20 ft simultaneously."
@@ -722,6 +726,7 @@ class_features:
     pf2e: captivating_performance
     active: true
     action_cost: 1
+    aoe_shape: burst
     aoe_radius: 30
     activate_text: "You turn on the charm and command the room."
     description: "Once per encounter, make an opposed Perform check to distract all enemies within 30 ft for 1 round."
@@ -751,6 +756,7 @@ class_features:
     pf2e: coerce
     active: true
     action_cost: 1
+    aoe_shape: burst
     aoe_radius: 15
     activate_text: "You make absolutely clear what happens to people who don't comply."
     description: "Intimidate a target; on success they take no hostile action against you for 24 hours."
@@ -847,6 +853,7 @@ class_features:
     pf2e: recall_knowledge
     active: true
     action_cost: 1
+    aoe_shape: burst
     aoe_radius: 15
     activate_text: "You open yourself to the possibility of something beyond."
     description: "Once per day, ask one yes/no question about a topic and receive a truthful answer at the GM's discretion."
@@ -950,6 +957,7 @@ class_features:
     pf2e: demoralize
     active: true
     action_cost: 2
+    aoe_shape: burst
     aoe_radius: 15
     activate_text: "You offer words of comfort and faith."
     description: "Once per day, remove the frightened condition from one demoralized ally as a single action."
@@ -966,6 +974,7 @@ class_features:
     pf2e: coerce
     active: true
     action_cost: 2
+    aoe_shape: burst
     aoe_radius: 15
     activate_text: "You speak with absolute conviction and leave no room for doubt."
     description: "Once per day, one NPC who fails a Will save becomes a devoted follower for 24 hours."

--- a/docs/architecture/combat.md
+++ b/docs/architecture/combat.md
@@ -314,6 +314,83 @@ for budget > 0:
 | `internal/game/combat/engine.go` | `Combat.Terrain`, `RoomHazards`, `skipHazardRoundStart` fields; round_start hazard hook in `StartRoundWithSrc` |
 | `internal/game/combat/combat.go` | `Combatant.SpeedBudget()` (replaces deprecated `SpeedSquares()`); `WeaknessFor`/`ResistanceFor` helpers |
 
+## Area-of-Effect (AOE Requirements)
+
+Typed AoE templates (burst / cone / line) flow from client to server to resolver via the
+new `AoeTemplate` proto message. Content declares an `aoe_shape` plus shape-appropriate
+dimensions; the resolver derives affected cells from the template, applies an optional
+post-filter, then applies the action's effect to every living combatant in the resulting
+cell set.
+
+### Requirements (35 total, summarised by category)
+
+| Category | Requirements | Summary |
+|----------|-------------|---------|
+| Content model | AOE-1..AOE-6 | `aoe_shape` enum (burst/cone/line) + `aoe_length` / `aoe_width` / `aoe_radius` per shape; loader defaults missing shape to `burst` (AOE-4); validator rejects mismatched dimensions (AOE-5/6). |
+| Geometry helpers | AOE-7..AOE-11 | Pure-function `BurstCells / ConeCells / LineCells / FacingFrom` in `internal/game/combat/geometry.go`; cone/line exclude apex (AOE-10); no occlusion consulted (AOE-11). |
+| Wire format | AOE-12..AOE-16 | `AoeTemplate{shape, anchor_x, anchor_y, facing, cells}` proto; `UseRequest.template` optional; cone/line require `template`, burst accepts either (AOE-13); legacy `target_x/y` retained for back-compat (AOE-16). |
+| Resolver | AOE-17..AOE-21 | `CellsForTemplate -> PostFilterAffectedCells -> CombatantsInCells -> effect application`; empty intersection still consumes AP (AOE-20); `PostFilterAffectedCells` is a no-op extension point reserved for #267 (AOE-21). |
+| Placement UX | AOE-22..AOE-32 | Telnet aim/face/confirm/cancel mode with 60s timeout; web `aoePlacement` state with mouse-driven anchor/facing and Enter/Esc bindings. *Deferred to a follow-up issue.* |
+| Content migration | AOE-33..AOE-35 | Explicit `aoe_shape: burst` on existing entries (done); cone/line exemplar migration deferred. |
+
+### Geometry helpers (`internal/game/combat/geometry.go`)
+
+| Helper | Signature | Notes |
+|--------|-----------|-------|
+| `BurstCells` | `(center Cell, radiusFt int) []Cell` | Includes center; Chebyshev distance, 5 ft per cell. |
+| `ConeCells` | `(apex Cell, dir Direction, lengthFt int) []Cell` | 90 degree octant wedge; excludes apex (AOE-10). |
+| `LineCells` | `(apex Cell, dir Direction, lengthFt, widthFt int) []Cell` | Excludes apex; width defaults to 5 ft (one cell). |
+| `FacingFrom` | `(from Cell, to Cell) Direction` | Rounds to nearest of 8 octants (N..NW), preferring axial in ties. |
+| `CellsForTemplate` | `(tmpl *AoeTemplate, content AoeContent) []Cell` | Dispatches by `tmpl.Shape`; reads dimensions from content. |
+| `combat.CombatantsInCells` | `(cbt *Combat, cells []Cell) []*Combatant` | Returns living combatants only; mirrors `CombatantsInRadius` filter (AOE-18). `CombatantsInRadius` retained as a thin wrapper (AOE-19). |
+
+### Resolver pipeline
+
+```
+1. affectedCells   = geometry.CellsForTemplate(template, content)        // AOE-17
+2. affectedCells   = resolver.PostFilterAffectedCells(cells, ctx)        // AOE-21 (identity in v1)
+3. affectedTargets = combat.CombatantsInCells(cbt, affectedCells)        // AOE-18
+4. for each target: applyEffect(action, target)                          // existing effect.Resolve path
+```
+
+`PostFilterAffectedCells` is the single seam where #267 (visibility / line-of-sight) will
+plug in without further resolver edits. v1 returns the input slice unchanged.
+
+### Back-compat
+
+When a `UseRequest` arrives with `template == nil` and valid `target_x` / `target_y`, the
+server synthesises a burst template centred on those coordinates using the content's
+`aoe_radius` (AOE-16). This preserves existing macros and aliases. The synthetic template
+is the only path by which `template == nil` is accepted; cone and line shapes always
+require an explicit `template` (AOE-13).
+
+### Validation
+
+Shape-specific load-time validation rejects authoring mistakes:
+
+| Shape | Required dimensions | Forbidden |
+|-------|---------------------|-----------|
+| `burst` | `aoe_radius > 0` | `aoe_length` / `aoe_width` set |
+| `cone` | `aoe_length > 0` | `aoe_radius` / `aoe_width` set |
+| `line` | `aoe_length > 0` (`aoe_width` defaults to 5 ft) | `aoe_radius` set |
+
+### Implementation files
+
+| File | Responsibility |
+|------|----------------|
+| `internal/game/combat/geometry.go` | `BurstCells`, `ConeCells`, `LineCells`, `FacingFrom`, `CellsForTemplate`, `Direction` |
+| `internal/game/combat/aoe.go` | `CombatantsInCells`, `CombatantsInRadius` (back-compat wrapper) |
+| `internal/gameserver/grpc_service.go` | Resolver swap (AOE-17): `CellsForTemplate -> PostFilterAffectedCells -> CombatantsInCells` |
+| `api/proto/game/v1/game.proto` | `AoeTemplate` message; `UseRequest.template` field |
+| `internal/game/loader/*.go` | `aoe_shape` / `aoe_length` / `aoe_width` parsing on `TechnologyDef`, `ClassFeatureDef`, `FeatDef`, `Explosive`; AOE-5 / AOE-6 validation |
+
+### Follow-up
+
+Interactive placement UX (telnet aim/face/confirm/cancel and the web `AoePlacement`
+component) is tracked as a follow-up to #250. The core resolver is functional end-to-end
+today: clients can submit programmatic `AoeTemplate` messages without an interactive
+placement step.
+
 ## Component Dependencies
 
 ```mermaid

--- a/internal/game/aoe/aoe_shape.go
+++ b/internal/game/aoe/aoe_shape.go
@@ -1,0 +1,133 @@
+// Package aoe defines the shared AoE (area-of-effect) shape vocabulary used by
+// content types that may produce a templated area effect — feats, class
+// features, technologies, and explosives.
+//
+// The package contains only value-typed declarations and pure validation; it
+// imports nothing from the rest of the game so it can be safely depended on by
+// every content package without risking an import cycle.
+package aoe
+
+import "fmt"
+
+// AoeShape names the geometric template a content definition produces.
+//
+// AoeShapeNone (the zero value, "") indicates no AoE — single-target.
+// AoeShapeBurst is a Chebyshev-radius burst centered on a target cell.
+// AoeShapeCone is a PF2E cone anchored at an apex with a facing.
+// AoeShapeLine is a PF2E line with length and width centered on a facing.
+type AoeShape string
+
+const (
+	// AoeShapeNone is the zero value indicating no area effect.
+	AoeShapeNone AoeShape = ""
+	// AoeShapeBurst is a square (Chebyshev) burst centered on a cell.
+	AoeShapeBurst AoeShape = "burst"
+	// AoeShapeCone is a PF2E cone anchored at an apex.
+	AoeShapeCone AoeShape = "cone"
+	// AoeShapeLine is a PF2E line oriented along a facing.
+	AoeShapeLine AoeShape = "line"
+)
+
+// DefaultLineWidthFt is the width applied when aoe_shape is "line" but
+// aoe_width is unset or zero. Per AOE-3 a default line is 5 ft wide
+// (one cell across).
+const DefaultLineWidthFt = 5
+
+// IsValidShape reports whether s is a recognised AoeShape value (including
+// the empty AoeShapeNone).
+func IsValidShape(s AoeShape) bool {
+	switch s {
+	case AoeShapeNone, AoeShapeBurst, AoeShapeCone, AoeShapeLine:
+		return true
+	}
+	return false
+}
+
+// ValidateAoeFields enforces the AoE-shape field rules across all content
+// types that carry an AoE template.
+//
+// Rules (AOE-3 / AOE-4 / AOE-5 / AOE-6):
+//
+//   - aoe_shape == "" and aoe_radius == 0 → no AoE, no error.
+//   - aoe_shape == "" and aoe_radius > 0  → legacy burst form (back-compat).
+//     aoe_length and aoe_width must be 0.
+//   - aoe_shape == "burst" → aoe_radius must be > 0; aoe_length must be 0.
+//     aoe_width is ignored.
+//   - aoe_shape == "cone"  → aoe_length must be > 0; aoe_radius and
+//     aoe_width must be 0.
+//   - aoe_shape == "line"  → aoe_length must be > 0; aoe_radius must be 0.
+//     aoe_width may be 0 (caller defaults to DefaultLineWidthFt) or > 0.
+//
+// All numeric fields must be non-negative.
+//
+// Precondition: none.
+// Postcondition: returns nil iff the combination is legal under the rules
+// above; otherwise returns a non-nil error whose message names the offending
+// field(s).
+func ValidateAoeFields(shape AoeShape, radiusFt, lengthFt, widthFt int) error {
+	if !IsValidShape(shape) {
+		return fmt.Errorf("aoe_shape %q is not a recognised shape", shape)
+	}
+	if radiusFt < 0 {
+		return fmt.Errorf("aoe_radius must be >= 0, got %d", radiusFt)
+	}
+	if lengthFt < 0 {
+		return fmt.Errorf("aoe_length must be >= 0, got %d", lengthFt)
+	}
+	if widthFt < 0 {
+		return fmt.Errorf("aoe_width must be >= 0, got %d", widthFt)
+	}
+	switch shape {
+	case AoeShapeNone:
+		// No explicit shape: legacy form. Only aoe_radius may be set.
+		if lengthFt > 0 {
+			return fmt.Errorf("aoe_length is only valid with aoe_shape: cone or line")
+		}
+		if widthFt > 0 {
+			return fmt.Errorf("aoe_width is only valid with aoe_shape: line")
+		}
+	case AoeShapeBurst:
+		if radiusFt <= 0 {
+			return fmt.Errorf("aoe_shape: burst requires aoe_radius > 0")
+		}
+		if lengthFt > 0 {
+			return fmt.Errorf("aoe_shape: burst does not accept aoe_length")
+		}
+		if widthFt > 0 {
+			return fmt.Errorf("aoe_shape: burst does not accept aoe_width")
+		}
+	case AoeShapeCone:
+		if lengthFt <= 0 {
+			return fmt.Errorf("aoe_shape: cone requires aoe_length > 0")
+		}
+		if radiusFt > 0 {
+			return fmt.Errorf("aoe_shape: cone does not accept aoe_radius")
+		}
+		if widthFt > 0 {
+			return fmt.Errorf("aoe_shape: cone does not accept aoe_width")
+		}
+	case AoeShapeLine:
+		if lengthFt <= 0 {
+			return fmt.Errorf("aoe_shape: line requires aoe_length > 0")
+		}
+		if radiusFt > 0 {
+			return fmt.Errorf("aoe_shape: line does not accept aoe_radius")
+		}
+		// widthFt may be 0 (caller defaults) or any positive value.
+	}
+	return nil
+}
+
+// ResolveLineWidth returns the effective line width in feet given the raw
+// widthFt field. Callers that have already passed ValidateAoeFields with
+// AoeShapeLine should use this helper to substitute the default when the
+// raw field is zero.
+//
+// Precondition: shape == AoeShapeLine; widthFt >= 0.
+// Postcondition: returns DefaultLineWidthFt when widthFt == 0, else widthFt.
+func ResolveLineWidth(widthFt int) int {
+	if widthFt == 0 {
+		return DefaultLineWidthFt
+	}
+	return widthFt
+}

--- a/internal/game/aoe/aoe_shape_test.go
+++ b/internal/game/aoe/aoe_shape_test.go
@@ -1,0 +1,95 @@
+package aoe
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAoeFields_Legacy(t *testing.T) {
+	// No shape, no radius → no AoE, no error.
+	if err := ValidateAoeFields(AoeShapeNone, 0, 0, 0); err != nil {
+		t.Fatalf("expected nil for empty shape with no radius; got %v", err)
+	}
+	// Legacy burst back-compat: no shape, positive radius.
+	if err := ValidateAoeFields(AoeShapeNone, 10, 0, 0); err != nil {
+		t.Fatalf("expected nil for legacy aoe_radius back-compat; got %v", err)
+	}
+	// Legacy form must reject aoe_length / aoe_width.
+	if err := ValidateAoeFields(AoeShapeNone, 0, 10, 0); err == nil {
+		t.Fatal("expected error when aoe_length set without aoe_shape")
+	}
+	if err := ValidateAoeFields(AoeShapeNone, 0, 0, 5); err == nil {
+		t.Fatal("expected error when aoe_width set without aoe_shape")
+	}
+}
+
+func TestValidateAoeFields_Burst(t *testing.T) {
+	if err := ValidateAoeFields(AoeShapeBurst, 10, 0, 0); err != nil {
+		t.Fatalf("expected nil for burst with radius; got %v", err)
+	}
+	if err := ValidateAoeFields(AoeShapeBurst, 0, 0, 0); err == nil {
+		t.Fatal("expected error: burst requires aoe_radius > 0")
+	}
+	err := ValidateAoeFields(AoeShapeBurst, 10, 30, 0)
+	if err == nil || !strings.Contains(err.Error(), "aoe_length") {
+		t.Fatalf("expected aoe_length error for burst+length; got %v", err)
+	}
+}
+
+func TestValidateAoeFields_Cone(t *testing.T) {
+	if err := ValidateAoeFields(AoeShapeCone, 0, 30, 0); err != nil {
+		t.Fatalf("expected nil for cone with length; got %v", err)
+	}
+	err := ValidateAoeFields(AoeShapeCone, 0, 0, 0)
+	if err == nil || !strings.Contains(err.Error(), "aoe_length") {
+		t.Fatalf("expected aoe_length error for cone with no length; got %v", err)
+	}
+	if err := ValidateAoeFields(AoeShapeCone, 10, 30, 0); err == nil {
+		t.Fatal("expected error: cone does not accept aoe_radius")
+	}
+}
+
+func TestValidateAoeFields_Line(t *testing.T) {
+	// Line with length, default width.
+	if err := ValidateAoeFields(AoeShapeLine, 0, 30, 0); err != nil {
+		t.Fatalf("expected nil for line with length and default width; got %v", err)
+	}
+	// Line with explicit width.
+	if err := ValidateAoeFields(AoeShapeLine, 0, 30, 10); err != nil {
+		t.Fatalf("expected nil for line with explicit width; got %v", err)
+	}
+	err := ValidateAoeFields(AoeShapeLine, 0, 0, 5)
+	if err == nil || !strings.Contains(err.Error(), "aoe_length") {
+		t.Fatalf("expected aoe_length error for line with no length; got %v", err)
+	}
+	if err := ValidateAoeFields(AoeShapeLine, 10, 30, 0); err == nil {
+		t.Fatal("expected error: line does not accept aoe_radius")
+	}
+}
+
+func TestValidateAoeFields_NegativeFields(t *testing.T) {
+	if err := ValidateAoeFields(AoeShapeNone, -1, 0, 0); err == nil {
+		t.Fatal("expected error for negative radius")
+	}
+	if err := ValidateAoeFields(AoeShapeCone, 0, -1, 0); err == nil {
+		t.Fatal("expected error for negative length")
+	}
+	if err := ValidateAoeFields(AoeShapeLine, 0, 30, -1); err == nil {
+		t.Fatal("expected error for negative width")
+	}
+}
+
+func TestValidateAoeFields_UnknownShape(t *testing.T) {
+	if err := ValidateAoeFields(AoeShape("orb"), 0, 0, 0); err == nil {
+		t.Fatal("expected error for unknown shape")
+	}
+}
+
+func TestResolveLineWidth(t *testing.T) {
+	if got := ResolveLineWidth(0); got != DefaultLineWidthFt {
+		t.Fatalf("ResolveLineWidth(0) = %d; want %d", got, DefaultLineWidthFt)
+	}
+	if got := ResolveLineWidth(15); got != 15 {
+		t.Fatalf("ResolveLineWidth(15) = %d; want 15", got)
+	}
+}

--- a/internal/game/combat/aoe.go
+++ b/internal/game/combat/aoe.go
@@ -1,15 +1,39 @@
 package combat
 
-// CombatantsInRadius returns all living combatants within radiusFt feet (Chebyshev) of center.
+// CombatantsInCells returns all living combatants whose grid cell appears in the
+// provided cell set. Order follows cbt.Combatants iteration order.
 //
-// Precondition: cbt must not be nil; radiusFt must be >= 0.
-// Postcondition: returned slice contains only non-dead combatants within range; nil if none.
-func CombatantsInRadius(cbt *Combat, center Combatant, radiusFt int) []*Combatant {
+// Precondition: cbt must not be nil.
+// Postcondition: returned slice contains only non-dead combatants whose
+// (GridX, GridY) is a member of cells; nil if none.
+func CombatantsInCells(cbt *Combat, cells []Cell) []*Combatant {
+	if len(cells) == 0 {
+		return nil
+	}
+	inSet := make(map[Cell]struct{}, len(cells))
+	for _, c := range cells {
+		inSet[c] = struct{}{}
+	}
 	var result []*Combatant
 	for _, c := range cbt.Combatants {
-		if !c.IsDead() && CombatRange(*c, center) <= radiusFt {
+		if c.IsDead() {
+			continue
+		}
+		if _, ok := inSet[Cell{X: c.GridX, Y: c.GridY}]; ok {
 			result = append(result, c)
 		}
 	}
 	return result
+}
+
+// CombatantsInRadius returns all living combatants within radiusFt feet (Chebyshev) of center.
+//
+// Precondition: cbt must not be nil; radiusFt must be >= 0.
+// Postcondition: returned slice contains only non-dead combatants within range; nil if none.
+//
+// Implementation note (AOE-19): retained as a thin wrapper for back-compat;
+// delegates to CombatantsInCells over BurstCells so behaviour stays in lock-step
+// with the cell-based AOE pipeline.
+func CombatantsInRadius(cbt *Combat, center Combatant, radiusFt int) []*Combatant {
+	return CombatantsInCells(cbt, BurstCells(Cell{X: center.GridX, Y: center.GridY}, radiusFt))
 }

--- a/internal/game/combat/aoe_test.go
+++ b/internal/game/combat/aoe_test.go
@@ -104,6 +104,41 @@ func TestProperty_CombatantsInRadius_NeverReturnsDead(t *testing.T) {
 	})
 }
 
+// REQ-AOE-HELPER-8: CombatantsInCells returns only living combatants whose cell
+// is in the input set; dead combatants and off-set combatants are excluded.
+func TestCombatantsInCells_FiltersDeadAndOffSet(t *testing.T) {
+	a := &Combatant{ID: "a", GridX: 5, GridY: 5, Dead: false, CurrentHP: 10}
+	b := &Combatant{ID: "b", GridX: 6, GridY: 6, Dead: true, CurrentHP: 0}
+	c := &Combatant{ID: "c", GridX: 9, GridY: 9, Dead: false, CurrentHP: 10}
+	cbt := &Combat{Combatants: []*Combatant{a, b, c}}
+
+	got := CombatantsInCells(cbt, []Cell{{X: 5, Y: 5}, {X: 6, Y: 6}})
+
+	require.Len(t, got, 1)
+	assert.Same(t, a, got[0])
+}
+
+// REQ-AOE-HELPER-9: CombatantsInCells returns nil for empty cell set.
+func TestCombatantsInCells_EmptyCells_ReturnsNil(t *testing.T) {
+	cbt := &Combat{Combatants: []*Combatant{
+		{ID: "a", GridX: 0, GridY: 0, CurrentHP: 10},
+	}}
+	assert.Nil(t, CombatantsInCells(cbt, nil))
+	assert.Nil(t, CombatantsInCells(cbt, []Cell{}))
+}
+
+// REQ-AOE-HELPER-10: CombatantsInRadius regression — behaviour after refactor
+// to delegate through CombatantsInCells/BurstCells matches Chebyshev distance.
+func TestCombatantsInRadius_RegressionAfterRefactor(t *testing.T) {
+	a := &Combatant{ID: "a", GridX: 5, GridY: 5, Dead: false, CurrentHP: 10}
+	b := &Combatant{ID: "b", GridX: 5, GridY: 6, Dead: false, CurrentHP: 10}
+	cbt := &Combat{Combatants: []*Combatant{a, b}}
+	center := Combatant{GridX: 5, GridY: 5}
+
+	got := CombatantsInRadius(cbt, center, 10)
+	require.Len(t, got, 2)
+}
+
 // REQ-AOE-HELPER-7 (property): All returned combatants are within radiusFt of center.
 func TestProperty_CombatantsInRadius_AllWithinRadius(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {

--- a/internal/game/combat/geometry.go
+++ b/internal/game/combat/geometry.go
@@ -1,0 +1,243 @@
+package combat
+
+// Cell is an integer (x,y) coordinate on the combat grid. Cells correspond to
+// 5-foot squares. Cell{0,0} is the apex/origin used by AOE templates.
+type Cell struct {
+	X int
+	Y int
+}
+
+// Direction is one of eight compass octants used to orient cone and line AOEs.
+type Direction int
+
+// Direction octants. The numeric values follow a clockwise sweep starting
+// from north; tests in this package depend on the iota order being stable.
+const (
+	DirN Direction = iota
+	DirNE
+	DirE
+	DirSE
+	DirS
+	DirSW
+	DirW
+	DirNW
+)
+
+// facingDelta returns the unit (dx, dy) vector for a facing direction.
+//
+// On the combat grid, +X is east and +Y is south (screen-style coordinates).
+// Diagonal facings return both components ±1; the helpers that consume the
+// delta interpret distance in Chebyshev squares so the unit vector need not
+// be normalised.
+func facingDelta(d Direction) (int, int) {
+	switch d {
+	case DirN:
+		return 0, -1
+	case DirNE:
+		return 1, -1
+	case DirE:
+		return 1, 0
+	case DirSE:
+		return 1, 1
+	case DirS:
+		return 0, 1
+	case DirSW:
+		return -1, 1
+	case DirW:
+		return -1, 0
+	case DirNW:
+		return -1, -1
+	default:
+		return 0, 0
+	}
+}
+
+// isDiagonal reports whether the facing is one of the four diagonal octants.
+func isDiagonal(d Direction) bool {
+	fdx, fdy := facingDelta(d)
+	return fdx != 0 && fdy != 0
+}
+
+// BurstCells returns every cell within Chebyshev radius radiusFt/5 of center,
+// inclusive of the center itself. The result has exactly (2r+1)^2 entries
+// where r = radiusFt/5.
+//
+// Precondition: radiusFt must be >= 0.
+// Postcondition: the returned slice contains center; no duplicate cells; every
+// cell c satisfies max(|c.X-center.X|, |c.Y-center.Y|) <= radiusFt/5.
+func BurstCells(center Cell, radiusFt int) []Cell {
+	rad := radiusFt / 5
+	if rad < 0 {
+		rad = 0
+	}
+	out := make([]Cell, 0, (2*rad+1)*(2*rad+1))
+	for dy := -rad; dy <= rad; dy++ {
+		for dx := -rad; dx <= rad; dx++ {
+			out = append(out, Cell{X: center.X + dx, Y: center.Y + dy})
+		}
+	}
+	return out
+}
+
+// ConeCells returns every cell inside the PF2E cone template anchored at apex
+// and oriented toward facing, of length lengthFt feet. Per AOE-10 the apex is
+// excluded from the result.
+//
+// The implementation forms a Chebyshev half-square (cardinal facings) or
+// quadrant (diagonal facings) of depth lengthFt/5, omitting any cell whose
+// offset from the apex has a non-positive dot product with the facing vector.
+//
+// Precondition: lengthFt must be >= 0.
+// Postcondition: every returned cell c satisfies
+//
+//	max(|c.X-apex.X|, |c.Y-apex.Y|) <= lengthFt/5
+//
+// and c != apex.
+func ConeCells(apex Cell, facing Direction, lengthFt int) []Cell {
+	depth := lengthFt / 5
+	if depth <= 0 {
+		return nil
+	}
+	fdx, fdy := facingDelta(facing)
+	diag := isDiagonal(facing)
+
+	out := make([]Cell, 0, (2*depth+1)*(2*depth+1))
+	for dy := -depth; dy <= depth; dy++ {
+		for dx := -depth; dx <= depth; dx++ {
+			if dx == 0 && dy == 0 {
+				continue // AOE-10: exclude apex
+			}
+			if diag {
+				// Diagonal cone: include only the quadrant matching the facing.
+				if fdx != 0 && dx*fdx < 0 {
+					continue
+				}
+				if fdy != 0 && dy*fdy < 0 {
+					continue
+				}
+				if dx == 0 || dy == 0 {
+					// Cells on the cardinal axes are not part of the diagonal cone.
+					continue
+				}
+			} else {
+				// Cardinal cone: include the half-plane facing direction, with
+				// |perpendicular offset| <= |facing offset| forming a triangle.
+				if fdx != 0 {
+					if dx*fdx <= 0 {
+						continue
+					}
+					if abs(dy) > abs(dx) {
+						continue
+					}
+				}
+				if fdy != 0 {
+					if dy*fdy <= 0 {
+						continue
+					}
+					if abs(dx) > abs(dy) {
+						continue
+					}
+				}
+			}
+			out = append(out, Cell{X: apex.X + dx, Y: apex.Y + dy})
+		}
+	}
+	return out
+}
+
+// LineCells returns every cell inside the PF2E line template originating at
+// origin, oriented toward facing, of length lengthFt feet and width widthFt
+// feet (centered on the facing axis). Per AOE-10 the origin cell is excluded.
+//
+// Length is measured in 5-ft cells (lengthFt/5 cells deep). Width is measured
+// in 5-ft cells (widthFt/5 cells across). When width is even the line is
+// centered with a one-cell offset toward the negative perpendicular axis;
+// when odd the line is exactly centered.
+//
+// Precondition: lengthFt must be >= 0; widthFt must be >= 5 to produce any
+// cells (a line with width < 5 ft has no thickness).
+// Postcondition: returned slice has at most (lengthFt/5)*(widthFt/5) cells;
+// origin is not included.
+func LineCells(origin Cell, facing Direction, lengthFt, widthFt int) []Cell {
+	depth := lengthFt / 5
+	width := widthFt / 5
+	if depth <= 0 || width <= 0 {
+		return nil
+	}
+	fdx, fdy := facingDelta(facing)
+	// Perpendicular axis: rotate facing 90° clockwise.
+	pdx, pdy := -fdy, fdx
+
+	// Centered range of width cells: w0..w1 inclusive.
+	w0 := -((width - 1) / 2)
+	w1 := width / 2
+
+	out := make([]Cell, 0, depth*width)
+	for d := 1; d <= depth; d++ {
+		for w := w0; w <= w1; w++ {
+			cx := origin.X + d*fdx + w*pdx
+			cy := origin.Y + d*fdy + w*pdy
+			out = append(out, Cell{X: cx, Y: cy})
+		}
+	}
+	return out
+}
+
+// FacingFrom returns the cardinal or diagonal Direction that best approximates
+// the vector from src to dst. Axial directions win ties (i.e. when
+// |dx| == |dy| the diagonal is selected, but pure-axial vectors with the
+// other component equal to zero always select the matching cardinal).
+//
+// When src == dst, FacingFrom returns DirN as a stable default.
+//
+// Precondition: none.
+// Postcondition: returned Direction is in [DirN, DirNW].
+func FacingFrom(src, dst Cell) Direction {
+	dx := dst.X - src.X
+	dy := dst.Y - src.Y
+	if dx == 0 && dy == 0 {
+		return DirN
+	}
+	return facingFromDelta(dx, dy)
+}
+
+// facingFromDelta classifies an integer offset into one of eight octants.
+// The classifier uses the ratio of |dx| and |dy|: components within a factor
+// of two of each other produce a diagonal; otherwise the larger axis wins.
+func facingFromDelta(dx, dy int) Direction {
+	adx := abs(dx)
+	ady := abs(dy)
+	// Cardinal: one component dominates by 2× or more.
+	if adx >= 2*ady {
+		if dx > 0 {
+			return DirE
+		}
+		return DirW
+	}
+	if ady >= 2*adx {
+		if dy > 0 {
+			return DirS
+		}
+		return DirN
+	}
+	// Diagonal quadrant.
+	switch {
+	case dx > 0 && dy < 0:
+		return DirNE
+	case dx > 0 && dy > 0:
+		return DirSE
+	case dx < 0 && dy > 0:
+		return DirSW
+	case dx < 0 && dy < 0:
+		return DirNW
+	}
+	// Should be unreachable given the cardinal short-circuits above.
+	return DirN
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/game/combat/geometry_test.go
+++ b/internal/game/combat/geometry_test.go
@@ -1,0 +1,354 @@
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	"pgregory.net/rapid"
+)
+
+func absInt(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// TestProperty_BurstCellsBoundedChebyshev asserts that BurstCells emits
+// exactly (2r+1)^2 cells and that every cell lies within Chebyshev radius r
+// of the center, where r = radiusFt/5.
+func TestProperty_BurstCellsBoundedChebyshev(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		cx := rapid.IntRange(-50, 50).Draw(t, "cx")
+		cy := rapid.IntRange(-50, 50).Draw(t, "cy")
+		radiusFt := rapid.IntRange(5, 60).Draw(t, "radiusFt")
+		cells := combat.BurstCells(combat.Cell{X: cx, Y: cy}, radiusFt)
+		rad := radiusFt / 5
+		for _, c := range cells {
+			dx := absInt(c.X - cx)
+			dy := absInt(c.Y - cy)
+			if maxInt(dx, dy) > rad {
+				t.Fatalf("cell %+v outside Chebyshev radius %d of (%d,%d)", c, rad, cx, cy)
+			}
+		}
+		if want := (2*rad + 1) * (2*rad + 1); len(cells) != want {
+			t.Fatalf("burst count: want %d got %d", want, len(cells))
+		}
+	})
+}
+
+// TestProperty_ConeCellsAlignedToFacing asserts that ConeCells excludes the
+// apex (AOE-10) and that every emitted cell lies within the cone's Chebyshev
+// length from the apex.
+func TestProperty_ConeCellsAlignedToFacing(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir := combat.Direction(rapid.IntRange(0, 7).Draw(t, "dir"))
+		lengthFt := rapid.IntRange(5, 60).Draw(t, "lenFt")
+		apex := combat.Cell{X: 0, Y: 0}
+		cells := combat.ConeCells(apex, dir, lengthFt)
+		for _, c := range cells {
+			if c == apex {
+				t.Fatalf("apex must be excluded (AOE-10); got %+v", c)
+			}
+			d := maxInt(absInt(c.X), absInt(c.Y))
+			if d > lengthFt/5 {
+				t.Fatalf("cone cell %+v exceeds cone length %d (cells)", c, lengthFt/5)
+			}
+		}
+	})
+}
+
+// TestProperty_LineCellsThicknessAndLength asserts that LineCells respects
+// the depth*width budget. The +1 slack handles odd-width centering.
+func TestProperty_LineCellsThicknessAndLength(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir := combat.Direction(rapid.IntRange(0, 7).Draw(t, "dir"))
+		lengthFt := rapid.IntRange(5, 50).Draw(t, "lenFt")
+		widthFt := rapid.IntRange(5, 25).Draw(t, "widthFt")
+		cells := combat.LineCells(combat.Cell{X: 0, Y: 0}, dir, lengthFt, widthFt)
+		wantLen := (lengthFt / 5) * (widthFt / 5)
+		if len(cells) > wantLen+1 {
+			t.Fatalf("line cells exceeded length*width budget: got %d, max %d",
+				len(cells), wantLen+1)
+		}
+		// AOE-10: origin is never in the result.
+		for _, c := range cells {
+			if c.X == 0 && c.Y == 0 {
+				t.Fatalf("origin must be excluded (AOE-10); got %+v", c)
+			}
+		}
+	})
+}
+
+// TestBurstCells_ZeroRadius_ReturnsCenterOnly verifies the degenerate case.
+func TestBurstCells_ZeroRadius_ReturnsCenterOnly(t *testing.T) {
+	cells := combat.BurstCells(combat.Cell{X: 3, Y: 4}, 0)
+	if len(cells) != 1 || cells[0] != (combat.Cell{X: 3, Y: 4}) {
+		t.Fatalf("zero-radius burst: want [{3,4}] got %+v", cells)
+	}
+}
+
+// TestConeCells_GoldenVectors_Cardinal hand-verifies a 10-ft cone (depth=2)
+// for every cardinal facing. The PF2E cardinal cone forms a square fan that
+// is 2d+1 cells wide at depth d, yielding 3+5 = 8 cells at length 10ft.
+func TestConeCells_GoldenVectors_Cardinal(t *testing.T) {
+	apex := combat.Cell{X: 0, Y: 0}
+	tests := []struct {
+		name string
+		dir  combat.Direction
+		want map[combat.Cell]bool
+	}{
+		{
+			name: "north",
+			dir:  combat.DirN,
+			want: map[combat.Cell]bool{
+				{X: -1, Y: -1}: true, {X: 0, Y: -1}: true, {X: 1, Y: -1}: true,
+				{X: -2, Y: -2}: true, {X: -1, Y: -2}: true, {X: 0, Y: -2}: true,
+				{X: 1, Y: -2}: true, {X: 2, Y: -2}: true,
+			},
+		},
+		{
+			name: "east",
+			dir:  combat.DirE,
+			want: map[combat.Cell]bool{
+				{X: 1, Y: -1}: true, {X: 1, Y: 0}: true, {X: 1, Y: 1}: true,
+				{X: 2, Y: -2}: true, {X: 2, Y: -1}: true, {X: 2, Y: 0}: true,
+				{X: 2, Y: 1}: true, {X: 2, Y: 2}: true,
+			},
+		},
+		{
+			name: "south",
+			dir:  combat.DirS,
+			want: map[combat.Cell]bool{
+				{X: -1, Y: 1}: true, {X: 0, Y: 1}: true, {X: 1, Y: 1}: true,
+				{X: -2, Y: 2}: true, {X: -1, Y: 2}: true, {X: 0, Y: 2}: true,
+				{X: 1, Y: 2}: true, {X: 2, Y: 2}: true,
+			},
+		},
+		{
+			name: "west",
+			dir:  combat.DirW,
+			want: map[combat.Cell]bool{
+				{X: -1, Y: -1}: true, {X: -1, Y: 0}: true, {X: -1, Y: 1}: true,
+				{X: -2, Y: -2}: true, {X: -2, Y: -1}: true, {X: -2, Y: 0}: true,
+				{X: -2, Y: 1}: true, {X: -2, Y: 2}: true,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := combat.ConeCells(apex, tc.dir, 10)
+			gotSet := make(map[combat.Cell]bool, len(got))
+			for _, c := range got {
+				gotSet[c] = true
+			}
+			if len(gotSet) != len(tc.want) {
+				t.Fatalf("%s: cell count: want %d got %d (cells=%+v)",
+					tc.name, len(tc.want), len(gotSet), got)
+			}
+			for c := range tc.want {
+				if !gotSet[c] {
+					t.Errorf("%s: missing expected cell %+v", tc.name, c)
+				}
+			}
+			for c := range gotSet {
+				if !tc.want[c] {
+					t.Errorf("%s: unexpected cell %+v", tc.name, c)
+				}
+			}
+		})
+	}
+}
+
+// TestConeCells_GoldenVectors_Diagonal hand-verifies the four diagonal cones
+// at 10ft (depth=2). Each diagonal cone spans the matching quadrant with the
+// cardinal axes excluded, yielding the 2x2 quadrant interior (4 cells).
+func TestConeCells_GoldenVectors_Diagonal(t *testing.T) {
+	apex := combat.Cell{X: 0, Y: 0}
+	tests := []struct {
+		name string
+		dir  combat.Direction
+		want map[combat.Cell]bool
+	}{
+		{
+			name: "northeast",
+			dir:  combat.DirNE,
+			want: map[combat.Cell]bool{
+				{X: 1, Y: -1}: true,
+				{X: 1, Y: -2}: true,
+				{X: 2, Y: -1}: true,
+				{X: 2, Y: -2}: true,
+			},
+		},
+		{
+			name: "southeast",
+			dir:  combat.DirSE,
+			want: map[combat.Cell]bool{
+				{X: 1, Y: 1}: true,
+				{X: 1, Y: 2}: true,
+				{X: 2, Y: 1}: true,
+				{X: 2, Y: 2}: true,
+			},
+		},
+		{
+			name: "southwest",
+			dir:  combat.DirSW,
+			want: map[combat.Cell]bool{
+				{X: -1, Y: 1}: true,
+				{X: -1, Y: 2}: true,
+				{X: -2, Y: 1}: true,
+				{X: -2, Y: 2}: true,
+			},
+		},
+		{
+			name: "northwest",
+			dir:  combat.DirNW,
+			want: map[combat.Cell]bool{
+				{X: -1, Y: -1}: true,
+				{X: -1, Y: -2}: true,
+				{X: -2, Y: -1}: true,
+				{X: -2, Y: -2}: true,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := combat.ConeCells(apex, tc.dir, 10)
+			gotSet := make(map[combat.Cell]bool, len(got))
+			for _, c := range got {
+				gotSet[c] = true
+			}
+			if len(gotSet) != len(tc.want) {
+				t.Fatalf("%s: cell count: want %d got %d (cells=%+v)",
+					tc.name, len(tc.want), len(gotSet), got)
+			}
+			for c := range tc.want {
+				if !gotSet[c] {
+					t.Errorf("%s: missing expected cell %+v", tc.name, c)
+				}
+			}
+			for c := range gotSet {
+				if !tc.want[c] {
+					t.Errorf("%s: unexpected cell %+v", tc.name, c)
+				}
+			}
+		})
+	}
+}
+
+// TestLineCells_GoldenVector_East hand-verifies a 15-ft long, 15-ft wide line
+// pointing east from the origin: depth=3, width=3, total=9 cells.
+func TestLineCells_GoldenVector_East(t *testing.T) {
+	got := combat.LineCells(combat.Cell{X: 0, Y: 0}, combat.DirE, 15, 15)
+	want := map[combat.Cell]bool{
+		{X: 1, Y: -1}: true, {X: 1, Y: 0}: true, {X: 1, Y: 1}: true,
+		{X: 2, Y: -1}: true, {X: 2, Y: 0}: true, {X: 2, Y: 1}: true,
+		{X: 3, Y: -1}: true, {X: 3, Y: 0}: true, {X: 3, Y: 1}: true,
+	}
+	gotSet := make(map[combat.Cell]bool, len(got))
+	for _, c := range got {
+		gotSet[c] = true
+	}
+	if len(gotSet) != len(want) {
+		t.Fatalf("east line: count: want %d got %d (cells=%+v)", len(want), len(gotSet), got)
+	}
+	for c := range want {
+		if !gotSet[c] {
+			t.Errorf("east line: missing %+v", c)
+		}
+	}
+}
+
+// TestLineCells_GoldenVector_NorthWidth5 verifies a 10-ft long, 5-ft wide
+// line pointing north: depth=2, width=1, total=2 cells, exactly along the
+// facing axis.
+func TestLineCells_GoldenVector_NorthWidth5(t *testing.T) {
+	got := combat.LineCells(combat.Cell{X: 0, Y: 0}, combat.DirN, 10, 5)
+	want := []combat.Cell{{X: 0, Y: -1}, {X: 0, Y: -2}}
+	if len(got) != len(want) {
+		t.Fatalf("north line width=5: count: want %d got %d (%+v)", len(want), len(got), got)
+	}
+	gotSet := map[combat.Cell]bool{}
+	for _, c := range got {
+		gotSet[c] = true
+	}
+	for _, c := range want {
+		if !gotSet[c] {
+			t.Errorf("north line width=5: missing %+v", c)
+		}
+	}
+}
+
+// TestLineCells_GoldenVector_SoutheastDiagonal verifies a diagonal line: 10ft
+// long, 5ft wide pointing southeast yields cells stepping +1,+1 each square.
+func TestLineCells_GoldenVector_SoutheastDiagonal(t *testing.T) {
+	got := combat.LineCells(combat.Cell{X: 0, Y: 0}, combat.DirSE, 10, 5)
+	want := []combat.Cell{{X: 1, Y: 1}, {X: 2, Y: 2}}
+	if len(got) != len(want) {
+		t.Fatalf("SE line: count: want %d got %d (%+v)", len(want), len(got), got)
+	}
+	gotSet := map[combat.Cell]bool{}
+	for _, c := range got {
+		gotSet[c] = true
+	}
+	for _, c := range want {
+		if !gotSet[c] {
+			t.Errorf("SE line: missing %+v", c)
+		}
+	}
+}
+
+// TestFacingFrom_CardinalAxes verifies pure-axial vectors yield their cardinal.
+func TestFacingFrom_CardinalAxes(t *testing.T) {
+	src := combat.Cell{X: 5, Y: 5}
+	tests := []struct {
+		dst  combat.Cell
+		want combat.Direction
+	}{
+		{combat.Cell{X: 5, Y: 0}, combat.DirN},
+		{combat.Cell{X: 10, Y: 5}, combat.DirE},
+		{combat.Cell{X: 5, Y: 10}, combat.DirS},
+		{combat.Cell{X: 0, Y: 5}, combat.DirW},
+	}
+	for _, tc := range tests {
+		got := combat.FacingFrom(src, tc.dst)
+		if got != tc.want {
+			t.Errorf("FacingFrom(%+v -> %+v): want %d got %d", src, tc.dst, tc.want, got)
+		}
+	}
+}
+
+// TestFacingFrom_Diagonals verifies equal-magnitude offsets yield diagonals.
+func TestFacingFrom_Diagonals(t *testing.T) {
+	src := combat.Cell{X: 0, Y: 0}
+	tests := []struct {
+		dst  combat.Cell
+		want combat.Direction
+	}{
+		{combat.Cell{X: 3, Y: -3}, combat.DirNE},
+		{combat.Cell{X: 3, Y: 3}, combat.DirSE},
+		{combat.Cell{X: -3, Y: 3}, combat.DirSW},
+		{combat.Cell{X: -3, Y: -3}, combat.DirNW},
+	}
+	for _, tc := range tests {
+		got := combat.FacingFrom(src, tc.dst)
+		if got != tc.want {
+			t.Errorf("FacingFrom(%+v -> %+v): want %d got %d", src, tc.dst, tc.want, got)
+		}
+	}
+}
+
+// TestFacingFrom_Identity returns DirN for src == dst.
+func TestFacingFrom_Identity(t *testing.T) {
+	src := combat.Cell{X: 7, Y: 7}
+	if got := combat.FacingFrom(src, src); got != combat.DirN {
+		t.Errorf("FacingFrom(identity): want DirN got %d", got)
+	}
+}

--- a/internal/game/inventory/explosive.go
+++ b/internal/game/inventory/explosive.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/cory-johannsen/mud/internal/game/aoe"
 )
 
 // AreaType represents the area of effect for an explosive.
@@ -43,11 +45,20 @@ type ExplosiveDef struct {
 	// When false (default), only enemy-kind combatants are targeted.
 	// When true, all living combatants except the thrower are targeted.
 	FriendlyFire bool `yaml:"friendly_fire,omitempty"`
+	// AoeShape selects the AoE template geometry: "" (legacy / single-target /
+	// back-compat), "burst", "cone", or "line". When empty and AoERadius > 0
+	// the explosive is treated as an AoeShapeBurst (back-compat AOE-4).
+	AoeShape aoe.AoeShape `yaml:"aoe_shape,omitempty"`
 	// AoERadius is the blast radius in feet for AreaTypeBurst explosives.
 	// Stored for future position-based filtering; not actively used in target selection now.
 	// Zero means room-wide effect (current behavior).
-	AoERadius int      `yaml:"aoe_radius,omitempty"`
-	Traits    []string `yaml:"traits"`
+	AoERadius int `yaml:"aoe_radius,omitempty"`
+	// AoeLength is the length in feet for cone/line shapes. Required (> 0) for those
+	// shapes; must be 0 otherwise.
+	AoeLength int `yaml:"aoe_length,omitempty"`
+	// AoeWidth is the width in feet for line shapes. Defaults to 5 ft when zero (AOE-3).
+	AoeWidth int      `yaml:"aoe_width,omitempty"`
+	Traits   []string `yaml:"traits"`
 }
 
 // Validate checks that the ExplosiveDef satisfies its invariants.
@@ -72,6 +83,9 @@ func (e *ExplosiveDef) Validate() error {
 	}
 	if e.SaveDC <= 0 {
 		errs = append(errs, errors.New("SaveDC must be > 0"))
+	}
+	if err := aoe.ValidateAoeFields(e.AoeShape, e.AoERadius, e.AoeLength, e.AoeWidth); err != nil {
+		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("explosive validation failed: %v", errs)

--- a/internal/game/inventory/explosive_aoe_test.go
+++ b/internal/game/inventory/explosive_aoe_test.go
@@ -1,0 +1,59 @@
+package inventory_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/aoe"
+	"github.com/cory-johannsen/mud/internal/game/inventory"
+)
+
+func baseExplosive() *inventory.ExplosiveDef {
+	return &inventory.ExplosiveDef{
+		ID:         "frag",
+		Name:       "Frag Grenade",
+		DamageDice: "2d6",
+		DamageType: "piercing",
+		AreaType:   inventory.AreaTypeBurst,
+		SaveType:   "reflex",
+		SaveDC:     17,
+		Fuse:       inventory.FuseImmediate,
+	}
+}
+
+func TestExplosive_LegacyAoeRadiusBackCompat(t *testing.T) {
+	e := baseExplosive()
+	e.AoERadius = 10
+	if err := e.Validate(); err != nil {
+		t.Fatalf("expected nil for legacy aoe_radius; got %v", err)
+	}
+	if e.AoeShape != aoe.AoeShapeNone {
+		t.Fatalf("expected AoeShapeNone; got %q", e.AoeShape)
+	}
+}
+
+func TestExplosive_ConeRequiresLength(t *testing.T) {
+	e := baseExplosive()
+	e.AoeShape = aoe.AoeShapeCone
+	err := e.Validate()
+	if err == nil || !strings.Contains(err.Error(), "aoe_length") {
+		t.Fatalf("expected aoe_length error; got %v", err)
+	}
+}
+
+func TestExplosive_ConeWithLengthOK(t *testing.T) {
+	e := baseExplosive()
+	e.AoeShape = aoe.AoeShapeCone
+	e.AoeLength = 30
+	if err := e.Validate(); err != nil {
+		t.Fatalf("expected nil; got %v", err)
+	}
+}
+
+func TestExplosive_LineNoLengthRejected(t *testing.T) {
+	e := baseExplosive()
+	e.AoeShape = aoe.AoeShapeLine
+	if err := e.Validate(); err == nil {
+		t.Fatal("expected error for line without aoe_length")
+	}
+}

--- a/internal/game/ruleset/class_feature.go
+++ b/internal/game/ruleset/class_feature.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/cory-johannsen/mud/internal/game/aoe"
 	"github.com/cory-johannsen/mud/internal/game/effect"
 	"gopkg.in/yaml.v3"
 )
@@ -50,11 +51,32 @@ type ClassFeature struct {
 	Contexts     []string        `yaml:"contexts"`    // valid contexts: combat, exploration, downtime
 	Effect            *ActionEffect   `yaml:"effect"`                        // nil for passive features
 	GrantsFocusPoint  bool            `yaml:"grants_focus_point,omitempty"`  // true if this feature grants a Focus Point slot
+	// AoeShape selects the AoE template geometry: "" (single-target / legacy
+	// back-compat), "burst", "cone", or "line". When empty and AoeRadius > 0
+	// the feature is treated as an AoeShapeBurst (back-compat AOE-4).
+	AoeShape aoe.AoeShape `yaml:"aoe_shape,omitempty"`
 	// AoeRadius is the radius in feet for area-of-effect feats. 0 = single target.
 	AoeRadius int `yaml:"aoe_radius,omitempty"`
+	// AoeLength is the length in feet for cone/line shapes. Required (> 0) for those
+	// shapes; must be 0 otherwise.
+	AoeLength int `yaml:"aoe_length,omitempty"`
+	// AoeWidth is the width in feet for line shapes. Defaults to 5 ft when zero (AOE-3).
+	AoeWidth int `yaml:"aoe_width,omitempty"`
 	// PassiveBonuses are always-on typed bonuses granted while this feature is active.
 	// Only meaningful when Active == false (passive features).
 	PassiveBonuses []effect.Bonus `yaml:"passive_bonuses,omitempty"`
+}
+
+// Validate returns an error if the feature's AoE fields are inconsistent.
+//
+// Precondition: cf is non-nil.
+// Postcondition: returns nil iff (AoeShape, AoeRadius, AoeLength, AoeWidth)
+// satisfy the AoE field rules.
+func (cf *ClassFeature) Validate() error {
+	if err := aoe.ValidateAoeFields(cf.AoeShape, cf.AoeRadius, cf.AoeLength, cf.AoeWidth); err != nil {
+		return fmt.Errorf("class_feature %q: %w", cf.ID, err)
+	}
+	return nil
 }
 
 // classFeaturesFile is the top-level YAML structure for content/class_features.yaml.
@@ -70,6 +92,11 @@ func LoadClassFeaturesFromBytes(data []byte) ([]*ClassFeature, error) {
 	var f classFeaturesFile
 	if err := yaml.Unmarshal(data, &f); err != nil {
 		return nil, fmt.Errorf("parsing class features: %w", err)
+	}
+	for _, cf := range f.ClassFeatures {
+		if err := cf.Validate(); err != nil {
+			return nil, err
+		}
 	}
 	return f.ClassFeatures, nil
 }

--- a/internal/game/ruleset/class_feature_aoe_test.go
+++ b/internal/game/ruleset/class_feature_aoe_test.go
@@ -1,0 +1,56 @@
+package ruleset_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/aoe"
+	"github.com/cory-johannsen/mud/internal/game/ruleset"
+)
+
+func TestLoadClassFeatures_LegacyAoeRadiusBackCompat(t *testing.T) {
+	yaml := `class_features:
+  - id: legacy_blast
+    name: Legacy Blast
+    aoe_radius: 15
+`
+	feats, err := ruleset.LoadClassFeaturesFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadClassFeaturesFromBytes: %v", err)
+	}
+	if feats[0].AoeShape != aoe.AoeShapeNone || feats[0].AoeRadius != 15 {
+		t.Fatalf("expected legacy form; got %+v", feats[0])
+	}
+}
+
+func TestLoadClassFeatures_ConeRequiresLength(t *testing.T) {
+	yaml := `class_features:
+  - id: cone_feature
+    name: Cone Feature
+    aoe_shape: cone
+`
+	_, err := ruleset.LoadClassFeaturesFromBytes([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "aoe_length") {
+		t.Fatalf("expected aoe_length error; got %v", err)
+	}
+}
+
+func TestLoadClassFeatures_LineDefaultWidth(t *testing.T) {
+	yaml := `class_features:
+  - id: line_feature
+    name: Line Feature
+    aoe_shape: line
+    aoe_length: 30
+`
+	feats, err := ruleset.LoadClassFeaturesFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadClassFeaturesFromBytes: %v", err)
+	}
+	// AoeWidth left at zero; consumer applies aoe.ResolveLineWidth at use time.
+	if feats[0].AoeShape != aoe.AoeShapeLine || feats[0].AoeWidth != 0 {
+		t.Fatalf("expected line shape with zero width (defaulted at use); got %+v", feats[0])
+	}
+	if got := aoe.ResolveLineWidth(feats[0].AoeWidth); got != aoe.DefaultLineWidthFt {
+		t.Fatalf("ResolveLineWidth = %d; want %d", got, aoe.DefaultLineWidthFt)
+	}
+}

--- a/internal/game/ruleset/feat.go
+++ b/internal/game/ruleset/feat.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/cory-johannsen/mud/internal/game/aoe"
 	"github.com/cory-johannsen/mud/internal/game/reaction"
 )
 
@@ -41,10 +42,20 @@ type Feat struct {
 	TargetTags []string `yaml:"target_tags"`
 	// GrantsFocusPoint when true means this feat grants one Focus Point slot to the character's pool.
 	GrantsFocusPoint bool `yaml:"grants_focus_point,omitempty"`
+	// AoeShape selects the AoE template geometry: "" (single-target / legacy
+	// back-compat), "burst", "cone", or "line". When empty and AoeRadius > 0
+	// the feat is treated as an AoeShapeBurst (back-compat AOE-4).
+	AoeShape aoe.AoeShape `yaml:"aoe_shape,omitempty"`
 	// AoeRadius is the radius in feet of an area-of-effect burst centered on the target grid square.
 	// 0 means single-target (default). When > 0 and UseRequest.target_x/target_y are non-zero,
 	// the feat's condition effect is applied to every combatant within Chebyshev distance AoeRadius.
 	AoeRadius int `yaml:"aoe_radius,omitempty"`
+	// AoeLength is the length in feet for AoeShapeCone or AoeShapeLine. Required (> 0) for
+	// those shapes; must be 0 for AoeShapeBurst and the legacy form.
+	AoeLength int `yaml:"aoe_length,omitempty"`
+	// AoeWidth is the width in feet for AoeShapeLine. Defaults to 5 ft when zero per AOE-3.
+	// Must be 0 for all other shapes.
+	AoeWidth int `yaml:"aoe_width,omitempty"`
 	// RequiresCombat, when true, means this feat may only be activated while the player is in
 	// an active combat encounter. Attempting to use it outside combat returns an error message.
 	RequiresCombat bool `yaml:"requires_combat,omitempty"`
@@ -54,6 +65,18 @@ type Feat struct {
 	// ActionCost is the number of action points this active feat costs to use.
 	// 0 means the engine defaults to 1 AP. Only meaningful for Active == true feats.
 	ActionCost int `yaml:"action_cost,omitempty"`
+}
+
+// Validate returns an error if the feat's AoE fields are inconsistent.
+//
+// Precondition: f is non-nil.
+// Postcondition: returns nil iff (AoeShape, AoeRadius, AoeLength, AoeWidth)
+// satisfy the AoE field rules.
+func (f *Feat) Validate() error {
+	if err := aoe.ValidateAoeFields(f.AoeShape, f.AoeRadius, f.AoeLength, f.AoeWidth); err != nil {
+		return fmt.Errorf("feat %q: %w", f.ID, err)
+	}
+	return nil
 }
 
 // featsFile is the top-level YAML structure for content/feats.yaml.
@@ -69,6 +92,11 @@ func LoadFeatsFromBytes(data []byte) ([]*Feat, error) {
 	var f featsFile
 	if err := yaml.Unmarshal(data, &f); err != nil {
 		return nil, fmt.Errorf("parsing feats: %w", err)
+	}
+	for _, feat := range f.Feats {
+		if err := feat.Validate(); err != nil {
+			return nil, err
+		}
 	}
 	return f.Feats, nil
 }

--- a/internal/game/ruleset/feat_aoe_test.go
+++ b/internal/game/ruleset/feat_aoe_test.go
@@ -1,0 +1,80 @@
+package ruleset_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/aoe"
+	"github.com/cory-johannsen/mud/internal/game/ruleset"
+)
+
+func TestLoadFeats_LegacyAoeRadiusBackCompat(t *testing.T) {
+	yaml := `feats:
+  - id: legacy_burst
+    name: Legacy Burst
+    category: general
+    aoe_radius: 10
+`
+	feats, err := ruleset.LoadFeatsFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadFeatsFromBytes: %v", err)
+	}
+	if len(feats) != 1 {
+		t.Fatalf("expected 1 feat; got %d", len(feats))
+	}
+	// Legacy: empty AoeShape with positive AoeRadius is allowed (treated as burst at use time).
+	if feats[0].AoeShape != aoe.AoeShapeNone {
+		t.Errorf("expected AoeShapeNone for legacy form; got %q", feats[0].AoeShape)
+	}
+	if feats[0].AoeRadius != 10 {
+		t.Errorf("expected AoeRadius 10; got %d", feats[0].AoeRadius)
+	}
+}
+
+func TestLoadFeats_ConeRequiresLength(t *testing.T) {
+	yaml := `feats:
+  - id: cone_feat
+    name: Cone Feat
+    category: general
+    aoe_shape: cone
+`
+	_, err := ruleset.LoadFeatsFromBytes([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for cone with no aoe_length")
+	}
+	if !strings.Contains(err.Error(), "aoe_length") {
+		t.Fatalf("expected error to mention aoe_length; got %v", err)
+	}
+}
+
+func TestLoadFeats_ConeWithLengthOK(t *testing.T) {
+	yaml := `feats:
+  - id: cone_feat
+    name: Cone Feat
+    category: general
+    aoe_shape: cone
+    aoe_length: 30
+`
+	feats, err := ruleset.LoadFeatsFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadFeatsFromBytes: %v", err)
+	}
+	if feats[0].AoeShape != aoe.AoeShapeCone || feats[0].AoeLength != 30 {
+		t.Fatalf("expected cone+30ft; got %+v", feats[0])
+	}
+}
+
+func TestLoadFeats_BurstWithLengthRejected(t *testing.T) {
+	yaml := `feats:
+  - id: bad_burst
+    name: Bad Burst
+    category: general
+    aoe_shape: burst
+    aoe_radius: 10
+    aoe_length: 30
+`
+	_, err := ruleset.LoadFeatsFromBytes([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for burst with aoe_length")
+	}
+}

--- a/internal/game/technology/model.go
+++ b/internal/game/technology/model.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/cory-johannsen/mud/internal/game/aoe"
 	"github.com/cory-johannsen/mud/internal/game/effect"
 	"github.com/cory-johannsen/mud/internal/game/reaction"
 )
@@ -237,10 +238,19 @@ type TechnologyDef struct {
 	// Reaction declares this tech as a player reaction with the given trigger and effect.
 	// Only applicable to innate techs. Nil means this tech is not a reaction.
 	Reaction *reaction.ReactionDef `yaml:"reaction,omitempty"`
+	// AoeShape selects the AoE template geometry: "" (single-target / legacy
+	// back-compat), "burst", "cone", or "line". When empty and AoeRadius > 0
+	// the technology is treated as an AoeShapeBurst (back-compat AOE-4).
+	AoeShape aoe.AoeShape `yaml:"aoe_shape,omitempty"`
 	// AoeRadius is the radius in feet of an area-of-effect burst centered on the target grid square.
 	// 0 means single-target (default). When > 0 and UseRequest.target_x/target_y are >= 0 (not the -1 sentinel),
 	// effects are applied to every combatant within Chebyshev distance AoeRadius of the target square.
 	AoeRadius int `yaml:"aoe_radius,omitempty"`
+	// AoeLength is the length in feet for cone/line shapes. Required (> 0) for those
+	// shapes; must be 0 otherwise.
+	AoeLength int `yaml:"aoe_length,omitempty"`
+	// AoeWidth is the width in feet for line shapes. Defaults to 5 ft when zero (AOE-3).
+	AoeWidth int `yaml:"aoe_width,omitempty"`
 	// PassiveBonuses are always-on typed bonuses granted while this technology is active (Passive == true only).
 	PassiveBonuses []effect.Bonus `yaml:"passive_bonuses,omitempty"`
 }
@@ -326,8 +336,8 @@ func (t *TechnologyDef) Validate() error {
 			return err
 		}
 	}
-	if t.AoeRadius < 0 {
-		return fmt.Errorf("technology %q: aoe_radius must be >= 0, got %d", t.ID, t.AoeRadius)
+	if err := aoe.ValidateAoeFields(t.AoeShape, t.AoeRadius, t.AoeLength, t.AoeWidth); err != nil {
+		return fmt.Errorf("technology %q: %w", t.ID, err)
 	}
 	if len(t.AmpedEffects.AllEffects()) > 0 && t.AmpedLevel == 0 {
 		return fmt.Errorf("amped_level must be > 0 when amped_effects is non-empty")

--- a/internal/game/technology/model_aoe_test.go
+++ b/internal/game/technology/model_aoe_test.go
@@ -1,0 +1,66 @@
+package technology_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/aoe"
+	"github.com/cory-johannsen/mud/internal/game/technology"
+)
+
+func baseTech() *technology.TechnologyDef {
+	return &technology.TechnologyDef{
+		ID:        "aoe_test_tech",
+		Name:      "AOE Test Tech",
+		Tradition: technology.TraditionTechnical,
+		Level:     1,
+		UsageType: technology.UsagePrepared,
+		Range:     technology.RangeRanged,
+		Targets:   technology.TargetsAllEnemies,
+		Duration:  "instant",
+		Effects: technology.TieredEffects{
+			OnApply: []technology.TechEffect{
+				{Type: technology.EffectDamage, Dice: "2d6", DamageType: "fire"},
+			},
+		},
+	}
+}
+
+func TestTechnology_LegacyAoeRadiusBackCompat(t *testing.T) {
+	td := baseTech()
+	td.AoeRadius = 10
+	if err := td.Validate(); err != nil {
+		t.Fatalf("expected nil for legacy aoe_radius; got %v", err)
+	}
+	if td.AoeShape != aoe.AoeShapeNone {
+		t.Fatalf("expected AoeShapeNone; got %q", td.AoeShape)
+	}
+}
+
+func TestTechnology_ConeRequiresLength(t *testing.T) {
+	td := baseTech()
+	td.AoeShape = aoe.AoeShapeCone
+	err := td.Validate()
+	if err == nil || !strings.Contains(err.Error(), "aoe_length") {
+		t.Fatalf("expected aoe_length error; got %v", err)
+	}
+}
+
+func TestTechnology_ConeWithLengthOK(t *testing.T) {
+	td := baseTech()
+	td.AoeShape = aoe.AoeShapeCone
+	td.AoeLength = 30
+	if err := td.Validate(); err != nil {
+		t.Fatalf("expected nil; got %v", err)
+	}
+}
+
+func TestTechnology_BurstWithLengthRejected(t *testing.T) {
+	td := baseTech()
+	td.AoeShape = aoe.AoeShapeBurst
+	td.AoeRadius = 10
+	td.AoeLength = 20
+	if err := td.Validate(); err == nil {
+		t.Fatal("expected error for burst with length")
+	}
+}

--- a/internal/gameserver/aoe_resolver.go
+++ b/internal/gameserver/aoe_resolver.go
@@ -1,0 +1,127 @@
+package gameserver
+
+import (
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	gamev1 "github.com/cory-johannsen/mud/internal/gameserver/gamev1"
+)
+
+// ResolveContext carries the per-resolution context used by future
+// PostFilterAffectedCells implementations (e.g. visibility / line-of-sight in
+// #267). v1 has no fields; the type exists so callers and the seam are stable.
+//
+// Precondition: none.
+// Postcondition: zero-value is a valid context.
+type ResolveContext struct {
+	// Combat is the active combat. May be nil for non-combat resolutions
+	// (e.g. preview / validation paths). Future filters MAY use it to
+	// derive line-of-sight from the source combatant.
+	Combat *combat.Combat
+	// SourceID is the id of the actor placing the template, when known.
+	SourceID string
+}
+
+// dirFromProto converts a wire-format AoeTemplate.Direction enum into the
+// internal combat.Direction octant.
+//
+// Precondition: none — DIR_UNSPECIFIED maps to combat.DirN as a stable default
+// to avoid panics on incomplete client requests.
+// Postcondition: returned Direction is in [combat.DirN, combat.DirNW].
+func dirFromProto(d gamev1.AoeTemplate_Direction) combat.Direction {
+	switch d {
+	case gamev1.AoeTemplate_DIR_N:
+		return combat.DirN
+	case gamev1.AoeTemplate_DIR_NE:
+		return combat.DirNE
+	case gamev1.AoeTemplate_DIR_E:
+		return combat.DirE
+	case gamev1.AoeTemplate_DIR_SE:
+		return combat.DirSE
+	case gamev1.AoeTemplate_DIR_S:
+		return combat.DirS
+	case gamev1.AoeTemplate_DIR_SW:
+		return combat.DirSW
+	case gamev1.AoeTemplate_DIR_W:
+		return combat.DirW
+	case gamev1.AoeTemplate_DIR_NW:
+		return combat.DirNW
+	default:
+		return combat.DirN
+	}
+}
+
+// CellsForTemplate returns the set of grid cells covered by the AoE template
+// for the given content dimensions. Burst templates use radiusFt; cone
+// templates use lengthFt; line templates use lengthFt and widthFt.
+//
+// The function delegates to the geometry helpers in the combat package and
+// dispatches on t.Shape. Unknown / unspecified shapes return nil.
+//
+// Precondition: t must be non-nil. radiusFt, lengthFt, widthFt must be >= 0.
+// Postcondition: returned slice contains no duplicates (when geometry helpers
+// guarantee that); origin / apex behaviour mirrors the helpers — burst
+// includes the centre, cone and line exclude the apex/origin per AOE-10.
+func CellsForTemplate(t *gamev1.AoeTemplate, radiusFt, lengthFt, widthFt int) []combat.Cell {
+	if t == nil {
+		return nil
+	}
+	anchor := combat.Cell{X: int(t.GetAnchorX()), Y: int(t.GetAnchorY())}
+	switch t.GetShape() {
+	case gamev1.AoeTemplate_SHAPE_BURST:
+		return combat.BurstCells(anchor, radiusFt)
+	case gamev1.AoeTemplate_SHAPE_CONE:
+		return combat.ConeCells(anchor, dirFromProto(t.GetFacing()), lengthFt)
+	case gamev1.AoeTemplate_SHAPE_LINE:
+		return combat.LineCells(anchor, dirFromProto(t.GetFacing()), lengthFt, widthFt)
+	}
+	return nil
+}
+
+// PostFilterAffectedCells is the extension seam (AOE-21) where future
+// visibility / line-of-sight filtering will plug in (issue #267). The v1
+// implementation is the identity function — it returns its input unchanged.
+//
+// Precondition: cells may be nil; ctx is passed through verbatim.
+// Postcondition: returns the same slice header (or nil) — no copy is made in
+// the v1 implementation.
+func PostFilterAffectedCells(cells []combat.Cell, _ ResolveContext) []combat.Cell {
+	return cells
+}
+
+// resolveAoeCells is the convenience wrapper used by the inline AoE paths in
+// grpc_service.go: it builds the template's cell set, runs the post-filter,
+// optionally writes the resolved cells back to the proto template (AOE-12),
+// and returns the combatants whose grid square intersects.
+//
+// When template is nil this is a back-compat path (AOE-16): the caller has
+// supplied targetX / targetY for a legacy burst content. A burst template is
+// synthesised on the fly so the same code path applies.
+//
+// Precondition: cbt must be non-nil.
+// Postcondition: returned slice is the affected combatants (possibly empty);
+// when template is non-nil, template.Cells is populated with the resolved
+// grid cells in geometry-helper order.
+func resolveAoeCells(template *gamev1.AoeTemplate, radiusFt, lengthFt, widthFt int, targetX, targetY int32, cbt *combat.Combat) ([]*combat.Combatant, []combat.Cell) {
+	if template == nil {
+		// AOE-16: synthesise a burst template at runtime when only the
+		// legacy targetX/targetY were supplied.
+		template = &gamev1.AoeTemplate{
+			Shape:   gamev1.AoeTemplate_SHAPE_BURST,
+			AnchorX: targetX,
+			AnchorY: targetY,
+		}
+	}
+	cells := CellsForTemplate(template, radiusFt, lengthFt, widthFt)
+	cells = PostFilterAffectedCells(cells, ResolveContext{Combat: cbt})
+
+	// AOE-12: populate the wire-format cells list on the inbound template so
+	// downstream emitters can echo it on the outbound combat event.
+	if len(cells) > 0 {
+		out := make([]*gamev1.AoeTemplate_Cell, 0, len(cells))
+		for _, c := range cells {
+			out = append(out, &gamev1.AoeTemplate_Cell{X: int32(c.X), Y: int32(c.Y)})
+		}
+		template.Cells = out
+	}
+
+	return combat.CombatantsInCells(cbt, cells), cells
+}

--- a/internal/gameserver/aoe_resolver_test.go
+++ b/internal/gameserver/aoe_resolver_test.go
@@ -1,0 +1,232 @@
+package gameserver
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	gamev1 "github.com/cory-johannsen/mud/internal/gameserver/gamev1"
+)
+
+// makeCombatWithCombatants returns a Combat populated with NPC combatants at
+// the supplied (x,y) cells. Identifiers are assigned positionally.
+func makeCombatWithCombatants(coords [][2]int) *combat.Combat {
+	cbt := &combat.Combat{}
+	for i, xy := range coords {
+		c := &combat.Combatant{
+			ID:    string(rune('a' + i)),
+			Name:  "npc" + string(rune('a'+i)),
+			Kind:  combat.KindNPC,
+			GridX: xy[0],
+			GridY: xy[1],
+			CurrentHP: 10,
+			MaxHP:     10,
+		}
+		cbt.Combatants = append(cbt.Combatants, c)
+	}
+	return cbt
+}
+
+func TestCellsForTemplate_Burst(t *testing.T) {
+	tmpl := &gamev1.AoeTemplate{
+		Shape:   gamev1.AoeTemplate_SHAPE_BURST,
+		AnchorX: 5,
+		AnchorY: 5,
+	}
+	cells := CellsForTemplate(tmpl, 10, 0, 0) // radius 10ft = 2 cells.
+	// Expect (2*2+1)^2 = 25 cells.
+	if got := len(cells); got != 25 {
+		t.Fatalf("burst cell count: want 25, got %d", got)
+	}
+	// Verify the centre is included.
+	found := false
+	for _, c := range cells {
+		if c.X == 5 && c.Y == 5 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("burst cells did not contain anchor (5,5)")
+	}
+}
+
+func TestCellsForTemplate_Cone(t *testing.T) {
+	tmpl := &gamev1.AoeTemplate{
+		Shape:   gamev1.AoeTemplate_SHAPE_CONE,
+		AnchorX: 5,
+		AnchorY: 5,
+		Facing:  gamev1.AoeTemplate_DIR_E,
+	}
+	cells := CellsForTemplate(tmpl, 0, 15, 0) // length 15ft = 3 cells.
+	if len(cells) == 0 {
+		t.Fatalf("cone cells: expected non-empty")
+	}
+	// Apex must be excluded (AOE-10).
+	for _, c := range cells {
+		if c.X == 5 && c.Y == 5 {
+			t.Fatalf("cone cells must not contain apex")
+		}
+	}
+	// All cone cells facing east must satisfy x > apex.X.
+	for _, c := range cells {
+		if c.X <= 5 {
+			t.Fatalf("east-facing cone has cell at x=%d (apex x=5)", c.X)
+		}
+	}
+}
+
+func TestCellsForTemplate_Line(t *testing.T) {
+	tmpl := &gamev1.AoeTemplate{
+		Shape:   gamev1.AoeTemplate_SHAPE_LINE,
+		AnchorX: 0,
+		AnchorY: 0,
+		Facing:  gamev1.AoeTemplate_DIR_E,
+	}
+	cells := CellsForTemplate(tmpl, 0, 25, 5) // 5 cells long, 1 cell wide.
+	if got := len(cells); got != 5 {
+		t.Fatalf("line cells: want 5, got %d (cells=%v)", got, cells)
+	}
+	for _, c := range cells {
+		if c.Y != 0 {
+			t.Fatalf("east line should have y=0, got %v", c)
+		}
+		if c.X == 0 {
+			t.Fatalf("line origin (0,0) must be excluded per AOE-10")
+		}
+	}
+}
+
+func TestDirFromProto_AllDirections(t *testing.T) {
+	cases := []struct {
+		in   gamev1.AoeTemplate_Direction
+		want combat.Direction
+	}{
+		{gamev1.AoeTemplate_DIR_N, combat.DirN},
+		{gamev1.AoeTemplate_DIR_NE, combat.DirNE},
+		{gamev1.AoeTemplate_DIR_E, combat.DirE},
+		{gamev1.AoeTemplate_DIR_SE, combat.DirSE},
+		{gamev1.AoeTemplate_DIR_S, combat.DirS},
+		{gamev1.AoeTemplate_DIR_SW, combat.DirSW},
+		{gamev1.AoeTemplate_DIR_W, combat.DirW},
+		{gamev1.AoeTemplate_DIR_NW, combat.DirNW},
+		{gamev1.AoeTemplate_DIR_UNSPECIFIED, combat.DirN}, // stable default.
+	}
+	for _, tc := range cases {
+		if got := dirFromProto(tc.in); got != tc.want {
+			t.Errorf("dirFromProto(%v): want %v, got %v", tc.in, tc.want, got)
+		}
+	}
+}
+
+func TestPostFilterAffectedCells_IdentityV1(t *testing.T) {
+	in := []combat.Cell{{X: 1, Y: 1}, {X: 2, Y: 2}}
+	out := PostFilterAffectedCells(in, ResolveContext{})
+	if len(out) != len(in) {
+		t.Fatalf("identity filter: len changed (in=%d out=%d)", len(in), len(out))
+	}
+	for i := range in {
+		if in[i] != out[i] {
+			t.Fatalf("identity filter: index %d changed (in=%v out=%v)", i, in[i], out[i])
+		}
+	}
+}
+
+func TestResolveAoeCells_BurstAffectsAndPopulatesCells(t *testing.T) {
+	cbt := makeCombatWithCombatants([][2]int{
+		{5, 5}, // inside a 10ft burst centered at (5,5): yes
+		{6, 6}, // inside: yes
+		{8, 8}, // outside: no
+	})
+	tmpl := &gamev1.AoeTemplate{
+		Shape:   gamev1.AoeTemplate_SHAPE_BURST,
+		AnchorX: 5,
+		AnchorY: 5,
+	}
+	affected, cells := resolveAoeCells(tmpl, 10, 0, 0, 5, 5, cbt)
+	if len(affected) != 2 {
+		t.Fatalf("burst affected: want 2, got %d", len(affected))
+	}
+	if len(cells) != 25 {
+		t.Fatalf("burst cells: want 25, got %d", len(cells))
+	}
+	// AOE-12: outbound template.Cells must be populated.
+	if got := len(tmpl.GetCells()); got != 25 {
+		t.Fatalf("template.Cells populated: want 25, got %d", got)
+	}
+}
+
+func TestResolveAoeCells_ConeShape(t *testing.T) {
+	cbt := makeCombatWithCombatants([][2]int{
+		{6, 5}, // east of (5,5), in cone: yes
+		{4, 5}, // west of (5,5), not in east cone: no
+	})
+	tmpl := &gamev1.AoeTemplate{
+		Shape:   gamev1.AoeTemplate_SHAPE_CONE,
+		AnchorX: 5,
+		AnchorY: 5,
+		Facing:  gamev1.AoeTemplate_DIR_E,
+	}
+	affected, _ := resolveAoeCells(tmpl, 0, 15, 0, 5, 5, cbt)
+	if len(affected) != 1 {
+		t.Fatalf("cone affected: want 1, got %d", len(affected))
+	}
+	if affected[0].GridX != 6 {
+		t.Fatalf("cone affected wrong cell: %+v", affected[0])
+	}
+}
+
+func TestResolveAoeCells_LineShape(t *testing.T) {
+	cbt := makeCombatWithCombatants([][2]int{
+		{1, 0}, // east of (0,0), on line: yes
+		{2, 0}, // also on line: yes
+		{0, 1}, // perpendicular: no
+	})
+	tmpl := &gamev1.AoeTemplate{
+		Shape:   gamev1.AoeTemplate_SHAPE_LINE,
+		AnchorX: 0,
+		AnchorY: 0,
+		Facing:  gamev1.AoeTemplate_DIR_E,
+	}
+	affected, _ := resolveAoeCells(tmpl, 0, 25, 5, 0, 0, cbt)
+	if len(affected) != 2 {
+		t.Fatalf("line affected: want 2, got %d (got=%+v)", len(affected), affected)
+	}
+}
+
+func TestResolveAoeCells_NilTemplateSynthesisesBurst(t *testing.T) {
+	// AOE-16: a nil template plus legacy targetX/targetY for an AoeRadius>0
+	// content must synthesise a burst template at runtime.
+	cbt := makeCombatWithCombatants([][2]int{
+		{3, 3}, // centre of a 5ft burst: yes
+		{4, 3}, // inside 5ft burst: yes
+		{6, 6}, // outside: no
+	})
+	affected, cells := resolveAoeCells(nil, 5, 0, 0, 3, 3, cbt)
+	if len(affected) != 2 {
+		t.Fatalf("synthesised burst affected: want 2, got %d", len(affected))
+	}
+	// Burst radius 5ft = 1 cell -> (2*1+1)^2 = 9.
+	if len(cells) != 9 {
+		t.Fatalf("synthesised burst cells: want 9, got %d", len(cells))
+	}
+}
+
+func TestResolveAoeCells_EmptyIntersection(t *testing.T) {
+	// AOE-20: when the placement intersects no living combatants the resolver
+	// returns an empty slice (the AP-consume / narrative path is the caller's).
+	cbt := makeCombatWithCombatants([][2]int{
+		{0, 0}, // far from anchor
+	})
+	tmpl := &gamev1.AoeTemplate{
+		Shape:   gamev1.AoeTemplate_SHAPE_BURST,
+		AnchorX: 9,
+		AnchorY: 9,
+	}
+	affected, cells := resolveAoeCells(tmpl, 5, 0, 0, 9, 9, cbt)
+	if len(affected) != 0 {
+		t.Fatalf("empty intersection: want 0 affected, got %d", len(affected))
+	}
+	if len(cells) == 0 {
+		t.Fatalf("empty intersection: cells should still be populated for client preview")
+	}
+}

--- a/internal/gameserver/gamev1/game.pb.go
+++ b/internal/gameserver/gamev1/game.pb.go
@@ -248,6 +248,125 @@ func (CombatEventType) EnumDescriptor() ([]byte, []int) {
 	return file_game_v1_game_proto_rawDescGZIP(), []int{3}
 }
 
+type AoeTemplate_Shape int32
+
+const (
+	AoeTemplate_SHAPE_UNSPECIFIED AoeTemplate_Shape = 0
+	AoeTemplate_SHAPE_BURST       AoeTemplate_Shape = 1
+	AoeTemplate_SHAPE_CONE        AoeTemplate_Shape = 2
+	AoeTemplate_SHAPE_LINE        AoeTemplate_Shape = 3
+)
+
+// Enum value maps for AoeTemplate_Shape.
+var (
+	AoeTemplate_Shape_name = map[int32]string{
+		0: "SHAPE_UNSPECIFIED",
+		1: "SHAPE_BURST",
+		2: "SHAPE_CONE",
+		3: "SHAPE_LINE",
+	}
+	AoeTemplate_Shape_value = map[string]int32{
+		"SHAPE_UNSPECIFIED": 0,
+		"SHAPE_BURST":       1,
+		"SHAPE_CONE":        2,
+		"SHAPE_LINE":        3,
+	}
+)
+
+func (x AoeTemplate_Shape) Enum() *AoeTemplate_Shape {
+	p := new(AoeTemplate_Shape)
+	*p = x
+	return p
+}
+
+func (x AoeTemplate_Shape) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AoeTemplate_Shape) Descriptor() protoreflect.EnumDescriptor {
+	return file_game_v1_game_proto_enumTypes[4].Descriptor()
+}
+
+func (AoeTemplate_Shape) Type() protoreflect.EnumType {
+	return &file_game_v1_game_proto_enumTypes[4]
+}
+
+func (x AoeTemplate_Shape) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AoeTemplate_Shape.Descriptor instead.
+func (AoeTemplate_Shape) EnumDescriptor() ([]byte, []int) {
+	return file_game_v1_game_proto_rawDescGZIP(), []int{133, 0}
+}
+
+type AoeTemplate_Direction int32
+
+const (
+	AoeTemplate_DIR_UNSPECIFIED AoeTemplate_Direction = 0
+	AoeTemplate_DIR_N           AoeTemplate_Direction = 1
+	AoeTemplate_DIR_NE          AoeTemplate_Direction = 2
+	AoeTemplate_DIR_E           AoeTemplate_Direction = 3
+	AoeTemplate_DIR_SE          AoeTemplate_Direction = 4
+	AoeTemplate_DIR_S           AoeTemplate_Direction = 5
+	AoeTemplate_DIR_SW          AoeTemplate_Direction = 6
+	AoeTemplate_DIR_W           AoeTemplate_Direction = 7
+	AoeTemplate_DIR_NW          AoeTemplate_Direction = 8
+)
+
+// Enum value maps for AoeTemplate_Direction.
+var (
+	AoeTemplate_Direction_name = map[int32]string{
+		0: "DIR_UNSPECIFIED",
+		1: "DIR_N",
+		2: "DIR_NE",
+		3: "DIR_E",
+		4: "DIR_SE",
+		5: "DIR_S",
+		6: "DIR_SW",
+		7: "DIR_W",
+		8: "DIR_NW",
+	}
+	AoeTemplate_Direction_value = map[string]int32{
+		"DIR_UNSPECIFIED": 0,
+		"DIR_N":           1,
+		"DIR_NE":          2,
+		"DIR_E":           3,
+		"DIR_SE":          4,
+		"DIR_S":           5,
+		"DIR_SW":          6,
+		"DIR_W":           7,
+		"DIR_NW":          8,
+	}
+)
+
+func (x AoeTemplate_Direction) Enum() *AoeTemplate_Direction {
+	p := new(AoeTemplate_Direction)
+	*p = x
+	return p
+}
+
+func (x AoeTemplate_Direction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AoeTemplate_Direction) Descriptor() protoreflect.EnumDescriptor {
+	return file_game_v1_game_proto_enumTypes[5].Descriptor()
+}
+
+func (AoeTemplate_Direction) Type() protoreflect.EnumType {
+	return &file_game_v1_game_proto_enumTypes[5]
+}
+
+func (x AoeTemplate_Direction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AoeTemplate_Direction.Descriptor instead.
+func (AoeTemplate_Direction) EnumDescriptor() ([]byte, []int) {
+	return file_game_v1_game_proto_rawDescGZIP(), []int{133, 1}
+}
+
 // ClientMessage wraps all client-to-server commands.
 type ClientMessage struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
@@ -11287,6 +11406,85 @@ func (x *InteractResponse) GetMessage() string {
 	return ""
 }
 
+// AoeTemplate describes a placed area-of-effect template for a Use action.
+// The client populates shape, anchor, and (for cones/lines) facing on inbound
+// requests; the server populates cells on outbound combat events.
+type AoeTemplate struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Shape         AoeTemplate_Shape      `protobuf:"varint,1,opt,name=shape,proto3,enum=game.v1.AoeTemplate_Shape" json:"shape,omitempty"`
+	AnchorX       int32                  `protobuf:"varint,2,opt,name=anchor_x,json=anchorX,proto3" json:"anchor_x,omitempty"`
+	AnchorY       int32                  `protobuf:"varint,3,opt,name=anchor_y,json=anchorY,proto3" json:"anchor_y,omitempty"`
+	Facing        AoeTemplate_Direction  `protobuf:"varint,4,opt,name=facing,proto3,enum=game.v1.AoeTemplate_Direction" json:"facing,omitempty"`
+	Cells         []*AoeTemplate_Cell    `protobuf:"bytes,5,rep,name=cells,proto3" json:"cells,omitempty"` // server-populated on outbound; ignored on inbound
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AoeTemplate) Reset() {
+	*x = AoeTemplate{}
+	mi := &file_game_v1_game_proto_msgTypes[133]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AoeTemplate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AoeTemplate) ProtoMessage() {}
+
+func (x *AoeTemplate) ProtoReflect() protoreflect.Message {
+	mi := &file_game_v1_game_proto_msgTypes[133]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AoeTemplate.ProtoReflect.Descriptor instead.
+func (*AoeTemplate) Descriptor() ([]byte, []int) {
+	return file_game_v1_game_proto_rawDescGZIP(), []int{133}
+}
+
+func (x *AoeTemplate) GetShape() AoeTemplate_Shape {
+	if x != nil {
+		return x.Shape
+	}
+	return AoeTemplate_SHAPE_UNSPECIFIED
+}
+
+func (x *AoeTemplate) GetAnchorX() int32 {
+	if x != nil {
+		return x.AnchorX
+	}
+	return 0
+}
+
+func (x *AoeTemplate) GetAnchorY() int32 {
+	if x != nil {
+		return x.AnchorY
+	}
+	return 0
+}
+
+func (x *AoeTemplate) GetFacing() AoeTemplate_Direction {
+	if x != nil {
+		return x.Facing
+	}
+	return AoeTemplate_DIR_UNSPECIFIED
+}
+
+func (x *AoeTemplate) GetCells() []*AoeTemplate_Cell {
+	if x != nil {
+		return x.Cells
+	}
+	return nil
+}
+
 // UseRequest asks the server to activate an active feat.
 // An empty feat_id causes the server to return the list of available active feats.
 type UseRequest struct {
@@ -11295,13 +11493,14 @@ type UseRequest struct {
 	Target        string                 `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
 	TargetX       int32                  `protobuf:"varint,3,opt,name=target_x,json=targetX,proto3" json:"target_x,omitempty"` // 0-based grid column (0–9); -1 means unset / no AoE; ignored unless feat has aoe_radius > 0
 	TargetY       int32                  `protobuf:"varint,4,opt,name=target_y,json=targetY,proto3" json:"target_y,omitempty"` // 0-based grid row (0–9); -1 means unset / no AoE; ignored unless feat has aoe_radius > 0
+	Template      *AoeTemplate           `protobuf:"bytes,5,opt,name=template,proto3" json:"template,omitempty"`               // optional; required for cone/line content (AOE-13)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *UseRequest) Reset() {
 	*x = UseRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[133]
+	mi := &file_game_v1_game_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11313,7 +11512,7 @@ func (x *UseRequest) String() string {
 func (*UseRequest) ProtoMessage() {}
 
 func (x *UseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[133]
+	mi := &file_game_v1_game_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11326,7 +11525,7 @@ func (x *UseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UseRequest.ProtoReflect.Descriptor instead.
 func (*UseRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{133}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *UseRequest) GetFeatId() string {
@@ -11357,6 +11556,13 @@ func (x *UseRequest) GetTargetY() int32 {
 	return 0
 }
 
+func (x *UseRequest) GetTemplate() *AoeTemplate {
+	if x != nil {
+		return x.Template
+	}
+	return nil
+}
+
 // UseResponse carries the result of a feat activation or a list of active feats.
 type UseResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -11368,7 +11574,7 @@ type UseResponse struct {
 
 func (x *UseResponse) Reset() {
 	*x = UseResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[134]
+	mi := &file_game_v1_game_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11380,7 +11586,7 @@ func (x *UseResponse) String() string {
 func (*UseResponse) ProtoMessage() {}
 
 func (x *UseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[134]
+	mi := &file_game_v1_game_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11393,7 +11599,7 @@ func (x *UseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UseResponse.ProtoReflect.Descriptor instead.
 func (*UseResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{134}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *UseResponse) GetMessage() string {
@@ -11426,7 +11632,7 @@ type PreparedSlotView struct {
 
 func (x *PreparedSlotView) Reset() {
 	*x = PreparedSlotView{}
-	mi := &file_game_v1_game_proto_msgTypes[135]
+	mi := &file_game_v1_game_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11438,7 +11644,7 @@ func (x *PreparedSlotView) String() string {
 func (*PreparedSlotView) ProtoMessage() {}
 
 func (x *PreparedSlotView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[135]
+	mi := &file_game_v1_game_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11451,7 +11657,7 @@ func (x *PreparedSlotView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedSlotView.ProtoReflect.Descriptor instead.
 func (*PreparedSlotView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{135}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *PreparedSlotView) GetTechId() string {
@@ -11518,7 +11724,7 @@ type HardwiredSlotView struct {
 
 func (x *HardwiredSlotView) Reset() {
 	*x = HardwiredSlotView{}
-	mi := &file_game_v1_game_proto_msgTypes[136]
+	mi := &file_game_v1_game_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11530,7 +11736,7 @@ func (x *HardwiredSlotView) String() string {
 func (*HardwiredSlotView) ProtoMessage() {}
 
 func (x *HardwiredSlotView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[136]
+	mi := &file_game_v1_game_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11543,7 +11749,7 @@ func (x *HardwiredSlotView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HardwiredSlotView.ProtoReflect.Descriptor instead.
 func (*HardwiredSlotView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{136}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *HardwiredSlotView) GetTechId() string {
@@ -11603,7 +11809,7 @@ type SpontaneousKnownEntry struct {
 
 func (x *SpontaneousKnownEntry) Reset() {
 	*x = SpontaneousKnownEntry{}
-	mi := &file_game_v1_game_proto_msgTypes[137]
+	mi := &file_game_v1_game_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11615,7 +11821,7 @@ func (x *SpontaneousKnownEntry) String() string {
 func (*SpontaneousKnownEntry) ProtoMessage() {}
 
 func (x *SpontaneousKnownEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[137]
+	mi := &file_game_v1_game_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11628,7 +11834,7 @@ func (x *SpontaneousKnownEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpontaneousKnownEntry.ProtoReflect.Descriptor instead.
 func (*SpontaneousKnownEntry) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{137}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *SpontaneousKnownEntry) GetTechId() string {
@@ -11754,7 +11960,7 @@ type CharacterSheetView struct {
 
 func (x *CharacterSheetView) Reset() {
 	*x = CharacterSheetView{}
-	mi := &file_game_v1_game_proto_msgTypes[138]
+	mi := &file_game_v1_game_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11766,7 +11972,7 @@ func (x *CharacterSheetView) String() string {
 func (*CharacterSheetView) ProtoMessage() {}
 
 func (x *CharacterSheetView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[138]
+	mi := &file_game_v1_game_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11779,7 +11985,7 @@ func (x *CharacterSheetView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CharacterSheetView.ProtoReflect.Descriptor instead.
 func (*CharacterSheetView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{138}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *CharacterSheetView) GetName() string {
@@ -12256,7 +12462,7 @@ type InnateSlotView struct {
 
 func (x *InnateSlotView) Reset() {
 	*x = InnateSlotView{}
-	mi := &file_game_v1_game_proto_msgTypes[139]
+	mi := &file_game_v1_game_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12268,7 +12474,7 @@ func (x *InnateSlotView) String() string {
 func (*InnateSlotView) ProtoMessage() {}
 
 func (x *InnateSlotView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[139]
+	mi := &file_game_v1_game_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12281,7 +12487,7 @@ func (x *InnateSlotView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InnateSlotView.ProtoReflect.Descriptor instead.
 func (*InnateSlotView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{139}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *InnateSlotView) GetTechId() string {
@@ -12366,7 +12572,7 @@ type SpontaneousUsePoolView struct {
 
 func (x *SpontaneousUsePoolView) Reset() {
 	*x = SpontaneousUsePoolView{}
-	mi := &file_game_v1_game_proto_msgTypes[140]
+	mi := &file_game_v1_game_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12378,7 +12584,7 @@ func (x *SpontaneousUsePoolView) String() string {
 func (*SpontaneousUsePoolView) ProtoMessage() {}
 
 func (x *SpontaneousUsePoolView) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[140]
+	mi := &file_game_v1_game_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12391,7 +12597,7 @@ func (x *SpontaneousUsePoolView) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpontaneousUsePoolView.ProtoReflect.Descriptor instead.
 func (*SpontaneousUsePoolView) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{140}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *SpontaneousUsePoolView) GetTechLevel() int32 {
@@ -12426,7 +12632,7 @@ type ResistanceEntry struct {
 
 func (x *ResistanceEntry) Reset() {
 	*x = ResistanceEntry{}
-	mi := &file_game_v1_game_proto_msgTypes[141]
+	mi := &file_game_v1_game_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12438,7 +12644,7 @@ func (x *ResistanceEntry) String() string {
 func (*ResistanceEntry) ProtoMessage() {}
 
 func (x *ResistanceEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[141]
+	mi := &file_game_v1_game_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12451,7 +12657,7 @@ func (x *ResistanceEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResistanceEntry.ProtoReflect.Descriptor instead.
 func (*ResistanceEntry) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{141}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *ResistanceEntry) GetDamageType() string {
@@ -12477,7 +12683,7 @@ type ProficienciesRequest struct {
 
 func (x *ProficienciesRequest) Reset() {
 	*x = ProficienciesRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[142]
+	mi := &file_game_v1_game_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12489,7 +12695,7 @@ func (x *ProficienciesRequest) String() string {
 func (*ProficienciesRequest) ProtoMessage() {}
 
 func (x *ProficienciesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[142]
+	mi := &file_game_v1_game_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12502,7 +12708,7 @@ func (x *ProficienciesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProficienciesRequest.ProtoReflect.Descriptor instead.
 func (*ProficienciesRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{142}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{143}
 }
 
 // ProficiencyEntry represents one proficiency category with its rank and bonus.
@@ -12519,7 +12725,7 @@ type ProficiencyEntry struct {
 
 func (x *ProficiencyEntry) Reset() {
 	*x = ProficiencyEntry{}
-	mi := &file_game_v1_game_proto_msgTypes[143]
+	mi := &file_game_v1_game_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12531,7 +12737,7 @@ func (x *ProficiencyEntry) String() string {
 func (*ProficiencyEntry) ProtoMessage() {}
 
 func (x *ProficiencyEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[143]
+	mi := &file_game_v1_game_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12544,7 +12750,7 @@ func (x *ProficiencyEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProficiencyEntry.ProtoReflect.Descriptor instead.
 func (*ProficiencyEntry) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{143}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *ProficiencyEntry) GetCategory() string {
@@ -12592,7 +12798,7 @@ type ProficienciesResponse struct {
 
 func (x *ProficienciesResponse) Reset() {
 	*x = ProficienciesResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[144]
+	mi := &file_game_v1_game_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12604,7 +12810,7 @@ func (x *ProficienciesResponse) String() string {
 func (*ProficienciesResponse) ProtoMessage() {}
 
 func (x *ProficienciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[144]
+	mi := &file_game_v1_game_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12617,7 +12823,7 @@ func (x *ProficienciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProficienciesResponse.ProtoReflect.Descriptor instead.
 func (*ProficienciesResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{144}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *ProficienciesResponse) GetProficiencies() []*ProficiencyEntry {
@@ -12637,7 +12843,7 @@ type LevelUpRequest struct {
 
 func (x *LevelUpRequest) Reset() {
 	*x = LevelUpRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[145]
+	mi := &file_game_v1_game_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12649,7 +12855,7 @@ func (x *LevelUpRequest) String() string {
 func (*LevelUpRequest) ProtoMessage() {}
 
 func (x *LevelUpRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[145]
+	mi := &file_game_v1_game_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12662,7 +12868,7 @@ func (x *LevelUpRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LevelUpRequest.ProtoReflect.Descriptor instead.
 func (*LevelUpRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{145}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *LevelUpRequest) GetAbility() string {
@@ -12682,7 +12888,7 @@ type CombatDefaultRequest struct {
 
 func (x *CombatDefaultRequest) Reset() {
 	*x = CombatDefaultRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[146]
+	mi := &file_game_v1_game_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12694,7 +12900,7 @@ func (x *CombatDefaultRequest) String() string {
 func (*CombatDefaultRequest) ProtoMessage() {}
 
 func (x *CombatDefaultRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[146]
+	mi := &file_game_v1_game_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12707,7 +12913,7 @@ func (x *CombatDefaultRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CombatDefaultRequest.ProtoReflect.Descriptor instead.
 func (*CombatDefaultRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{146}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *CombatDefaultRequest) GetAction() string {
@@ -12727,7 +12933,7 @@ type TrainSkillRequest struct {
 
 func (x *TrainSkillRequest) Reset() {
 	*x = TrainSkillRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[147]
+	mi := &file_game_v1_game_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12739,7 +12945,7 @@ func (x *TrainSkillRequest) String() string {
 func (*TrainSkillRequest) ProtoMessage() {}
 
 func (x *TrainSkillRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[147]
+	mi := &file_game_v1_game_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12752,7 +12958,7 @@ func (x *TrainSkillRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TrainSkillRequest.ProtoReflect.Descriptor instead.
 func (*TrainSkillRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{147}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *TrainSkillRequest) GetSkillId() string {
@@ -12774,7 +12980,7 @@ type ActionRequest struct {
 
 func (x *ActionRequest) Reset() {
 	*x = ActionRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[148]
+	mi := &file_game_v1_game_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12786,7 +12992,7 @@ func (x *ActionRequest) String() string {
 func (*ActionRequest) ProtoMessage() {}
 
 func (x *ActionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[148]
+	mi := &file_game_v1_game_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12799,7 +13005,7 @@ func (x *ActionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActionRequest.ProtoReflect.Descriptor instead.
 func (*ActionRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{148}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *ActionRequest) GetName() string {
@@ -12825,7 +13031,7 @@ type RaiseShieldRequest struct {
 
 func (x *RaiseShieldRequest) Reset() {
 	*x = RaiseShieldRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[149]
+	mi := &file_game_v1_game_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12837,7 +13043,7 @@ func (x *RaiseShieldRequest) String() string {
 func (*RaiseShieldRequest) ProtoMessage() {}
 
 func (x *RaiseShieldRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[149]
+	mi := &file_game_v1_game_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12850,7 +13056,7 @@ func (x *RaiseShieldRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RaiseShieldRequest.ProtoReflect.Descriptor instead.
 func (*RaiseShieldRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{149}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{150}
 }
 
 // TakeCoverRequest asks the server to have the player take cover.
@@ -12862,7 +13068,7 @@ type TakeCoverRequest struct {
 
 func (x *TakeCoverRequest) Reset() {
 	*x = TakeCoverRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[150]
+	mi := &file_game_v1_game_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12874,7 +13080,7 @@ func (x *TakeCoverRequest) String() string {
 func (*TakeCoverRequest) ProtoMessage() {}
 
 func (x *TakeCoverRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[150]
+	mi := &file_game_v1_game_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12887,7 +13093,7 @@ func (x *TakeCoverRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TakeCoverRequest.ProtoReflect.Descriptor instead.
 func (*TakeCoverRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{150}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{151}
 }
 
 // FirstAidRequest asks the server to apply first aid to the player.
@@ -12899,7 +13105,7 @@ type FirstAidRequest struct {
 
 func (x *FirstAidRequest) Reset() {
 	*x = FirstAidRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[151]
+	mi := &file_game_v1_game_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12911,7 +13117,7 @@ func (x *FirstAidRequest) String() string {
 func (*FirstAidRequest) ProtoMessage() {}
 
 func (x *FirstAidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[151]
+	mi := &file_game_v1_game_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12924,7 +13130,7 @@ func (x *FirstAidRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FirstAidRequest.ProtoReflect.Descriptor instead.
 func (*FirstAidRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{151}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{152}
 }
 
 // FeintRequest asks the server to feint against a target NPC.
@@ -12937,7 +13143,7 @@ type FeintRequest struct {
 
 func (x *FeintRequest) Reset() {
 	*x = FeintRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[152]
+	mi := &file_game_v1_game_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12949,7 +13155,7 @@ func (x *FeintRequest) String() string {
 func (*FeintRequest) ProtoMessage() {}
 
 func (x *FeintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[152]
+	mi := &file_game_v1_game_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12962,7 +13168,7 @@ func (x *FeintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeintRequest.ProtoReflect.Descriptor instead.
 func (*FeintRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{152}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *FeintRequest) GetTarget() string {
@@ -12982,7 +13188,7 @@ type DemoralizeRequest struct {
 
 func (x *DemoralizeRequest) Reset() {
 	*x = DemoralizeRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[153]
+	mi := &file_game_v1_game_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12994,7 +13200,7 @@ func (x *DemoralizeRequest) String() string {
 func (*DemoralizeRequest) ProtoMessage() {}
 
 func (x *DemoralizeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[153]
+	mi := &file_game_v1_game_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13007,7 +13213,7 @@ func (x *DemoralizeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DemoralizeRequest.ProtoReflect.Descriptor instead.
 func (*DemoralizeRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{153}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *DemoralizeRequest) GetTarget() string {
@@ -13027,7 +13233,7 @@ type GrappleRequest struct {
 
 func (x *GrappleRequest) Reset() {
 	*x = GrappleRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[154]
+	mi := &file_game_v1_game_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13039,7 +13245,7 @@ func (x *GrappleRequest) String() string {
 func (*GrappleRequest) ProtoMessage() {}
 
 func (x *GrappleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[154]
+	mi := &file_game_v1_game_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13052,7 +13258,7 @@ func (x *GrappleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GrappleRequest.ProtoReflect.Descriptor instead.
 func (*GrappleRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{154}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *GrappleRequest) GetTarget() string {
@@ -13072,7 +13278,7 @@ type TripRequest struct {
 
 func (x *TripRequest) Reset() {
 	*x = TripRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[155]
+	mi := &file_game_v1_game_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13084,7 +13290,7 @@ func (x *TripRequest) String() string {
 func (*TripRequest) ProtoMessage() {}
 
 func (x *TripRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[155]
+	mi := &file_game_v1_game_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13097,7 +13303,7 @@ func (x *TripRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TripRequest.ProtoReflect.Descriptor instead.
 func (*TripRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{155}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *TripRequest) GetTarget() string {
@@ -13117,7 +13323,7 @@ type DisarmRequest struct {
 
 func (x *DisarmRequest) Reset() {
 	*x = DisarmRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[156]
+	mi := &file_game_v1_game_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13129,7 +13335,7 @@ func (x *DisarmRequest) String() string {
 func (*DisarmRequest) ProtoMessage() {}
 
 func (x *DisarmRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[156]
+	mi := &file_game_v1_game_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13142,7 +13348,7 @@ func (x *DisarmRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DisarmRequest.ProtoReflect.Descriptor instead.
 func (*DisarmRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{156}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *DisarmRequest) GetTarget() string {
@@ -13162,7 +13368,7 @@ type StrideRequest struct {
 
 func (x *StrideRequest) Reset() {
 	*x = StrideRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[157]
+	mi := &file_game_v1_game_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13174,7 +13380,7 @@ func (x *StrideRequest) String() string {
 func (*StrideRequest) ProtoMessage() {}
 
 func (x *StrideRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[157]
+	mi := &file_game_v1_game_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13187,7 +13393,7 @@ func (x *StrideRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StrideRequest.ProtoReflect.Descriptor instead.
 func (*StrideRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{157}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *StrideRequest) GetDirection() string {
@@ -13210,7 +13416,7 @@ type MoveToRequest struct {
 
 func (x *MoveToRequest) Reset() {
 	*x = MoveToRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[158]
+	mi := &file_game_v1_game_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13222,7 +13428,7 @@ func (x *MoveToRequest) String() string {
 func (*MoveToRequest) ProtoMessage() {}
 
 func (x *MoveToRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[158]
+	mi := &file_game_v1_game_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13235,7 +13441,7 @@ func (x *MoveToRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveToRequest.ProtoReflect.Descriptor instead.
 func (*MoveToRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{158}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *MoveToRequest) GetTargetX() int32 {
@@ -13262,7 +13468,7 @@ type ShoveRequest struct {
 
 func (x *ShoveRequest) Reset() {
 	*x = ShoveRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[159]
+	mi := &file_game_v1_game_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13274,7 +13480,7 @@ func (x *ShoveRequest) String() string {
 func (*ShoveRequest) ProtoMessage() {}
 
 func (x *ShoveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[159]
+	mi := &file_game_v1_game_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13287,7 +13493,7 @@ func (x *ShoveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShoveRequest.ProtoReflect.Descriptor instead.
 func (*ShoveRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{159}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *ShoveRequest) GetTarget() string {
@@ -13308,7 +13514,7 @@ type StepRequest struct {
 
 func (x *StepRequest) Reset() {
 	*x = StepRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[160]
+	mi := &file_game_v1_game_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13320,7 +13526,7 @@ func (x *StepRequest) String() string {
 func (*StepRequest) ProtoMessage() {}
 
 func (x *StepRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[160]
+	mi := &file_game_v1_game_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13333,7 +13539,7 @@ func (x *StepRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepRequest.ProtoReflect.Descriptor instead.
 func (*StepRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{160}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *StepRequest) GetDirection() string {
@@ -13352,7 +13558,7 @@ type HideRequest struct {
 
 func (x *HideRequest) Reset() {
 	*x = HideRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[161]
+	mi := &file_game_v1_game_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13364,7 +13570,7 @@ func (x *HideRequest) String() string {
 func (*HideRequest) ProtoMessage() {}
 
 func (x *HideRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[161]
+	mi := &file_game_v1_game_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13377,7 +13583,7 @@ func (x *HideRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HideRequest.ProtoReflect.Descriptor instead.
 func (*HideRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{161}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{162}
 }
 
 // SneakRequest asks the server to attempt to sneak while hidden.
@@ -13389,7 +13595,7 @@ type SneakRequest struct {
 
 func (x *SneakRequest) Reset() {
 	*x = SneakRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[162]
+	mi := &file_game_v1_game_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13401,7 +13607,7 @@ func (x *SneakRequest) String() string {
 func (*SneakRequest) ProtoMessage() {}
 
 func (x *SneakRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[162]
+	mi := &file_game_v1_game_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13414,7 +13620,7 @@ func (x *SneakRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SneakRequest.ProtoReflect.Descriptor instead.
 func (*SneakRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{162}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{163}
 }
 
 // DivertRequest asks the server to create a diversion to hide the player.
@@ -13426,7 +13632,7 @@ type DivertRequest struct {
 
 func (x *DivertRequest) Reset() {
 	*x = DivertRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[163]
+	mi := &file_game_v1_game_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13438,7 +13644,7 @@ func (x *DivertRequest) String() string {
 func (*DivertRequest) ProtoMessage() {}
 
 func (x *DivertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[163]
+	mi := &file_game_v1_game_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13451,7 +13657,7 @@ func (x *DivertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DivertRequest.ProtoReflect.Descriptor instead.
 func (*DivertRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{163}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{164}
 }
 
 // EscapeRequest asks the server to escape from the grabbed condition.
@@ -13463,7 +13669,7 @@ type EscapeRequest struct {
 
 func (x *EscapeRequest) Reset() {
 	*x = EscapeRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[164]
+	mi := &file_game_v1_game_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13475,7 +13681,7 @@ func (x *EscapeRequest) String() string {
 func (*EscapeRequest) ProtoMessage() {}
 
 func (x *EscapeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[164]
+	mi := &file_game_v1_game_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13488,7 +13694,7 @@ func (x *EscapeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscapeRequest.ProtoReflect.Descriptor instead.
 func (*EscapeRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{164}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{165}
 }
 
 // TumbleRequest asks the server to tumble through the target NPC's space (Acrobatics vs Hustle DC).
@@ -13501,7 +13707,7 @@ type TumbleRequest struct {
 
 func (x *TumbleRequest) Reset() {
 	*x = TumbleRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[165]
+	mi := &file_game_v1_game_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13513,7 +13719,7 @@ func (x *TumbleRequest) String() string {
 func (*TumbleRequest) ProtoMessage() {}
 
 func (x *TumbleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[165]
+	mi := &file_game_v1_game_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13526,7 +13732,7 @@ func (x *TumbleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TumbleRequest.ProtoReflect.Descriptor instead.
 func (*TumbleRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{165}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *TumbleRequest) GetTarget() string {
@@ -13545,7 +13751,7 @@ type SeekRequest struct {
 
 func (x *SeekRequest) Reset() {
 	*x = SeekRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[166]
+	mi := &file_game_v1_game_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13557,7 +13763,7 @@ func (x *SeekRequest) String() string {
 func (*SeekRequest) ProtoMessage() {}
 
 func (x *SeekRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[166]
+	mi := &file_game_v1_game_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13570,7 +13776,7 @@ func (x *SeekRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SeekRequest.ProtoReflect.Descriptor instead.
 func (*SeekRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{166}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{167}
 }
 
 // ClimbRequest asks the server to attempt climbing a climbable surface.
@@ -13583,7 +13789,7 @@ type ClimbRequest struct {
 
 func (x *ClimbRequest) Reset() {
 	*x = ClimbRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[167]
+	mi := &file_game_v1_game_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13595,7 +13801,7 @@ func (x *ClimbRequest) String() string {
 func (*ClimbRequest) ProtoMessage() {}
 
 func (x *ClimbRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[167]
+	mi := &file_game_v1_game_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13608,7 +13814,7 @@ func (x *ClimbRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClimbRequest.ProtoReflect.Descriptor instead.
 func (*ClimbRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{167}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{168}
 }
 
 func (x *ClimbRequest) GetDirection() string {
@@ -13628,7 +13834,7 @@ type SwimRequest struct {
 
 func (x *SwimRequest) Reset() {
 	*x = SwimRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[168]
+	mi := &file_game_v1_game_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13640,7 +13846,7 @@ func (x *SwimRequest) String() string {
 func (*SwimRequest) ProtoMessage() {}
 
 func (x *SwimRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[168]
+	mi := &file_game_v1_game_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13653,7 +13859,7 @@ func (x *SwimRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwimRequest.ProtoReflect.Descriptor instead.
 func (*SwimRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{168}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{169}
 }
 
 func (x *SwimRequest) GetDirection() string {
@@ -13672,7 +13878,7 @@ type CalmRequest struct {
 
 func (x *CalmRequest) Reset() {
 	*x = CalmRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[169]
+	mi := &file_game_v1_game_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13684,7 +13890,7 @@ func (x *CalmRequest) String() string {
 func (*CalmRequest) ProtoMessage() {}
 
 func (x *CalmRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[169]
+	mi := &file_game_v1_game_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13697,7 +13903,7 @@ func (x *CalmRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CalmRequest.ProtoReflect.Descriptor instead.
 func (*CalmRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{169}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{170}
 }
 
 // HeroPointRequest asks the server to spend a hero point.
@@ -13710,7 +13916,7 @@ type HeroPointRequest struct {
 
 func (x *HeroPointRequest) Reset() {
 	*x = HeroPointRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[170]
+	mi := &file_game_v1_game_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13722,7 +13928,7 @@ func (x *HeroPointRequest) String() string {
 func (*HeroPointRequest) ProtoMessage() {}
 
 func (x *HeroPointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[170]
+	mi := &file_game_v1_game_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13735,7 +13941,7 @@ func (x *HeroPointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeroPointRequest.ProtoReflect.Descriptor instead.
 func (*HeroPointRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{170}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{171}
 }
 
 func (x *HeroPointRequest) GetSubcommand() string {
@@ -13754,7 +13960,7 @@ type DelayRequest struct {
 
 func (x *DelayRequest) Reset() {
 	*x = DelayRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[171]
+	mi := &file_game_v1_game_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13766,7 +13972,7 @@ func (x *DelayRequest) String() string {
 func (*DelayRequest) ProtoMessage() {}
 
 func (x *DelayRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[171]
+	mi := &file_game_v1_game_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13779,7 +13985,7 @@ func (x *DelayRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DelayRequest.ProtoReflect.Descriptor instead.
 func (*DelayRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{171}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{172}
 }
 
 // JoinRequest asks the server to join active combat in the current room.
@@ -13791,7 +13997,7 @@ type JoinRequest struct {
 
 func (x *JoinRequest) Reset() {
 	*x = JoinRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[172]
+	mi := &file_game_v1_game_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13803,7 +14009,7 @@ func (x *JoinRequest) String() string {
 func (*JoinRequest) ProtoMessage() {}
 
 func (x *JoinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[172]
+	mi := &file_game_v1_game_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13816,7 +14022,7 @@ func (x *JoinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRequest.ProtoReflect.Descriptor instead.
 func (*JoinRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{172}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{173}
 }
 
 // DeclineRequest asks the server to decline joining active combat.
@@ -13828,7 +14034,7 @@ type DeclineRequest struct {
 
 func (x *DeclineRequest) Reset() {
 	*x = DeclineRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[173]
+	mi := &file_game_v1_game_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13840,7 +14046,7 @@ func (x *DeclineRequest) String() string {
 func (*DeclineRequest) ProtoMessage() {}
 
 func (x *DeclineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[173]
+	mi := &file_game_v1_game_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13853,7 +14059,7 @@ func (x *DeclineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeclineRequest.ProtoReflect.Descriptor instead.
 func (*DeclineRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{173}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{174}
 }
 
 // GroupRequest asks the server to create a group or show group info.
@@ -13867,7 +14073,7 @@ type GroupRequest struct {
 
 func (x *GroupRequest) Reset() {
 	*x = GroupRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[174]
+	mi := &file_game_v1_game_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13879,7 +14085,7 @@ func (x *GroupRequest) String() string {
 func (*GroupRequest) ProtoMessage() {}
 
 func (x *GroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[174]
+	mi := &file_game_v1_game_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13892,7 +14098,7 @@ func (x *GroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupRequest.ProtoReflect.Descriptor instead.
 func (*GroupRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{174}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{175}
 }
 
 func (x *GroupRequest) GetArgs() string {
@@ -13912,7 +14118,7 @@ type InviteRequest struct {
 
 func (x *InviteRequest) Reset() {
 	*x = InviteRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[175]
+	mi := &file_game_v1_game_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13924,7 +14130,7 @@ func (x *InviteRequest) String() string {
 func (*InviteRequest) ProtoMessage() {}
 
 func (x *InviteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[175]
+	mi := &file_game_v1_game_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13937,7 +14143,7 @@ func (x *InviteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InviteRequest.ProtoReflect.Descriptor instead.
 func (*InviteRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{175}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{176}
 }
 
 func (x *InviteRequest) GetPlayer() string {
@@ -13956,7 +14162,7 @@ type AcceptGroupRequest struct {
 
 func (x *AcceptGroupRequest) Reset() {
 	*x = AcceptGroupRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[176]
+	mi := &file_game_v1_game_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13968,7 +14174,7 @@ func (x *AcceptGroupRequest) String() string {
 func (*AcceptGroupRequest) ProtoMessage() {}
 
 func (x *AcceptGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[176]
+	mi := &file_game_v1_game_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13981,7 +14187,7 @@ func (x *AcceptGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AcceptGroupRequest.ProtoReflect.Descriptor instead.
 func (*AcceptGroupRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{176}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{177}
 }
 
 // DeclineGroupRequest asks the server to decline a pending group invitation.
@@ -13993,7 +14199,7 @@ type DeclineGroupRequest struct {
 
 func (x *DeclineGroupRequest) Reset() {
 	*x = DeclineGroupRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[177]
+	mi := &file_game_v1_game_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14005,7 +14211,7 @@ func (x *DeclineGroupRequest) String() string {
 func (*DeclineGroupRequest) ProtoMessage() {}
 
 func (x *DeclineGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[177]
+	mi := &file_game_v1_game_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14018,7 +14224,7 @@ func (x *DeclineGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeclineGroupRequest.ProtoReflect.Descriptor instead.
 func (*DeclineGroupRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{177}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{178}
 }
 
 // UngroupRequest asks the server to leave (or disband) the sender's group.
@@ -14030,7 +14236,7 @@ type UngroupRequest struct {
 
 func (x *UngroupRequest) Reset() {
 	*x = UngroupRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[178]
+	mi := &file_game_v1_game_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14042,7 +14248,7 @@ func (x *UngroupRequest) String() string {
 func (*UngroupRequest) ProtoMessage() {}
 
 func (x *UngroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[178]
+	mi := &file_game_v1_game_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14055,7 +14261,7 @@ func (x *UngroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UngroupRequest.ProtoReflect.Descriptor instead.
 func (*UngroupRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{178}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{179}
 }
 
 // KickRequest asks the server to remove a player from the sender's group.
@@ -14068,7 +14274,7 @@ type KickRequest struct {
 
 func (x *KickRequest) Reset() {
 	*x = KickRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[179]
+	mi := &file_game_v1_game_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14080,7 +14286,7 @@ func (x *KickRequest) String() string {
 func (*KickRequest) ProtoMessage() {}
 
 func (x *KickRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[179]
+	mi := &file_game_v1_game_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14093,7 +14299,7 @@ func (x *KickRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KickRequest.ProtoReflect.Descriptor instead.
 func (*KickRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{179}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{180}
 }
 
 func (x *KickRequest) GetPlayer() string {
@@ -14113,7 +14319,7 @@ type MotiveRequest struct {
 
 func (x *MotiveRequest) Reset() {
 	*x = MotiveRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[180]
+	mi := &file_game_v1_game_proto_msgTypes[181]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14125,7 +14331,7 @@ func (x *MotiveRequest) String() string {
 func (*MotiveRequest) ProtoMessage() {}
 
 func (x *MotiveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[180]
+	mi := &file_game_v1_game_proto_msgTypes[181]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14138,7 +14344,7 @@ func (x *MotiveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MotiveRequest.ProtoReflect.Descriptor instead.
 func (*MotiveRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{180}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{181}
 }
 
 func (x *MotiveRequest) GetTarget() string {
@@ -14161,7 +14367,7 @@ type GrantRequest struct {
 
 func (x *GrantRequest) Reset() {
 	*x = GrantRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[181]
+	mi := &file_game_v1_game_proto_msgTypes[182]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14173,7 +14379,7 @@ func (x *GrantRequest) String() string {
 func (*GrantRequest) ProtoMessage() {}
 
 func (x *GrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[181]
+	mi := &file_game_v1_game_proto_msgTypes[182]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14186,7 +14392,7 @@ func (x *GrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GrantRequest.ProtoReflect.Descriptor instead.
 func (*GrantRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{181}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{182}
 }
 
 func (x *GrantRequest) GetGrantType() string {
@@ -14228,7 +14434,7 @@ type SpawnNPCRequest struct {
 
 func (x *SpawnNPCRequest) Reset() {
 	*x = SpawnNPCRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[182]
+	mi := &file_game_v1_game_proto_msgTypes[183]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14240,7 +14446,7 @@ func (x *SpawnNPCRequest) String() string {
 func (*SpawnNPCRequest) ProtoMessage() {}
 
 func (x *SpawnNPCRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[182]
+	mi := &file_game_v1_game_proto_msgTypes[183]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14253,7 +14459,7 @@ func (x *SpawnNPCRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpawnNPCRequest.ProtoReflect.Descriptor instead.
 func (*SpawnNPCRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{182}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{183}
 }
 
 func (x *SpawnNPCRequest) GetTemplateId() string {
@@ -14280,7 +14486,7 @@ type KillNPCRequest struct {
 
 func (x *KillNPCRequest) Reset() {
 	*x = KillNPCRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[183]
+	mi := &file_game_v1_game_proto_msgTypes[184]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14292,7 +14498,7 @@ func (x *KillNPCRequest) String() string {
 func (*KillNPCRequest) ProtoMessage() {}
 
 func (x *KillNPCRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[183]
+	mi := &file_game_v1_game_proto_msgTypes[184]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14305,7 +14511,7 @@ func (x *KillNPCRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KillNPCRequest.ProtoReflect.Descriptor instead.
 func (*KillNPCRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{183}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{184}
 }
 
 func (x *KillNPCRequest) GetTemplateId() string {
@@ -14327,7 +14533,7 @@ type AddRoomRequest struct {
 
 func (x *AddRoomRequest) Reset() {
 	*x = AddRoomRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[184]
+	mi := &file_game_v1_game_proto_msgTypes[185]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14339,7 +14545,7 @@ func (x *AddRoomRequest) String() string {
 func (*AddRoomRequest) ProtoMessage() {}
 
 func (x *AddRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[184]
+	mi := &file_game_v1_game_proto_msgTypes[185]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14352,7 +14558,7 @@ func (x *AddRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddRoomRequest.ProtoReflect.Descriptor instead.
 func (*AddRoomRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{184}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{185}
 }
 
 func (x *AddRoomRequest) GetZoneId() string {
@@ -14388,7 +14594,7 @@ type AddLinkRequest struct {
 
 func (x *AddLinkRequest) Reset() {
 	*x = AddLinkRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[185]
+	mi := &file_game_v1_game_proto_msgTypes[186]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14400,7 +14606,7 @@ func (x *AddLinkRequest) String() string {
 func (*AddLinkRequest) ProtoMessage() {}
 
 func (x *AddLinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[185]
+	mi := &file_game_v1_game_proto_msgTypes[186]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14413,7 +14619,7 @@ func (x *AddLinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddLinkRequest.ProtoReflect.Descriptor instead.
 func (*AddLinkRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{185}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{186}
 }
 
 func (x *AddLinkRequest) GetFromRoomId() string {
@@ -14448,7 +14654,7 @@ type RemoveLinkRequest struct {
 
 func (x *RemoveLinkRequest) Reset() {
 	*x = RemoveLinkRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[186]
+	mi := &file_game_v1_game_proto_msgTypes[187]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14460,7 +14666,7 @@ func (x *RemoveLinkRequest) String() string {
 func (*RemoveLinkRequest) ProtoMessage() {}
 
 func (x *RemoveLinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[186]
+	mi := &file_game_v1_game_proto_msgTypes[187]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14473,7 +14679,7 @@ func (x *RemoveLinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveLinkRequest.ProtoReflect.Descriptor instead.
 func (*RemoveLinkRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{186}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{187}
 }
 
 func (x *RemoveLinkRequest) GetRoomId() string {
@@ -14501,7 +14707,7 @@ type SetRoomRequest struct {
 
 func (x *SetRoomRequest) Reset() {
 	*x = SetRoomRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[187]
+	mi := &file_game_v1_game_proto_msgTypes[188]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14513,7 +14719,7 @@ func (x *SetRoomRequest) String() string {
 func (*SetRoomRequest) ProtoMessage() {}
 
 func (x *SetRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[187]
+	mi := &file_game_v1_game_proto_msgTypes[188]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14526,7 +14732,7 @@ func (x *SetRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetRoomRequest.ProtoReflect.Descriptor instead.
 func (*SetRoomRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{187}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{188}
 }
 
 func (x *SetRoomRequest) GetField() string {
@@ -14552,7 +14758,7 @@ type EditorCmdsRequest struct {
 
 func (x *EditorCmdsRequest) Reset() {
 	*x = EditorCmdsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[188]
+	mi := &file_game_v1_game_proto_msgTypes[189]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14564,7 +14770,7 @@ func (x *EditorCmdsRequest) String() string {
 func (*EditorCmdsRequest) ProtoMessage() {}
 
 func (x *EditorCmdsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[188]
+	mi := &file_game_v1_game_proto_msgTypes[189]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14577,7 +14783,7 @@ func (x *EditorCmdsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditorCmdsRequest.ProtoReflect.Descriptor instead.
 func (*EditorCmdsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{188}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{189}
 }
 
 // SpawnCharRequest asks the server to create a test character for the claude_player account.
@@ -14590,7 +14796,7 @@ type SpawnCharRequest struct {
 
 func (x *SpawnCharRequest) Reset() {
 	*x = SpawnCharRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[189]
+	mi := &file_game_v1_game_proto_msgTypes[190]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14602,7 +14808,7 @@ func (x *SpawnCharRequest) String() string {
 func (*SpawnCharRequest) ProtoMessage() {}
 
 func (x *SpawnCharRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[189]
+	mi := &file_game_v1_game_proto_msgTypes[190]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14615,7 +14821,7 @@ func (x *SpawnCharRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpawnCharRequest.ProtoReflect.Descriptor instead.
 func (*SpawnCharRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{189}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{190}
 }
 
 func (x *SpawnCharRequest) GetName() string {
@@ -14635,7 +14841,7 @@ type DeleteCharRequest struct {
 
 func (x *DeleteCharRequest) Reset() {
 	*x = DeleteCharRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[190]
+	mi := &file_game_v1_game_proto_msgTypes[191]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14647,7 +14853,7 @@ func (x *DeleteCharRequest) String() string {
 func (*DeleteCharRequest) ProtoMessage() {}
 
 func (x *DeleteCharRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[190]
+	mi := &file_game_v1_game_proto_msgTypes[191]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14660,7 +14866,7 @@ func (x *DeleteCharRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteCharRequest.ProtoReflect.Descriptor instead.
 func (*DeleteCharRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{190}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{191}
 }
 
 func (x *DeleteCharRequest) GetName() string {
@@ -14679,7 +14885,7 @@ type FactionRequest struct {
 
 func (x *FactionRequest) Reset() {
 	*x = FactionRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[191]
+	mi := &file_game_v1_game_proto_msgTypes[192]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14691,7 +14897,7 @@ func (x *FactionRequest) String() string {
 func (*FactionRequest) ProtoMessage() {}
 
 func (x *FactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[191]
+	mi := &file_game_v1_game_proto_msgTypes[192]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14704,7 +14910,7 @@ func (x *FactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FactionRequest.ProtoReflect.Descriptor instead.
 func (*FactionRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{191}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{192}
 }
 
 // FactionInfoRequest asks the server for public information about a specific faction.
@@ -14717,7 +14923,7 @@ type FactionInfoRequest struct {
 
 func (x *FactionInfoRequest) Reset() {
 	*x = FactionInfoRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[192]
+	mi := &file_game_v1_game_proto_msgTypes[193]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14729,7 +14935,7 @@ func (x *FactionInfoRequest) String() string {
 func (*FactionInfoRequest) ProtoMessage() {}
 
 func (x *FactionInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[192]
+	mi := &file_game_v1_game_proto_msgTypes[193]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14742,7 +14948,7 @@ func (x *FactionInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FactionInfoRequest.ProtoReflect.Descriptor instead.
 func (*FactionInfoRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{192}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{193}
 }
 
 func (x *FactionInfoRequest) GetFactionId() string {
@@ -14761,7 +14967,7 @@ type FactionStandingRequest struct {
 
 func (x *FactionStandingRequest) Reset() {
 	*x = FactionStandingRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[193]
+	mi := &file_game_v1_game_proto_msgTypes[194]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14773,7 +14979,7 @@ func (x *FactionStandingRequest) String() string {
 func (*FactionStandingRequest) ProtoMessage() {}
 
 func (x *FactionStandingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[193]
+	mi := &file_game_v1_game_proto_msgTypes[194]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14786,7 +14992,7 @@ func (x *FactionStandingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FactionStandingRequest.ProtoReflect.Descriptor instead.
 func (*FactionStandingRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{193}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{194}
 }
 
 // ChangeRepRequest asks a Fixer NPC to improve the player's faction standing for currency.
@@ -14799,7 +15005,7 @@ type ChangeRepRequest struct {
 
 func (x *ChangeRepRequest) Reset() {
 	*x = ChangeRepRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[194]
+	mi := &file_game_v1_game_proto_msgTypes[195]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14811,7 +15017,7 @@ func (x *ChangeRepRequest) String() string {
 func (*ChangeRepRequest) ProtoMessage() {}
 
 func (x *ChangeRepRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[194]
+	mi := &file_game_v1_game_proto_msgTypes[195]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14824,7 +15030,7 @@ func (x *ChangeRepRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeRepRequest.ProtoReflect.Descriptor instead.
 func (*ChangeRepRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{194}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{195}
 }
 
 func (x *ChangeRepRequest) GetFactionId() string {
@@ -14844,7 +15050,7 @@ type TabCompleteRequest struct {
 
 func (x *TabCompleteRequest) Reset() {
 	*x = TabCompleteRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[195]
+	mi := &file_game_v1_game_proto_msgTypes[196]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14856,7 +15062,7 @@ func (x *TabCompleteRequest) String() string {
 func (*TabCompleteRequest) ProtoMessage() {}
 
 func (x *TabCompleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[195]
+	mi := &file_game_v1_game_proto_msgTypes[196]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14869,7 +15075,7 @@ func (x *TabCompleteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TabCompleteRequest.ProtoReflect.Descriptor instead.
 func (*TabCompleteRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{195}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{196}
 }
 
 func (x *TabCompleteRequest) GetPrefix() string {
@@ -14889,7 +15095,7 @@ type TabCompleteResponse struct {
 
 func (x *TabCompleteResponse) Reset() {
 	*x = TabCompleteResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[196]
+	mi := &file_game_v1_game_proto_msgTypes[197]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14901,7 +15107,7 @@ func (x *TabCompleteResponse) String() string {
 func (*TabCompleteResponse) ProtoMessage() {}
 
 func (x *TabCompleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[196]
+	mi := &file_game_v1_game_proto_msgTypes[197]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14914,7 +15120,7 @@ func (x *TabCompleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TabCompleteResponse.ProtoReflect.Descriptor instead.
 func (*TabCompleteResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{196}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{197}
 }
 
 func (x *TabCompleteResponse) GetCompletions() []string {
@@ -14934,7 +15140,7 @@ type MaterialsRequest struct {
 
 func (x *MaterialsRequest) Reset() {
 	*x = MaterialsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[197]
+	mi := &file_game_v1_game_proto_msgTypes[198]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14946,7 +15152,7 @@ func (x *MaterialsRequest) String() string {
 func (*MaterialsRequest) ProtoMessage() {}
 
 func (x *MaterialsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[197]
+	mi := &file_game_v1_game_proto_msgTypes[198]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14959,7 +15165,7 @@ func (x *MaterialsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MaterialsRequest.ProtoReflect.Descriptor instead.
 func (*MaterialsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{197}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{198}
 }
 
 func (x *MaterialsRequest) GetCategory() string {
@@ -14979,7 +15185,7 @@ type CraftListRequest struct {
 
 func (x *CraftListRequest) Reset() {
 	*x = CraftListRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[198]
+	mi := &file_game_v1_game_proto_msgTypes[199]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14991,7 +15197,7 @@ func (x *CraftListRequest) String() string {
 func (*CraftListRequest) ProtoMessage() {}
 
 func (x *CraftListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[198]
+	mi := &file_game_v1_game_proto_msgTypes[199]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15004,7 +15210,7 @@ func (x *CraftListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftListRequest.ProtoReflect.Descriptor instead.
 func (*CraftListRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{198}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{199}
 }
 
 func (x *CraftListRequest) GetCategory() string {
@@ -15024,7 +15230,7 @@ type CraftRequest struct {
 
 func (x *CraftRequest) Reset() {
 	*x = CraftRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[199]
+	mi := &file_game_v1_game_proto_msgTypes[200]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15036,7 +15242,7 @@ func (x *CraftRequest) String() string {
 func (*CraftRequest) ProtoMessage() {}
 
 func (x *CraftRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[199]
+	mi := &file_game_v1_game_proto_msgTypes[200]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15049,7 +15255,7 @@ func (x *CraftRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftRequest.ProtoReflect.Descriptor instead.
 func (*CraftRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{199}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{200}
 }
 
 func (x *CraftRequest) GetRecipeId() string {
@@ -15068,7 +15274,7 @@ type CraftConfirmRequest struct {
 
 func (x *CraftConfirmRequest) Reset() {
 	*x = CraftConfirmRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[200]
+	mi := &file_game_v1_game_proto_msgTypes[201]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15080,7 +15286,7 @@ func (x *CraftConfirmRequest) String() string {
 func (*CraftConfirmRequest) ProtoMessage() {}
 
 func (x *CraftConfirmRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[200]
+	mi := &file_game_v1_game_proto_msgTypes[201]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15093,7 +15299,7 @@ func (x *CraftConfirmRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftConfirmRequest.ProtoReflect.Descriptor instead.
 func (*CraftConfirmRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{200}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{201}
 }
 
 // ScavengeRequest asks the server to scavenge the current room for materials.
@@ -15105,7 +15311,7 @@ type ScavengeRequest struct {
 
 func (x *ScavengeRequest) Reset() {
 	*x = ScavengeRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[201]
+	mi := &file_game_v1_game_proto_msgTypes[202]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15117,7 +15323,7 @@ func (x *ScavengeRequest) String() string {
 func (*ScavengeRequest) ProtoMessage() {}
 
 func (x *ScavengeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[201]
+	mi := &file_game_v1_game_proto_msgTypes[202]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15130,7 +15336,7 @@ func (x *ScavengeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScavengeRequest.ProtoReflect.Descriptor instead.
 func (*ScavengeRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{201}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{202}
 }
 
 // AffixRequest asks the server to affix a precious material to an equipped item.
@@ -15144,7 +15350,7 @@ type AffixRequest struct {
 
 func (x *AffixRequest) Reset() {
 	*x = AffixRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[202]
+	mi := &file_game_v1_game_proto_msgTypes[203]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15156,7 +15362,7 @@ func (x *AffixRequest) String() string {
 func (*AffixRequest) ProtoMessage() {}
 
 func (x *AffixRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[202]
+	mi := &file_game_v1_game_proto_msgTypes[203]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15169,7 +15375,7 @@ func (x *AffixRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AffixRequest.ProtoReflect.Descriptor instead.
 func (*AffixRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{202}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{203}
 }
 
 func (x *AffixRequest) GetMaterialQuery() string {
@@ -15202,7 +15408,7 @@ type ExploreRequest struct {
 
 func (x *ExploreRequest) Reset() {
 	*x = ExploreRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[203]
+	mi := &file_game_v1_game_proto_msgTypes[204]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15214,7 +15420,7 @@ func (x *ExploreRequest) String() string {
 func (*ExploreRequest) ProtoMessage() {}
 
 func (x *ExploreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[203]
+	mi := &file_game_v1_game_proto_msgTypes[204]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15227,7 +15433,7 @@ func (x *ExploreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExploreRequest.ProtoReflect.Descriptor instead.
 func (*ExploreRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{203}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{204}
 }
 
 func (x *ExploreRequest) GetMode() string {
@@ -15253,7 +15459,7 @@ type RefocusRequest struct {
 
 func (x *RefocusRequest) Reset() {
 	*x = RefocusRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[204]
+	mi := &file_game_v1_game_proto_msgTypes[205]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15265,7 +15471,7 @@ func (x *RefocusRequest) String() string {
 func (*RefocusRequest) ProtoMessage() {}
 
 func (x *RefocusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[204]
+	mi := &file_game_v1_game_proto_msgTypes[205]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15278,7 +15484,7 @@ func (x *RefocusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefocusRequest.ProtoReflect.Descriptor instead.
 func (*RefocusRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{204}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{205}
 }
 
 // SeduceRequest asks the server to attempt to seduce a target NPC (REQ-ZN-7).
@@ -15291,7 +15497,7 @@ type SeduceRequest struct {
 
 func (x *SeduceRequest) Reset() {
 	*x = SeduceRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[205]
+	mi := &file_game_v1_game_proto_msgTypes[206]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15303,7 +15509,7 @@ func (x *SeduceRequest) String() string {
 func (*SeduceRequest) ProtoMessage() {}
 
 func (x *SeduceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[205]
+	mi := &file_game_v1_game_proto_msgTypes[206]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15316,7 +15522,7 @@ func (x *SeduceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SeduceRequest.ProtoReflect.Descriptor instead.
 func (*SeduceRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{205}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{206}
 }
 
 func (x *SeduceRequest) GetTarget() string {
@@ -15351,7 +15557,7 @@ type HotbarSlot struct {
 
 func (x *HotbarSlot) Reset() {
 	*x = HotbarSlot{}
-	mi := &file_game_v1_game_proto_msgTypes[206]
+	mi := &file_game_v1_game_proto_msgTypes[207]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15363,7 +15569,7 @@ func (x *HotbarSlot) String() string {
 func (*HotbarSlot) ProtoMessage() {}
 
 func (x *HotbarSlot) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[206]
+	mi := &file_game_v1_game_proto_msgTypes[207]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15376,7 +15582,7 @@ func (x *HotbarSlot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HotbarSlot.ProtoReflect.Descriptor instead.
 func (*HotbarSlot) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{206}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{207}
 }
 
 func (x *HotbarSlot) GetKind() string {
@@ -15459,7 +15665,7 @@ type HotbarRequest struct {
 
 func (x *HotbarRequest) Reset() {
 	*x = HotbarRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[207]
+	mi := &file_game_v1_game_proto_msgTypes[208]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15471,7 +15677,7 @@ func (x *HotbarRequest) String() string {
 func (*HotbarRequest) ProtoMessage() {}
 
 func (x *HotbarRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[207]
+	mi := &file_game_v1_game_proto_msgTypes[208]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15484,7 +15690,7 @@ func (x *HotbarRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HotbarRequest.ProtoReflect.Descriptor instead.
 func (*HotbarRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{207}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{208}
 }
 
 func (x *HotbarRequest) GetAction() string {
@@ -15544,7 +15750,7 @@ type HotbarUpdateEvent struct {
 
 func (x *HotbarUpdateEvent) Reset() {
 	*x = HotbarUpdateEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[208]
+	mi := &file_game_v1_game_proto_msgTypes[209]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15556,7 +15762,7 @@ func (x *HotbarUpdateEvent) String() string {
 func (*HotbarUpdateEvent) ProtoMessage() {}
 
 func (x *HotbarUpdateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[208]
+	mi := &file_game_v1_game_proto_msgTypes[209]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15569,7 +15775,7 @@ func (x *HotbarUpdateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HotbarUpdateEvent.ProtoReflect.Descriptor instead.
 func (*HotbarUpdateEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{208}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{209}
 }
 
 func (x *HotbarUpdateEvent) GetSlots() []*HotbarSlot {
@@ -15611,7 +15817,7 @@ type DowntimeRequest struct {
 
 func (x *DowntimeRequest) Reset() {
 	*x = DowntimeRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[209]
+	mi := &file_game_v1_game_proto_msgTypes[210]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15623,7 +15829,7 @@ func (x *DowntimeRequest) String() string {
 func (*DowntimeRequest) ProtoMessage() {}
 
 func (x *DowntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[209]
+	mi := &file_game_v1_game_proto_msgTypes[210]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15636,7 +15842,7 @@ func (x *DowntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DowntimeRequest.ProtoReflect.Descriptor instead.
 func (*DowntimeRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{209}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{210}
 }
 
 func (x *DowntimeRequest) GetSubcommand() string {
@@ -15664,7 +15870,7 @@ type QuestRequest struct {
 
 func (x *QuestRequest) Reset() {
 	*x = QuestRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[210]
+	mi := &file_game_v1_game_proto_msgTypes[211]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15676,7 +15882,7 @@ func (x *QuestRequest) String() string {
 func (*QuestRequest) ProtoMessage() {}
 
 func (x *QuestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[210]
+	mi := &file_game_v1_game_proto_msgTypes[211]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15689,7 +15895,7 @@ func (x *QuestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuestRequest.ProtoReflect.Descriptor instead.
 func (*QuestRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{210}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{211}
 }
 
 func (x *QuestRequest) GetArgs() string {
@@ -15710,7 +15916,7 @@ type MaterialLoss struct {
 
 func (x *MaterialLoss) Reset() {
 	*x = MaterialLoss{}
-	mi := &file_game_v1_game_proto_msgTypes[211]
+	mi := &file_game_v1_game_proto_msgTypes[212]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15722,7 +15928,7 @@ func (x *MaterialLoss) String() string {
 func (*MaterialLoss) ProtoMessage() {}
 
 func (x *MaterialLoss) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[211]
+	mi := &file_game_v1_game_proto_msgTypes[212]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15735,7 +15941,7 @@ func (x *MaterialLoss) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MaterialLoss.ProtoReflect.Descriptor instead.
 func (*MaterialLoss) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{211}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{212}
 }
 
 func (x *MaterialLoss) GetMaterialId() string {
@@ -15765,7 +15971,7 @@ type CraftResultEvent struct {
 
 func (x *CraftResultEvent) Reset() {
 	*x = CraftResultEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[212]
+	mi := &file_game_v1_game_proto_msgTypes[213]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15777,7 +15983,7 @@ func (x *CraftResultEvent) String() string {
 func (*CraftResultEvent) ProtoMessage() {}
 
 func (x *CraftResultEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[212]
+	mi := &file_game_v1_game_proto_msgTypes[213]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15790,7 +15996,7 @@ func (x *CraftResultEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftResultEvent.ProtoReflect.Descriptor instead.
 func (*CraftResultEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{212}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{213}
 }
 
 func (x *CraftResultEvent) GetSuccess() bool {
@@ -15832,7 +16038,7 @@ type UncurseRequest struct {
 
 func (x *UncurseRequest) Reset() {
 	*x = UncurseRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[213]
+	mi := &file_game_v1_game_proto_msgTypes[214]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15844,7 +16050,7 @@ func (x *UncurseRequest) String() string {
 func (*UncurseRequest) ProtoMessage() {}
 
 func (x *UncurseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[213]
+	mi := &file_game_v1_game_proto_msgTypes[214]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15857,7 +16063,7 @@ func (x *UncurseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UncurseRequest.ProtoReflect.Descriptor instead.
 func (*UncurseRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{213}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{214}
 }
 
 func (x *UncurseRequest) GetNpcName() string {
@@ -15886,7 +16092,7 @@ type WeatherEvent struct {
 
 func (x *WeatherEvent) Reset() {
 	*x = WeatherEvent{}
-	mi := &file_game_v1_game_proto_msgTypes[214]
+	mi := &file_game_v1_game_proto_msgTypes[215]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15898,7 +16104,7 @@ func (x *WeatherEvent) String() string {
 func (*WeatherEvent) ProtoMessage() {}
 
 func (x *WeatherEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[214]
+	mi := &file_game_v1_game_proto_msgTypes[215]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15911,7 +16117,7 @@ func (x *WeatherEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WeatherEvent.ProtoReflect.Descriptor instead.
 func (*WeatherEvent) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{214}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{215}
 }
 
 func (x *WeatherEvent) GetWeatherName() string {
@@ -15944,7 +16150,7 @@ type JobGrantsRequest struct {
 
 func (x *JobGrantsRequest) Reset() {
 	*x = JobGrantsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[215]
+	mi := &file_game_v1_game_proto_msgTypes[216]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15956,7 +16162,7 @@ func (x *JobGrantsRequest) String() string {
 func (*JobGrantsRequest) ProtoMessage() {}
 
 func (x *JobGrantsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[215]
+	mi := &file_game_v1_game_proto_msgTypes[216]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15969,7 +16175,7 @@ func (x *JobGrantsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobGrantsRequest.ProtoReflect.Descriptor instead.
 func (*JobGrantsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{215}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{216}
 }
 
 // JobFeatGrant describes a single feat granted by the job at a specific level.
@@ -15984,7 +16190,7 @@ type JobFeatGrant struct {
 
 func (x *JobFeatGrant) Reset() {
 	*x = JobFeatGrant{}
-	mi := &file_game_v1_game_proto_msgTypes[216]
+	mi := &file_game_v1_game_proto_msgTypes[217]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15996,7 +16202,7 @@ func (x *JobFeatGrant) String() string {
 func (*JobFeatGrant) ProtoMessage() {}
 
 func (x *JobFeatGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[216]
+	mi := &file_game_v1_game_proto_msgTypes[217]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16009,7 +16215,7 @@ func (x *JobFeatGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobFeatGrant.ProtoReflect.Descriptor instead.
 func (*JobFeatGrant) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{216}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{217}
 }
 
 func (x *JobFeatGrant) GetGrantLevel() int32 {
@@ -16047,7 +16253,7 @@ type JobTechGrant struct {
 
 func (x *JobTechGrant) Reset() {
 	*x = JobTechGrant{}
-	mi := &file_game_v1_game_proto_msgTypes[217]
+	mi := &file_game_v1_game_proto_msgTypes[218]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16059,7 +16265,7 @@ func (x *JobTechGrant) String() string {
 func (*JobTechGrant) ProtoMessage() {}
 
 func (x *JobTechGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[217]
+	mi := &file_game_v1_game_proto_msgTypes[218]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16072,7 +16278,7 @@ func (x *JobTechGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobTechGrant.ProtoReflect.Descriptor instead.
 func (*JobTechGrant) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{217}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{218}
 }
 
 func (x *JobTechGrant) GetGrantLevel() int32 {
@@ -16122,7 +16328,7 @@ type JobGrantsResponse struct {
 
 func (x *JobGrantsResponse) Reset() {
 	*x = JobGrantsResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[218]
+	mi := &file_game_v1_game_proto_msgTypes[219]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16134,7 +16340,7 @@ func (x *JobGrantsResponse) String() string {
 func (*JobGrantsResponse) ProtoMessage() {}
 
 func (x *JobGrantsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[218]
+	mi := &file_game_v1_game_proto_msgTypes[219]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16147,7 +16353,7 @@ func (x *JobGrantsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobGrantsResponse.ProtoReflect.Descriptor instead.
 func (*JobGrantsResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{218}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{219}
 }
 
 func (x *JobGrantsResponse) GetFeatGrants() []*JobFeatGrant {
@@ -16186,7 +16392,7 @@ type FeatOption struct {
 
 func (x *FeatOption) Reset() {
 	*x = FeatOption{}
-	mi := &file_game_v1_game_proto_msgTypes[219]
+	mi := &file_game_v1_game_proto_msgTypes[220]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16198,7 +16404,7 @@ func (x *FeatOption) String() string {
 func (*FeatOption) ProtoMessage() {}
 
 func (x *FeatOption) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[219]
+	mi := &file_game_v1_game_proto_msgTypes[220]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16211,7 +16417,7 @@ func (x *FeatOption) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeatOption.ProtoReflect.Descriptor instead.
 func (*FeatOption) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{219}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{220}
 }
 
 func (x *FeatOption) GetFeatId() string {
@@ -16256,7 +16462,7 @@ type PendingFeatChoice struct {
 
 func (x *PendingFeatChoice) Reset() {
 	*x = PendingFeatChoice{}
-	mi := &file_game_v1_game_proto_msgTypes[220]
+	mi := &file_game_v1_game_proto_msgTypes[221]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16268,7 +16474,7 @@ func (x *PendingFeatChoice) String() string {
 func (*PendingFeatChoice) ProtoMessage() {}
 
 func (x *PendingFeatChoice) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[220]
+	mi := &file_game_v1_game_proto_msgTypes[221]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16281,7 +16487,7 @@ func (x *PendingFeatChoice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PendingFeatChoice.ProtoReflect.Descriptor instead.
 func (*PendingFeatChoice) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{220}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{221}
 }
 
 func (x *PendingFeatChoice) GetGrantLevel() int32 {
@@ -16318,7 +16524,7 @@ type ChooseFeatRequest struct {
 
 func (x *ChooseFeatRequest) Reset() {
 	*x = ChooseFeatRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[221]
+	mi := &file_game_v1_game_proto_msgTypes[222]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16330,7 +16536,7 @@ func (x *ChooseFeatRequest) String() string {
 func (*ChooseFeatRequest) ProtoMessage() {}
 
 func (x *ChooseFeatRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[221]
+	mi := &file_game_v1_game_proto_msgTypes[222]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16343,7 +16549,7 @@ func (x *ChooseFeatRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChooseFeatRequest.ProtoReflect.Descriptor instead.
 func (*ChooseFeatRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{221}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{222}
 }
 
 func (x *ChooseFeatRequest) GetGrantLevel() int32 {
@@ -16376,7 +16582,7 @@ type AdminSessionInfo struct {
 
 func (x *AdminSessionInfo) Reset() {
 	*x = AdminSessionInfo{}
-	mi := &file_game_v1_game_proto_msgTypes[222]
+	mi := &file_game_v1_game_proto_msgTypes[223]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16388,7 +16594,7 @@ func (x *AdminSessionInfo) String() string {
 func (*AdminSessionInfo) ProtoMessage() {}
 
 func (x *AdminSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[222]
+	mi := &file_game_v1_game_proto_msgTypes[223]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16401,7 +16607,7 @@ func (x *AdminSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminSessionInfo.ProtoReflect.Descriptor instead.
 func (*AdminSessionInfo) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{222}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{223}
 }
 
 func (x *AdminSessionInfo) GetCharId() int64 {
@@ -16461,7 +16667,7 @@ type AdminListSessionsRequest struct {
 
 func (x *AdminListSessionsRequest) Reset() {
 	*x = AdminListSessionsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[223]
+	mi := &file_game_v1_game_proto_msgTypes[224]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16473,7 +16679,7 @@ func (x *AdminListSessionsRequest) String() string {
 func (*AdminListSessionsRequest) ProtoMessage() {}
 
 func (x *AdminListSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[223]
+	mi := &file_game_v1_game_proto_msgTypes[224]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16486,7 +16692,7 @@ func (x *AdminListSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListSessionsRequest.ProtoReflect.Descriptor instead.
 func (*AdminListSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{223}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{224}
 }
 
 type AdminListSessionsResponse struct {
@@ -16498,7 +16704,7 @@ type AdminListSessionsResponse struct {
 
 func (x *AdminListSessionsResponse) Reset() {
 	*x = AdminListSessionsResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[224]
+	mi := &file_game_v1_game_proto_msgTypes[225]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16510,7 +16716,7 @@ func (x *AdminListSessionsResponse) String() string {
 func (*AdminListSessionsResponse) ProtoMessage() {}
 
 func (x *AdminListSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[224]
+	mi := &file_game_v1_game_proto_msgTypes[225]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16523,7 +16729,7 @@ func (x *AdminListSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListSessionsResponse.ProtoReflect.Descriptor instead.
 func (*AdminListSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{224}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{225}
 }
 
 func (x *AdminListSessionsResponse) GetSessions() []*AdminSessionInfo {
@@ -16542,7 +16748,7 @@ type AdminKickRequest struct {
 
 func (x *AdminKickRequest) Reset() {
 	*x = AdminKickRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[225]
+	mi := &file_game_v1_game_proto_msgTypes[226]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16554,7 +16760,7 @@ func (x *AdminKickRequest) String() string {
 func (*AdminKickRequest) ProtoMessage() {}
 
 func (x *AdminKickRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[225]
+	mi := &file_game_v1_game_proto_msgTypes[226]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16567,7 +16773,7 @@ func (x *AdminKickRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminKickRequest.ProtoReflect.Descriptor instead.
 func (*AdminKickRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{225}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{226}
 }
 
 func (x *AdminKickRequest) GetCharId() int64 {
@@ -16585,7 +16791,7 @@ type AdminKickResponse struct {
 
 func (x *AdminKickResponse) Reset() {
 	*x = AdminKickResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[226]
+	mi := &file_game_v1_game_proto_msgTypes[227]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16597,7 +16803,7 @@ func (x *AdminKickResponse) String() string {
 func (*AdminKickResponse) ProtoMessage() {}
 
 func (x *AdminKickResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[226]
+	mi := &file_game_v1_game_proto_msgTypes[227]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16610,7 +16816,7 @@ func (x *AdminKickResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminKickResponse.ProtoReflect.Descriptor instead.
 func (*AdminKickResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{226}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{227}
 }
 
 type AdminMessageRequest struct {
@@ -16623,7 +16829,7 @@ type AdminMessageRequest struct {
 
 func (x *AdminMessageRequest) Reset() {
 	*x = AdminMessageRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[227]
+	mi := &file_game_v1_game_proto_msgTypes[228]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16635,7 +16841,7 @@ func (x *AdminMessageRequest) String() string {
 func (*AdminMessageRequest) ProtoMessage() {}
 
 func (x *AdminMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[227]
+	mi := &file_game_v1_game_proto_msgTypes[228]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16648,7 +16854,7 @@ func (x *AdminMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminMessageRequest.ProtoReflect.Descriptor instead.
 func (*AdminMessageRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{227}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{228}
 }
 
 func (x *AdminMessageRequest) GetCharId() int64 {
@@ -16673,7 +16879,7 @@ type AdminMessageResponse struct {
 
 func (x *AdminMessageResponse) Reset() {
 	*x = AdminMessageResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[228]
+	mi := &file_game_v1_game_proto_msgTypes[229]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16685,7 +16891,7 @@ func (x *AdminMessageResponse) String() string {
 func (*AdminMessageResponse) ProtoMessage() {}
 
 func (x *AdminMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[228]
+	mi := &file_game_v1_game_proto_msgTypes[229]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16698,7 +16904,7 @@ func (x *AdminMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminMessageResponse.ProtoReflect.Descriptor instead.
 func (*AdminMessageResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{228}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{229}
 }
 
 type AdminTeleportRequest struct {
@@ -16711,7 +16917,7 @@ type AdminTeleportRequest struct {
 
 func (x *AdminTeleportRequest) Reset() {
 	*x = AdminTeleportRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[229]
+	mi := &file_game_v1_game_proto_msgTypes[230]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16723,7 +16929,7 @@ func (x *AdminTeleportRequest) String() string {
 func (*AdminTeleportRequest) ProtoMessage() {}
 
 func (x *AdminTeleportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[229]
+	mi := &file_game_v1_game_proto_msgTypes[230]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16736,7 +16942,7 @@ func (x *AdminTeleportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminTeleportRequest.ProtoReflect.Descriptor instead.
 func (*AdminTeleportRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{229}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{230}
 }
 
 func (x *AdminTeleportRequest) GetCharId() int64 {
@@ -16761,7 +16967,7 @@ type AdminTeleportResponse struct {
 
 func (x *AdminTeleportResponse) Reset() {
 	*x = AdminTeleportResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[230]
+	mi := &file_game_v1_game_proto_msgTypes[231]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16773,7 +16979,7 @@ func (x *AdminTeleportResponse) String() string {
 func (*AdminTeleportResponse) ProtoMessage() {}
 
 func (x *AdminTeleportResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[230]
+	mi := &file_game_v1_game_proto_msgTypes[231]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16786,7 +16992,7 @@ func (x *AdminTeleportResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminTeleportResponse.ProtoReflect.Descriptor instead.
 func (*AdminTeleportResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{230}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{231}
 }
 
 type AdminListZonesRequest struct {
@@ -16797,7 +17003,7 @@ type AdminListZonesRequest struct {
 
 func (x *AdminListZonesRequest) Reset() {
 	*x = AdminListZonesRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[231]
+	mi := &file_game_v1_game_proto_msgTypes[232]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16809,7 +17015,7 @@ func (x *AdminListZonesRequest) String() string {
 func (*AdminListZonesRequest) ProtoMessage() {}
 
 func (x *AdminListZonesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[231]
+	mi := &file_game_v1_game_proto_msgTypes[232]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16822,7 +17028,7 @@ func (x *AdminListZonesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListZonesRequest.ProtoReflect.Descriptor instead.
 func (*AdminListZonesRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{231}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{232}
 }
 
 type AdminZoneSummary struct {
@@ -16837,7 +17043,7 @@ type AdminZoneSummary struct {
 
 func (x *AdminZoneSummary) Reset() {
 	*x = AdminZoneSummary{}
-	mi := &file_game_v1_game_proto_msgTypes[232]
+	mi := &file_game_v1_game_proto_msgTypes[233]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16849,7 +17055,7 @@ func (x *AdminZoneSummary) String() string {
 func (*AdminZoneSummary) ProtoMessage() {}
 
 func (x *AdminZoneSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[232]
+	mi := &file_game_v1_game_proto_msgTypes[233]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16862,7 +17068,7 @@ func (x *AdminZoneSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminZoneSummary.ProtoReflect.Descriptor instead.
 func (*AdminZoneSummary) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{232}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{233}
 }
 
 func (x *AdminZoneSummary) GetId() string {
@@ -16902,7 +17108,7 @@ type AdminListZonesResponse struct {
 
 func (x *AdminListZonesResponse) Reset() {
 	*x = AdminListZonesResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[233]
+	mi := &file_game_v1_game_proto_msgTypes[234]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16914,7 +17120,7 @@ func (x *AdminListZonesResponse) String() string {
 func (*AdminListZonesResponse) ProtoMessage() {}
 
 func (x *AdminListZonesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[233]
+	mi := &file_game_v1_game_proto_msgTypes[234]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16927,7 +17133,7 @@ func (x *AdminListZonesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListZonesResponse.ProtoReflect.Descriptor instead.
 func (*AdminListZonesResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{233}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{234}
 }
 
 func (x *AdminListZonesResponse) GetZones() []*AdminZoneSummary {
@@ -16946,7 +17152,7 @@ type AdminListRoomsRequest struct {
 
 func (x *AdminListRoomsRequest) Reset() {
 	*x = AdminListRoomsRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[234]
+	mi := &file_game_v1_game_proto_msgTypes[235]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16958,7 +17164,7 @@ func (x *AdminListRoomsRequest) String() string {
 func (*AdminListRoomsRequest) ProtoMessage() {}
 
 func (x *AdminListRoomsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[234]
+	mi := &file_game_v1_game_proto_msgTypes[235]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16971,7 +17177,7 @@ func (x *AdminListRoomsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListRoomsRequest.ProtoReflect.Descriptor instead.
 func (*AdminListRoomsRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{234}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{235}
 }
 
 func (x *AdminListRoomsRequest) GetZoneId() string {
@@ -16993,7 +17199,7 @@ type AdminRoomSummary struct {
 
 func (x *AdminRoomSummary) Reset() {
 	*x = AdminRoomSummary{}
-	mi := &file_game_v1_game_proto_msgTypes[235]
+	mi := &file_game_v1_game_proto_msgTypes[236]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17005,7 +17211,7 @@ func (x *AdminRoomSummary) String() string {
 func (*AdminRoomSummary) ProtoMessage() {}
 
 func (x *AdminRoomSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[235]
+	mi := &file_game_v1_game_proto_msgTypes[236]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17018,7 +17224,7 @@ func (x *AdminRoomSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminRoomSummary.ProtoReflect.Descriptor instead.
 func (*AdminRoomSummary) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{235}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{236}
 }
 
 func (x *AdminRoomSummary) GetId() string {
@@ -17058,7 +17264,7 @@ type AdminListRoomsResponse struct {
 
 func (x *AdminListRoomsResponse) Reset() {
 	*x = AdminListRoomsResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[236]
+	mi := &file_game_v1_game_proto_msgTypes[237]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17070,7 +17276,7 @@ func (x *AdminListRoomsResponse) String() string {
 func (*AdminListRoomsResponse) ProtoMessage() {}
 
 func (x *AdminListRoomsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[236]
+	mi := &file_game_v1_game_proto_msgTypes[237]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17083,7 +17289,7 @@ func (x *AdminListRoomsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListRoomsResponse.ProtoReflect.Descriptor instead.
 func (*AdminListRoomsResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{236}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{237}
 }
 
 func (x *AdminListRoomsResponse) GetRooms() []*AdminRoomSummary {
@@ -17105,7 +17311,7 @@ type AdminUpdateRoomRequest struct {
 
 func (x *AdminUpdateRoomRequest) Reset() {
 	*x = AdminUpdateRoomRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[237]
+	mi := &file_game_v1_game_proto_msgTypes[238]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17117,7 +17323,7 @@ func (x *AdminUpdateRoomRequest) String() string {
 func (*AdminUpdateRoomRequest) ProtoMessage() {}
 
 func (x *AdminUpdateRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[237]
+	mi := &file_game_v1_game_proto_msgTypes[238]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17130,7 +17336,7 @@ func (x *AdminUpdateRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminUpdateRoomRequest.ProtoReflect.Descriptor instead.
 func (*AdminUpdateRoomRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{237}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{238}
 }
 
 func (x *AdminUpdateRoomRequest) GetRoomId() string {
@@ -17169,7 +17375,7 @@ type AdminUpdateRoomResponse struct {
 
 func (x *AdminUpdateRoomResponse) Reset() {
 	*x = AdminUpdateRoomResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[238]
+	mi := &file_game_v1_game_proto_msgTypes[239]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17181,7 +17387,7 @@ func (x *AdminUpdateRoomResponse) String() string {
 func (*AdminUpdateRoomResponse) ProtoMessage() {}
 
 func (x *AdminUpdateRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[238]
+	mi := &file_game_v1_game_proto_msgTypes[239]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17194,7 +17400,7 @@ func (x *AdminUpdateRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminUpdateRoomResponse.ProtoReflect.Descriptor instead.
 func (*AdminUpdateRoomResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{238}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{239}
 }
 
 type AdminListNPCTemplatesRequest struct {
@@ -17205,7 +17411,7 @@ type AdminListNPCTemplatesRequest struct {
 
 func (x *AdminListNPCTemplatesRequest) Reset() {
 	*x = AdminListNPCTemplatesRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[239]
+	mi := &file_game_v1_game_proto_msgTypes[240]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17217,7 +17423,7 @@ func (x *AdminListNPCTemplatesRequest) String() string {
 func (*AdminListNPCTemplatesRequest) ProtoMessage() {}
 
 func (x *AdminListNPCTemplatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[239]
+	mi := &file_game_v1_game_proto_msgTypes[240]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17230,7 +17436,7 @@ func (x *AdminListNPCTemplatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListNPCTemplatesRequest.ProtoReflect.Descriptor instead.
 func (*AdminListNPCTemplatesRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{239}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{240}
 }
 
 type AdminNPCTemplateSummary struct {
@@ -17245,7 +17451,7 @@ type AdminNPCTemplateSummary struct {
 
 func (x *AdminNPCTemplateSummary) Reset() {
 	*x = AdminNPCTemplateSummary{}
-	mi := &file_game_v1_game_proto_msgTypes[240]
+	mi := &file_game_v1_game_proto_msgTypes[241]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17257,7 +17463,7 @@ func (x *AdminNPCTemplateSummary) String() string {
 func (*AdminNPCTemplateSummary) ProtoMessage() {}
 
 func (x *AdminNPCTemplateSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[240]
+	mi := &file_game_v1_game_proto_msgTypes[241]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17270,7 +17476,7 @@ func (x *AdminNPCTemplateSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminNPCTemplateSummary.ProtoReflect.Descriptor instead.
 func (*AdminNPCTemplateSummary) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{240}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{241}
 }
 
 func (x *AdminNPCTemplateSummary) GetId() string {
@@ -17310,7 +17516,7 @@ type AdminListNPCTemplatesResponse struct {
 
 func (x *AdminListNPCTemplatesResponse) Reset() {
 	*x = AdminListNPCTemplatesResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[241]
+	mi := &file_game_v1_game_proto_msgTypes[242]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17322,7 +17528,7 @@ func (x *AdminListNPCTemplatesResponse) String() string {
 func (*AdminListNPCTemplatesResponse) ProtoMessage() {}
 
 func (x *AdminListNPCTemplatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[241]
+	mi := &file_game_v1_game_proto_msgTypes[242]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17335,7 +17541,7 @@ func (x *AdminListNPCTemplatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminListNPCTemplatesResponse.ProtoReflect.Descriptor instead.
 func (*AdminListNPCTemplatesResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{241}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{242}
 }
 
 func (x *AdminListNPCTemplatesResponse) GetTemplates() []*AdminNPCTemplateSummary {
@@ -17356,7 +17562,7 @@ type AdminSpawnNPCRequest struct {
 
 func (x *AdminSpawnNPCRequest) Reset() {
 	*x = AdminSpawnNPCRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[242]
+	mi := &file_game_v1_game_proto_msgTypes[243]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17368,7 +17574,7 @@ func (x *AdminSpawnNPCRequest) String() string {
 func (*AdminSpawnNPCRequest) ProtoMessage() {}
 
 func (x *AdminSpawnNPCRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[242]
+	mi := &file_game_v1_game_proto_msgTypes[243]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17381,7 +17587,7 @@ func (x *AdminSpawnNPCRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminSpawnNPCRequest.ProtoReflect.Descriptor instead.
 func (*AdminSpawnNPCRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{242}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{243}
 }
 
 func (x *AdminSpawnNPCRequest) GetTemplateId() string {
@@ -17414,7 +17620,7 @@ type AdminSpawnNPCResponse struct {
 
 func (x *AdminSpawnNPCResponse) Reset() {
 	*x = AdminSpawnNPCResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[243]
+	mi := &file_game_v1_game_proto_msgTypes[244]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17426,7 +17632,7 @@ func (x *AdminSpawnNPCResponse) String() string {
 func (*AdminSpawnNPCResponse) ProtoMessage() {}
 
 func (x *AdminSpawnNPCResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[243]
+	mi := &file_game_v1_game_proto_msgTypes[244]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17439,7 +17645,7 @@ func (x *AdminSpawnNPCResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminSpawnNPCResponse.ProtoReflect.Descriptor instead.
 func (*AdminSpawnNPCResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{243}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{244}
 }
 
 func (x *AdminSpawnNPCResponse) GetSpawnedCount() int32 {
@@ -17460,7 +17666,7 @@ type AdminGiveItemRequest struct {
 
 func (x *AdminGiveItemRequest) Reset() {
 	*x = AdminGiveItemRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[244]
+	mi := &file_game_v1_game_proto_msgTypes[245]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17472,7 +17678,7 @@ func (x *AdminGiveItemRequest) String() string {
 func (*AdminGiveItemRequest) ProtoMessage() {}
 
 func (x *AdminGiveItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[244]
+	mi := &file_game_v1_game_proto_msgTypes[245]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17485,7 +17691,7 @@ func (x *AdminGiveItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminGiveItemRequest.ProtoReflect.Descriptor instead.
 func (*AdminGiveItemRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{244}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{245}
 }
 
 func (x *AdminGiveItemRequest) GetCharId() int64 {
@@ -17517,7 +17723,7 @@ type AdminGiveItemResponse struct {
 
 func (x *AdminGiveItemResponse) Reset() {
 	*x = AdminGiveItemResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[245]
+	mi := &file_game_v1_game_proto_msgTypes[246]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17529,7 +17735,7 @@ func (x *AdminGiveItemResponse) String() string {
 func (*AdminGiveItemResponse) ProtoMessage() {}
 
 func (x *AdminGiveItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[245]
+	mi := &file_game_v1_game_proto_msgTypes[246]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17542,7 +17748,7 @@ func (x *AdminGiveItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminGiveItemResponse.ProtoReflect.Descriptor instead.
 func (*AdminGiveItemResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{245}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{246}
 }
 
 type AdminGiveCurrencyRequest struct {
@@ -17555,7 +17761,7 @@ type AdminGiveCurrencyRequest struct {
 
 func (x *AdminGiveCurrencyRequest) Reset() {
 	*x = AdminGiveCurrencyRequest{}
-	mi := &file_game_v1_game_proto_msgTypes[246]
+	mi := &file_game_v1_game_proto_msgTypes[247]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17567,7 +17773,7 @@ func (x *AdminGiveCurrencyRequest) String() string {
 func (*AdminGiveCurrencyRequest) ProtoMessage() {}
 
 func (x *AdminGiveCurrencyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[246]
+	mi := &file_game_v1_game_proto_msgTypes[247]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17580,7 +17786,7 @@ func (x *AdminGiveCurrencyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminGiveCurrencyRequest.ProtoReflect.Descriptor instead.
 func (*AdminGiveCurrencyRequest) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{246}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{247}
 }
 
 func (x *AdminGiveCurrencyRequest) GetCharId() int64 {
@@ -17605,7 +17811,7 @@ type AdminGiveCurrencyResponse struct {
 
 func (x *AdminGiveCurrencyResponse) Reset() {
 	*x = AdminGiveCurrencyResponse{}
-	mi := &file_game_v1_game_proto_msgTypes[247]
+	mi := &file_game_v1_game_proto_msgTypes[248]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17617,7 +17823,7 @@ func (x *AdminGiveCurrencyResponse) String() string {
 func (*AdminGiveCurrencyResponse) ProtoMessage() {}
 
 func (x *AdminGiveCurrencyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_game_v1_game_proto_msgTypes[247]
+	mi := &file_game_v1_game_proto_msgTypes[248]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17630,7 +17836,59 @@ func (x *AdminGiveCurrencyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminGiveCurrencyResponse.ProtoReflect.Descriptor instead.
 func (*AdminGiveCurrencyResponse) Descriptor() ([]byte, []int) {
-	return file_game_v1_game_proto_rawDescGZIP(), []int{247}
+	return file_game_v1_game_proto_rawDescGZIP(), []int{248}
+}
+
+type AoeTemplate_Cell struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	X             int32                  `protobuf:"varint,1,opt,name=x,proto3" json:"x,omitempty"`
+	Y             int32                  `protobuf:"varint,2,opt,name=y,proto3" json:"y,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AoeTemplate_Cell) Reset() {
+	*x = AoeTemplate_Cell{}
+	mi := &file_game_v1_game_proto_msgTypes[250]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AoeTemplate_Cell) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AoeTemplate_Cell) ProtoMessage() {}
+
+func (x *AoeTemplate_Cell) ProtoReflect() protoreflect.Message {
+	mi := &file_game_v1_game_proto_msgTypes[250]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AoeTemplate_Cell.ProtoReflect.Descriptor instead.
+func (*AoeTemplate_Cell) Descriptor() ([]byte, []int) {
+	return file_game_v1_game_proto_rawDescGZIP(), []int{133, 0}
+}
+
+func (x *AoeTemplate_Cell) GetX() int32 {
+	if x != nil {
+		return x.X
+	}
+	return 0
+}
+
+func (x *AoeTemplate_Cell) GetY() int32 {
+	if x != nil {
+		return x.Y
+	}
+	return 0
 }
 
 var File_game_v1_game_proto protoreflect.FileDescriptor
@@ -18456,13 +18714,44 @@ const file_game_v1_game_proto_rawDesc = "" +
 	"\vinstance_id\x18\x01 \x01(\tR\n" +
 	"instanceId\",\n" +
 	"\x10InteractResponse\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\"s\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"\xd1\x03\n" +
+	"\vAoeTemplate\x120\n" +
+	"\x05shape\x18\x01 \x01(\x0e2\x1a.game.v1.AoeTemplate.ShapeR\x05shape\x12\x19\n" +
+	"\banchor_x\x18\x02 \x01(\x05R\aanchorX\x12\x19\n" +
+	"\banchor_y\x18\x03 \x01(\x05R\aanchorY\x126\n" +
+	"\x06facing\x18\x04 \x01(\x0e2\x1e.game.v1.AoeTemplate.DirectionR\x06facing\x12/\n" +
+	"\x05cells\x18\x05 \x03(\v2\x19.game.v1.AoeTemplate.CellR\x05cells\x1a\"\n" +
+	"\x04Cell\x12\f\n" +
+	"\x01x\x18\x01 \x01(\x05R\x01x\x12\f\n" +
+	"\x01y\x18\x02 \x01(\x05R\x01y\"O\n" +
+	"\x05Shape\x12\x15\n" +
+	"\x11SHAPE_UNSPECIFIED\x10\x00\x12\x0f\n" +
+	"\vSHAPE_BURST\x10\x01\x12\x0e\n" +
+	"\n" +
+	"SHAPE_CONE\x10\x02\x12\x0e\n" +
+	"\n" +
+	"SHAPE_LINE\x10\x03\"|\n" +
+	"\tDirection\x12\x13\n" +
+	"\x0fDIR_UNSPECIFIED\x10\x00\x12\t\n" +
+	"\x05DIR_N\x10\x01\x12\n" +
+	"\n" +
+	"\x06DIR_NE\x10\x02\x12\t\n" +
+	"\x05DIR_E\x10\x03\x12\n" +
+	"\n" +
+	"\x06DIR_SE\x10\x04\x12\t\n" +
+	"\x05DIR_S\x10\x05\x12\n" +
+	"\n" +
+	"\x06DIR_SW\x10\x06\x12\t\n" +
+	"\x05DIR_W\x10\a\x12\n" +
+	"\n" +
+	"\x06DIR_NW\x10\b\"\xa5\x01\n" +
 	"\n" +
 	"UseRequest\x12\x17\n" +
 	"\afeat_id\x18\x01 \x01(\tR\x06featId\x12\x16\n" +
 	"\x06target\x18\x02 \x01(\tR\x06target\x12\x19\n" +
 	"\btarget_x\x18\x03 \x01(\x05R\atargetX\x12\x19\n" +
-	"\btarget_y\x18\x04 \x01(\x05R\atargetY\"U\n" +
+	"\btarget_y\x18\x04 \x01(\x05R\atargetY\x120\n" +
+	"\btemplate\x18\x05 \x01(\v2\x14.game.v1.AoeTemplateR\btemplate\"U\n" +
 	"\vUseResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12,\n" +
 	"\achoices\x18\x02 \x03(\v2\x12.game.v1.FeatEntryR\achoices\"\xed\x01\n" +
@@ -18940,537 +19229,545 @@ func file_game_v1_game_proto_rawDescGZIP() []byte {
 	return file_game_v1_game_proto_rawDescData
 }
 
-var file_game_v1_game_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_game_v1_game_proto_msgTypes = make([]protoimpl.MessageInfo, 252)
+var file_game_v1_game_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
+var file_game_v1_game_proto_msgTypes = make([]protoimpl.MessageInfo, 254)
 var file_game_v1_game_proto_goTypes = []any{
 	(MessageType)(0),                      // 0: game.v1.MessageType
 	(RoomEventType)(0),                    // 1: game.v1.RoomEventType
 	(CombatStatus)(0),                     // 2: game.v1.CombatStatus
 	(CombatEventType)(0),                  // 3: game.v1.CombatEventType
-	(*ClientMessage)(nil),                 // 4: game.v1.ClientMessage
-	(*UncoverRequest)(nil),                // 5: game.v1.UncoverRequest
-	(*RestRequest)(nil),                   // 6: game.v1.RestRequest
-	(*SelectTechRequest)(nil),             // 7: game.v1.SelectTechRequest
-	(*AidRequest)(nil),                    // 8: game.v1.AidRequest
-	(*DisarmTrapRequest)(nil),             // 9: game.v1.DisarmTrapRequest
-	(*ReadyRequest)(nil),                  // 10: game.v1.ReadyRequest
-	(*BrowseRequest)(nil),                 // 11: game.v1.BrowseRequest
-	(*BuyRequest)(nil),                    // 12: game.v1.BuyRequest
-	(*SellRequest)(nil),                   // 13: game.v1.SellRequest
-	(*NegotiateRequest)(nil),              // 14: game.v1.NegotiateRequest
-	(*StashDepositRequest)(nil),           // 15: game.v1.StashDepositRequest
-	(*StashWithdrawRequest)(nil),          // 16: game.v1.StashWithdrawRequest
-	(*StashBalanceRequest)(nil),           // 17: game.v1.StashBalanceRequest
-	(*HealRequest)(nil),                   // 18: game.v1.HealRequest
-	(*HealAmountRequest)(nil),             // 19: game.v1.HealAmountRequest
-	(*TrainJobRequest)(nil),               // 20: game.v1.TrainJobRequest
-	(*TrainTechRequest)(nil),              // 21: game.v1.TrainTechRequest
-	(*ListJobsRequest)(nil),               // 22: game.v1.ListJobsRequest
-	(*SetJobRequest)(nil),                 // 23: game.v1.SetJobRequest
-	(*HireRequest)(nil),                   // 24: game.v1.HireRequest
-	(*DismissRequest)(nil),                // 25: game.v1.DismissRequest
-	(*TalkRequest)(nil),                   // 26: game.v1.TalkRequest
-	(*BribeRequest)(nil),                  // 27: game.v1.BribeRequest
-	(*BribeConfirmRequest)(nil),           // 28: game.v1.BribeConfirmRequest
-	(*SurrenderRequest)(nil),              // 29: game.v1.SurrenderRequest
-	(*ReleaseRequest)(nil),                // 30: game.v1.ReleaseRequest
-	(*DeployTrapRequest)(nil),             // 31: game.v1.DeployTrapRequest
-	(*TravelRequest)(nil),                 // 32: game.v1.TravelRequest
-	(*ActivateItemRequest)(nil),           // 33: game.v1.ActivateItemRequest
-	(*ServerEvent)(nil),                   // 34: game.v1.ServerEvent
-	(*ReactionPromptEvent)(nil),           // 35: game.v1.ReactionPromptEvent
-	(*ReactionPromptOption)(nil),          // 36: game.v1.ReactionPromptOption
-	(*ReactionResponse)(nil),              // 37: game.v1.ReactionResponse
-	(*ShopItem)(nil),                      // 38: game.v1.ShopItem
-	(*ShopView)(nil),                      // 39: game.v1.ShopView
-	(*HpUpdateEvent)(nil),                 // 40: game.v1.HpUpdateEvent
-	(*JoinWorldRequest)(nil),              // 41: game.v1.JoinWorldRequest
-	(*MoveRequest)(nil),                   // 42: game.v1.MoveRequest
-	(*LookRequest)(nil),                   // 43: game.v1.LookRequest
-	(*SayRequest)(nil),                    // 44: game.v1.SayRequest
-	(*EmoteRequest)(nil),                  // 45: game.v1.EmoteRequest
-	(*WhoRequest)(nil),                    // 46: game.v1.WhoRequest
-	(*ExitsRequest)(nil),                  // 47: game.v1.ExitsRequest
-	(*QuitRequest)(nil),                   // 48: game.v1.QuitRequest
-	(*SwitchCharacterRequest)(nil),        // 49: game.v1.SwitchCharacterRequest
-	(*RoomView)(nil),                      // 50: game.v1.RoomView
-	(*ExitInfo)(nil),                      // 51: game.v1.ExitInfo
-	(*MessageEvent)(nil),                  // 52: game.v1.MessageEvent
-	(*RoomEvent)(nil),                     // 53: game.v1.RoomEvent
-	(*PlayerList)(nil),                    // 54: game.v1.PlayerList
-	(*PlayerInfo)(nil),                    // 55: game.v1.PlayerInfo
-	(*ExitList)(nil),                      // 56: game.v1.ExitList
-	(*ErrorEvent)(nil),                    // 57: game.v1.ErrorEvent
-	(*Disconnected)(nil),                  // 58: game.v1.Disconnected
-	(*TimeOfDayEvent)(nil),                // 59: game.v1.TimeOfDayEvent
-	(*CharacterInfo)(nil),                 // 60: game.v1.CharacterInfo
-	(*NpcInfo)(nil),                       // 61: game.v1.NpcInfo
-	(*ExamineRequest)(nil),                // 62: game.v1.ExamineRequest
-	(*NpcView)(nil),                       // 63: game.v1.NpcView
-	(*HealerView)(nil),                    // 64: game.v1.HealerView
-	(*JobOfferEntry)(nil),                 // 65: game.v1.JobOfferEntry
-	(*TrainerView)(nil),                   // 66: game.v1.TrainerView
-	(*TechTrainerView)(nil),               // 67: game.v1.TechTrainerView
-	(*TechOfferEntry)(nil),                // 68: game.v1.TechOfferEntry
-	(*FixerView)(nil),                     // 69: game.v1.FixerView
-	(*RestView)(nil),                      // 70: game.v1.RestView
-	(*AttackRequest)(nil),                 // 71: game.v1.AttackRequest
-	(*FleeRequest)(nil),                   // 72: game.v1.FleeRequest
-	(*PassRequest)(nil),                   // 73: game.v1.PassRequest
-	(*StrikeRequest)(nil),                 // 74: game.v1.StrikeRequest
-	(*EquipRequest)(nil),                  // 75: game.v1.EquipRequest
-	(*ReloadRequest)(nil),                 // 76: game.v1.ReloadRequest
-	(*FireBurstRequest)(nil),              // 77: game.v1.FireBurstRequest
-	(*FireAutomaticRequest)(nil),          // 78: game.v1.FireAutomaticRequest
-	(*ThrowRequest)(nil),                  // 79: game.v1.ThrowRequest
-	(*InventoryRequest)(nil),              // 80: game.v1.InventoryRequest
-	(*GetItemRequest)(nil),                // 81: game.v1.GetItemRequest
-	(*DropItemRequest)(nil),               // 82: game.v1.DropItemRequest
-	(*BalanceRequest)(nil),                // 83: game.v1.BalanceRequest
-	(*SetRoleRequest)(nil),                // 84: game.v1.SetRoleRequest
-	(*LoadoutRequest)(nil),                // 85: game.v1.LoadoutRequest
-	(*LoadoutWeaponPreset)(nil),           // 86: game.v1.LoadoutWeaponPreset
-	(*LoadoutView)(nil),                   // 87: game.v1.LoadoutView
-	(*QuestObjectiveView)(nil),            // 88: game.v1.QuestObjectiveView
-	(*QuestEntryView)(nil),                // 89: game.v1.QuestEntryView
-	(*QuestGiverView)(nil),                // 90: game.v1.QuestGiverView
-	(*QuestLogView)(nil),                  // 91: game.v1.QuestLogView
-	(*QuestCompleteEvent)(nil),            // 92: game.v1.QuestCompleteEvent
-	(*QuestLogRequest)(nil),               // 93: game.v1.QuestLogRequest
-	(*UnequipRequest)(nil),                // 94: game.v1.UnequipRequest
-	(*EquipmentRequest)(nil),              // 95: game.v1.EquipmentRequest
-	(*TeleportRequest)(nil),               // 96: game.v1.TeleportRequest
-	(*SummonItemRequest)(nil),             // 97: game.v1.SummonItemRequest
-	(*FloorItem)(nil),                     // 98: game.v1.FloorItem
-	(*RoomEquipmentItem)(nil),             // 99: game.v1.RoomEquipmentItem
-	(*UseEquipmentRequest)(nil),           // 100: game.v1.UseEquipmentRequest
-	(*MapRequest)(nil),                    // 101: game.v1.MapRequest
-	(*PoiWithNpc)(nil),                    // 102: game.v1.PoiWithNpc
-	(*ZoneExitInfo)(nil),                  // 103: game.v1.ZoneExitInfo
-	(*SameZoneExitTarget)(nil),            // 104: game.v1.SameZoneExitTarget
-	(*MapTile)(nil),                       // 105: game.v1.MapTile
-	(*WorldZoneTile)(nil),                 // 106: game.v1.WorldZoneTile
-	(*GameConfig)(nil),                    // 107: game.v1.GameConfig
-	(*MapResponse)(nil),                   // 108: game.v1.MapResponse
-	(*SkillsRequest)(nil),                 // 109: game.v1.SkillsRequest
-	(*SkillEntry)(nil),                    // 110: game.v1.SkillEntry
-	(*SkillsResponse)(nil),                // 111: game.v1.SkillsResponse
-	(*RoomEquipRequest)(nil),              // 112: game.v1.RoomEquipRequest
-	(*InventoryItem)(nil),                 // 113: game.v1.InventoryItem
-	(*InventoryView)(nil),                 // 114: game.v1.InventoryView
-	(*CombatantPosition)(nil),             // 115: game.v1.CombatantPosition
-	(*CoverObjectPosition)(nil),           // 116: game.v1.CoverObjectPosition
-	(*TerrainCell)(nil),                   // 117: game.v1.TerrainCell
-	(*RoundStartEvent)(nil),               // 118: game.v1.RoundStartEvent
-	(*RoundEndEvent)(nil),                 // 119: game.v1.RoundEndEvent
-	(*APUpdateEvent)(nil),                 // 120: game.v1.APUpdateEvent
-	(*CombatEvent)(nil),                   // 121: game.v1.CombatEvent
-	(*StatusRequest)(nil),                 // 122: game.v1.StatusRequest
-	(*ConditionEvent)(nil),                // 123: game.v1.ConditionEvent
-	(*WearRequest)(nil),                   // 124: game.v1.WearRequest
-	(*RemoveArmorRequest)(nil),            // 125: game.v1.RemoveArmorRequest
-	(*ConditionInfo)(nil),                 // 126: game.v1.ConditionInfo
-	(*CharacterSheetRequest)(nil),         // 127: game.v1.CharacterSheetRequest
-	(*ArchetypeSelectionRequest)(nil),     // 128: game.v1.ArchetypeSelectionRequest
-	(*FeatsRequest)(nil),                  // 129: game.v1.FeatsRequest
-	(*FeatEntry)(nil),                     // 130: game.v1.FeatEntry
-	(*FeatsResponse)(nil),                 // 131: game.v1.FeatsResponse
-	(*ClassFeaturesRequest)(nil),          // 132: game.v1.ClassFeaturesRequest
-	(*ClassFeatureEntry)(nil),             // 133: game.v1.ClassFeatureEntry
-	(*ClassFeaturesResponse)(nil),         // 134: game.v1.ClassFeaturesResponse
-	(*InteractRequest)(nil),               // 135: game.v1.InteractRequest
-	(*InteractResponse)(nil),              // 136: game.v1.InteractResponse
-	(*UseRequest)(nil),                    // 137: game.v1.UseRequest
-	(*UseResponse)(nil),                   // 138: game.v1.UseResponse
-	(*PreparedSlotView)(nil),              // 139: game.v1.PreparedSlotView
-	(*HardwiredSlotView)(nil),             // 140: game.v1.HardwiredSlotView
-	(*SpontaneousKnownEntry)(nil),         // 141: game.v1.SpontaneousKnownEntry
-	(*CharacterSheetView)(nil),            // 142: game.v1.CharacterSheetView
-	(*InnateSlotView)(nil),                // 143: game.v1.InnateSlotView
-	(*SpontaneousUsePoolView)(nil),        // 144: game.v1.SpontaneousUsePoolView
-	(*ResistanceEntry)(nil),               // 145: game.v1.ResistanceEntry
-	(*ProficienciesRequest)(nil),          // 146: game.v1.ProficienciesRequest
-	(*ProficiencyEntry)(nil),              // 147: game.v1.ProficiencyEntry
-	(*ProficienciesResponse)(nil),         // 148: game.v1.ProficienciesResponse
-	(*LevelUpRequest)(nil),                // 149: game.v1.LevelUpRequest
-	(*CombatDefaultRequest)(nil),          // 150: game.v1.CombatDefaultRequest
-	(*TrainSkillRequest)(nil),             // 151: game.v1.TrainSkillRequest
-	(*ActionRequest)(nil),                 // 152: game.v1.ActionRequest
-	(*RaiseShieldRequest)(nil),            // 153: game.v1.RaiseShieldRequest
-	(*TakeCoverRequest)(nil),              // 154: game.v1.TakeCoverRequest
-	(*FirstAidRequest)(nil),               // 155: game.v1.FirstAidRequest
-	(*FeintRequest)(nil),                  // 156: game.v1.FeintRequest
-	(*DemoralizeRequest)(nil),             // 157: game.v1.DemoralizeRequest
-	(*GrappleRequest)(nil),                // 158: game.v1.GrappleRequest
-	(*TripRequest)(nil),                   // 159: game.v1.TripRequest
-	(*DisarmRequest)(nil),                 // 160: game.v1.DisarmRequest
-	(*StrideRequest)(nil),                 // 161: game.v1.StrideRequest
-	(*MoveToRequest)(nil),                 // 162: game.v1.MoveToRequest
-	(*ShoveRequest)(nil),                  // 163: game.v1.ShoveRequest
-	(*StepRequest)(nil),                   // 164: game.v1.StepRequest
-	(*HideRequest)(nil),                   // 165: game.v1.HideRequest
-	(*SneakRequest)(nil),                  // 166: game.v1.SneakRequest
-	(*DivertRequest)(nil),                 // 167: game.v1.DivertRequest
-	(*EscapeRequest)(nil),                 // 168: game.v1.EscapeRequest
-	(*TumbleRequest)(nil),                 // 169: game.v1.TumbleRequest
-	(*SeekRequest)(nil),                   // 170: game.v1.SeekRequest
-	(*ClimbRequest)(nil),                  // 171: game.v1.ClimbRequest
-	(*SwimRequest)(nil),                   // 172: game.v1.SwimRequest
-	(*CalmRequest)(nil),                   // 173: game.v1.CalmRequest
-	(*HeroPointRequest)(nil),              // 174: game.v1.HeroPointRequest
-	(*DelayRequest)(nil),                  // 175: game.v1.DelayRequest
-	(*JoinRequest)(nil),                   // 176: game.v1.JoinRequest
-	(*DeclineRequest)(nil),                // 177: game.v1.DeclineRequest
-	(*GroupRequest)(nil),                  // 178: game.v1.GroupRequest
-	(*InviteRequest)(nil),                 // 179: game.v1.InviteRequest
-	(*AcceptGroupRequest)(nil),            // 180: game.v1.AcceptGroupRequest
-	(*DeclineGroupRequest)(nil),           // 181: game.v1.DeclineGroupRequest
-	(*UngroupRequest)(nil),                // 182: game.v1.UngroupRequest
-	(*KickRequest)(nil),                   // 183: game.v1.KickRequest
-	(*MotiveRequest)(nil),                 // 184: game.v1.MotiveRequest
-	(*GrantRequest)(nil),                  // 185: game.v1.GrantRequest
-	(*SpawnNPCRequest)(nil),               // 186: game.v1.SpawnNPCRequest
-	(*KillNPCRequest)(nil),                // 187: game.v1.KillNPCRequest
-	(*AddRoomRequest)(nil),                // 188: game.v1.AddRoomRequest
-	(*AddLinkRequest)(nil),                // 189: game.v1.AddLinkRequest
-	(*RemoveLinkRequest)(nil),             // 190: game.v1.RemoveLinkRequest
-	(*SetRoomRequest)(nil),                // 191: game.v1.SetRoomRequest
-	(*EditorCmdsRequest)(nil),             // 192: game.v1.EditorCmdsRequest
-	(*SpawnCharRequest)(nil),              // 193: game.v1.SpawnCharRequest
-	(*DeleteCharRequest)(nil),             // 194: game.v1.DeleteCharRequest
-	(*FactionRequest)(nil),                // 195: game.v1.FactionRequest
-	(*FactionInfoRequest)(nil),            // 196: game.v1.FactionInfoRequest
-	(*FactionStandingRequest)(nil),        // 197: game.v1.FactionStandingRequest
-	(*ChangeRepRequest)(nil),              // 198: game.v1.ChangeRepRequest
-	(*TabCompleteRequest)(nil),            // 199: game.v1.TabCompleteRequest
-	(*TabCompleteResponse)(nil),           // 200: game.v1.TabCompleteResponse
-	(*MaterialsRequest)(nil),              // 201: game.v1.MaterialsRequest
-	(*CraftListRequest)(nil),              // 202: game.v1.CraftListRequest
-	(*CraftRequest)(nil),                  // 203: game.v1.CraftRequest
-	(*CraftConfirmRequest)(nil),           // 204: game.v1.CraftConfirmRequest
-	(*ScavengeRequest)(nil),               // 205: game.v1.ScavengeRequest
-	(*AffixRequest)(nil),                  // 206: game.v1.AffixRequest
-	(*ExploreRequest)(nil),                // 207: game.v1.ExploreRequest
-	(*RefocusRequest)(nil),                // 208: game.v1.RefocusRequest
-	(*SeduceRequest)(nil),                 // 209: game.v1.SeduceRequest
-	(*HotbarSlot)(nil),                    // 210: game.v1.HotbarSlot
-	(*HotbarRequest)(nil),                 // 211: game.v1.HotbarRequest
-	(*HotbarUpdateEvent)(nil),             // 212: game.v1.HotbarUpdateEvent
-	(*DowntimeRequest)(nil),               // 213: game.v1.DowntimeRequest
-	(*QuestRequest)(nil),                  // 214: game.v1.QuestRequest
-	(*MaterialLoss)(nil),                  // 215: game.v1.MaterialLoss
-	(*CraftResultEvent)(nil),              // 216: game.v1.CraftResultEvent
-	(*UncurseRequest)(nil),                // 217: game.v1.UncurseRequest
-	(*WeatherEvent)(nil),                  // 218: game.v1.WeatherEvent
-	(*JobGrantsRequest)(nil),              // 219: game.v1.JobGrantsRequest
-	(*JobFeatGrant)(nil),                  // 220: game.v1.JobFeatGrant
-	(*JobTechGrant)(nil),                  // 221: game.v1.JobTechGrant
-	(*JobGrantsResponse)(nil),             // 222: game.v1.JobGrantsResponse
-	(*FeatOption)(nil),                    // 223: game.v1.FeatOption
-	(*PendingFeatChoice)(nil),             // 224: game.v1.PendingFeatChoice
-	(*ChooseFeatRequest)(nil),             // 225: game.v1.ChooseFeatRequest
-	(*AdminSessionInfo)(nil),              // 226: game.v1.AdminSessionInfo
-	(*AdminListSessionsRequest)(nil),      // 227: game.v1.AdminListSessionsRequest
-	(*AdminListSessionsResponse)(nil),     // 228: game.v1.AdminListSessionsResponse
-	(*AdminKickRequest)(nil),              // 229: game.v1.AdminKickRequest
-	(*AdminKickResponse)(nil),             // 230: game.v1.AdminKickResponse
-	(*AdminMessageRequest)(nil),           // 231: game.v1.AdminMessageRequest
-	(*AdminMessageResponse)(nil),          // 232: game.v1.AdminMessageResponse
-	(*AdminTeleportRequest)(nil),          // 233: game.v1.AdminTeleportRequest
-	(*AdminTeleportResponse)(nil),         // 234: game.v1.AdminTeleportResponse
-	(*AdminListZonesRequest)(nil),         // 235: game.v1.AdminListZonesRequest
-	(*AdminZoneSummary)(nil),              // 236: game.v1.AdminZoneSummary
-	(*AdminListZonesResponse)(nil),        // 237: game.v1.AdminListZonesResponse
-	(*AdminListRoomsRequest)(nil),         // 238: game.v1.AdminListRoomsRequest
-	(*AdminRoomSummary)(nil),              // 239: game.v1.AdminRoomSummary
-	(*AdminListRoomsResponse)(nil),        // 240: game.v1.AdminListRoomsResponse
-	(*AdminUpdateRoomRequest)(nil),        // 241: game.v1.AdminUpdateRoomRequest
-	(*AdminUpdateRoomResponse)(nil),       // 242: game.v1.AdminUpdateRoomResponse
-	(*AdminListNPCTemplatesRequest)(nil),  // 243: game.v1.AdminListNPCTemplatesRequest
-	(*AdminNPCTemplateSummary)(nil),       // 244: game.v1.AdminNPCTemplateSummary
-	(*AdminListNPCTemplatesResponse)(nil), // 245: game.v1.AdminListNPCTemplatesResponse
-	(*AdminSpawnNPCRequest)(nil),          // 246: game.v1.AdminSpawnNPCRequest
-	(*AdminSpawnNPCResponse)(nil),         // 247: game.v1.AdminSpawnNPCResponse
-	(*AdminGiveItemRequest)(nil),          // 248: game.v1.AdminGiveItemRequest
-	(*AdminGiveItemResponse)(nil),         // 249: game.v1.AdminGiveItemResponse
-	(*AdminGiveCurrencyRequest)(nil),      // 250: game.v1.AdminGiveCurrencyRequest
-	(*AdminGiveCurrencyResponse)(nil),     // 251: game.v1.AdminGiveCurrencyResponse
-	nil,                                   // 252: game.v1.FixerView.BribeCostsEntry
-	nil,                                   // 253: game.v1.CharacterSheetView.ArmorEntry
-	nil,                                   // 254: game.v1.CharacterSheetView.AccessoriesEntry
-	nil,                                   // 255: game.v1.CharacterSheetView.ArmorCategoriesEntry
+	(AoeTemplate_Shape)(0),                // 4: game.v1.AoeTemplate.Shape
+	(AoeTemplate_Direction)(0),            // 5: game.v1.AoeTemplate.Direction
+	(*ClientMessage)(nil),                 // 6: game.v1.ClientMessage
+	(*UncoverRequest)(nil),                // 7: game.v1.UncoverRequest
+	(*RestRequest)(nil),                   // 8: game.v1.RestRequest
+	(*SelectTechRequest)(nil),             // 9: game.v1.SelectTechRequest
+	(*AidRequest)(nil),                    // 10: game.v1.AidRequest
+	(*DisarmTrapRequest)(nil),             // 11: game.v1.DisarmTrapRequest
+	(*ReadyRequest)(nil),                  // 12: game.v1.ReadyRequest
+	(*BrowseRequest)(nil),                 // 13: game.v1.BrowseRequest
+	(*BuyRequest)(nil),                    // 14: game.v1.BuyRequest
+	(*SellRequest)(nil),                   // 15: game.v1.SellRequest
+	(*NegotiateRequest)(nil),              // 16: game.v1.NegotiateRequest
+	(*StashDepositRequest)(nil),           // 17: game.v1.StashDepositRequest
+	(*StashWithdrawRequest)(nil),          // 18: game.v1.StashWithdrawRequest
+	(*StashBalanceRequest)(nil),           // 19: game.v1.StashBalanceRequest
+	(*HealRequest)(nil),                   // 20: game.v1.HealRequest
+	(*HealAmountRequest)(nil),             // 21: game.v1.HealAmountRequest
+	(*TrainJobRequest)(nil),               // 22: game.v1.TrainJobRequest
+	(*TrainTechRequest)(nil),              // 23: game.v1.TrainTechRequest
+	(*ListJobsRequest)(nil),               // 24: game.v1.ListJobsRequest
+	(*SetJobRequest)(nil),                 // 25: game.v1.SetJobRequest
+	(*HireRequest)(nil),                   // 26: game.v1.HireRequest
+	(*DismissRequest)(nil),                // 27: game.v1.DismissRequest
+	(*TalkRequest)(nil),                   // 28: game.v1.TalkRequest
+	(*BribeRequest)(nil),                  // 29: game.v1.BribeRequest
+	(*BribeConfirmRequest)(nil),           // 30: game.v1.BribeConfirmRequest
+	(*SurrenderRequest)(nil),              // 31: game.v1.SurrenderRequest
+	(*ReleaseRequest)(nil),                // 32: game.v1.ReleaseRequest
+	(*DeployTrapRequest)(nil),             // 33: game.v1.DeployTrapRequest
+	(*TravelRequest)(nil),                 // 34: game.v1.TravelRequest
+	(*ActivateItemRequest)(nil),           // 35: game.v1.ActivateItemRequest
+	(*ServerEvent)(nil),                   // 36: game.v1.ServerEvent
+	(*ReactionPromptEvent)(nil),           // 37: game.v1.ReactionPromptEvent
+	(*ReactionPromptOption)(nil),          // 38: game.v1.ReactionPromptOption
+	(*ReactionResponse)(nil),              // 39: game.v1.ReactionResponse
+	(*ShopItem)(nil),                      // 40: game.v1.ShopItem
+	(*ShopView)(nil),                      // 41: game.v1.ShopView
+	(*HpUpdateEvent)(nil),                 // 42: game.v1.HpUpdateEvent
+	(*JoinWorldRequest)(nil),              // 43: game.v1.JoinWorldRequest
+	(*MoveRequest)(nil),                   // 44: game.v1.MoveRequest
+	(*LookRequest)(nil),                   // 45: game.v1.LookRequest
+	(*SayRequest)(nil),                    // 46: game.v1.SayRequest
+	(*EmoteRequest)(nil),                  // 47: game.v1.EmoteRequest
+	(*WhoRequest)(nil),                    // 48: game.v1.WhoRequest
+	(*ExitsRequest)(nil),                  // 49: game.v1.ExitsRequest
+	(*QuitRequest)(nil),                   // 50: game.v1.QuitRequest
+	(*SwitchCharacterRequest)(nil),        // 51: game.v1.SwitchCharacterRequest
+	(*RoomView)(nil),                      // 52: game.v1.RoomView
+	(*ExitInfo)(nil),                      // 53: game.v1.ExitInfo
+	(*MessageEvent)(nil),                  // 54: game.v1.MessageEvent
+	(*RoomEvent)(nil),                     // 55: game.v1.RoomEvent
+	(*PlayerList)(nil),                    // 56: game.v1.PlayerList
+	(*PlayerInfo)(nil),                    // 57: game.v1.PlayerInfo
+	(*ExitList)(nil),                      // 58: game.v1.ExitList
+	(*ErrorEvent)(nil),                    // 59: game.v1.ErrorEvent
+	(*Disconnected)(nil),                  // 60: game.v1.Disconnected
+	(*TimeOfDayEvent)(nil),                // 61: game.v1.TimeOfDayEvent
+	(*CharacterInfo)(nil),                 // 62: game.v1.CharacterInfo
+	(*NpcInfo)(nil),                       // 63: game.v1.NpcInfo
+	(*ExamineRequest)(nil),                // 64: game.v1.ExamineRequest
+	(*NpcView)(nil),                       // 65: game.v1.NpcView
+	(*HealerView)(nil),                    // 66: game.v1.HealerView
+	(*JobOfferEntry)(nil),                 // 67: game.v1.JobOfferEntry
+	(*TrainerView)(nil),                   // 68: game.v1.TrainerView
+	(*TechTrainerView)(nil),               // 69: game.v1.TechTrainerView
+	(*TechOfferEntry)(nil),                // 70: game.v1.TechOfferEntry
+	(*FixerView)(nil),                     // 71: game.v1.FixerView
+	(*RestView)(nil),                      // 72: game.v1.RestView
+	(*AttackRequest)(nil),                 // 73: game.v1.AttackRequest
+	(*FleeRequest)(nil),                   // 74: game.v1.FleeRequest
+	(*PassRequest)(nil),                   // 75: game.v1.PassRequest
+	(*StrikeRequest)(nil),                 // 76: game.v1.StrikeRequest
+	(*EquipRequest)(nil),                  // 77: game.v1.EquipRequest
+	(*ReloadRequest)(nil),                 // 78: game.v1.ReloadRequest
+	(*FireBurstRequest)(nil),              // 79: game.v1.FireBurstRequest
+	(*FireAutomaticRequest)(nil),          // 80: game.v1.FireAutomaticRequest
+	(*ThrowRequest)(nil),                  // 81: game.v1.ThrowRequest
+	(*InventoryRequest)(nil),              // 82: game.v1.InventoryRequest
+	(*GetItemRequest)(nil),                // 83: game.v1.GetItemRequest
+	(*DropItemRequest)(nil),               // 84: game.v1.DropItemRequest
+	(*BalanceRequest)(nil),                // 85: game.v1.BalanceRequest
+	(*SetRoleRequest)(nil),                // 86: game.v1.SetRoleRequest
+	(*LoadoutRequest)(nil),                // 87: game.v1.LoadoutRequest
+	(*LoadoutWeaponPreset)(nil),           // 88: game.v1.LoadoutWeaponPreset
+	(*LoadoutView)(nil),                   // 89: game.v1.LoadoutView
+	(*QuestObjectiveView)(nil),            // 90: game.v1.QuestObjectiveView
+	(*QuestEntryView)(nil),                // 91: game.v1.QuestEntryView
+	(*QuestGiverView)(nil),                // 92: game.v1.QuestGiverView
+	(*QuestLogView)(nil),                  // 93: game.v1.QuestLogView
+	(*QuestCompleteEvent)(nil),            // 94: game.v1.QuestCompleteEvent
+	(*QuestLogRequest)(nil),               // 95: game.v1.QuestLogRequest
+	(*UnequipRequest)(nil),                // 96: game.v1.UnequipRequest
+	(*EquipmentRequest)(nil),              // 97: game.v1.EquipmentRequest
+	(*TeleportRequest)(nil),               // 98: game.v1.TeleportRequest
+	(*SummonItemRequest)(nil),             // 99: game.v1.SummonItemRequest
+	(*FloorItem)(nil),                     // 100: game.v1.FloorItem
+	(*RoomEquipmentItem)(nil),             // 101: game.v1.RoomEquipmentItem
+	(*UseEquipmentRequest)(nil),           // 102: game.v1.UseEquipmentRequest
+	(*MapRequest)(nil),                    // 103: game.v1.MapRequest
+	(*PoiWithNpc)(nil),                    // 104: game.v1.PoiWithNpc
+	(*ZoneExitInfo)(nil),                  // 105: game.v1.ZoneExitInfo
+	(*SameZoneExitTarget)(nil),            // 106: game.v1.SameZoneExitTarget
+	(*MapTile)(nil),                       // 107: game.v1.MapTile
+	(*WorldZoneTile)(nil),                 // 108: game.v1.WorldZoneTile
+	(*GameConfig)(nil),                    // 109: game.v1.GameConfig
+	(*MapResponse)(nil),                   // 110: game.v1.MapResponse
+	(*SkillsRequest)(nil),                 // 111: game.v1.SkillsRequest
+	(*SkillEntry)(nil),                    // 112: game.v1.SkillEntry
+	(*SkillsResponse)(nil),                // 113: game.v1.SkillsResponse
+	(*RoomEquipRequest)(nil),              // 114: game.v1.RoomEquipRequest
+	(*InventoryItem)(nil),                 // 115: game.v1.InventoryItem
+	(*InventoryView)(nil),                 // 116: game.v1.InventoryView
+	(*CombatantPosition)(nil),             // 117: game.v1.CombatantPosition
+	(*CoverObjectPosition)(nil),           // 118: game.v1.CoverObjectPosition
+	(*TerrainCell)(nil),                   // 119: game.v1.TerrainCell
+	(*RoundStartEvent)(nil),               // 120: game.v1.RoundStartEvent
+	(*RoundEndEvent)(nil),                 // 121: game.v1.RoundEndEvent
+	(*APUpdateEvent)(nil),                 // 122: game.v1.APUpdateEvent
+	(*CombatEvent)(nil),                   // 123: game.v1.CombatEvent
+	(*StatusRequest)(nil),                 // 124: game.v1.StatusRequest
+	(*ConditionEvent)(nil),                // 125: game.v1.ConditionEvent
+	(*WearRequest)(nil),                   // 126: game.v1.WearRequest
+	(*RemoveArmorRequest)(nil),            // 127: game.v1.RemoveArmorRequest
+	(*ConditionInfo)(nil),                 // 128: game.v1.ConditionInfo
+	(*CharacterSheetRequest)(nil),         // 129: game.v1.CharacterSheetRequest
+	(*ArchetypeSelectionRequest)(nil),     // 130: game.v1.ArchetypeSelectionRequest
+	(*FeatsRequest)(nil),                  // 131: game.v1.FeatsRequest
+	(*FeatEntry)(nil),                     // 132: game.v1.FeatEntry
+	(*FeatsResponse)(nil),                 // 133: game.v1.FeatsResponse
+	(*ClassFeaturesRequest)(nil),          // 134: game.v1.ClassFeaturesRequest
+	(*ClassFeatureEntry)(nil),             // 135: game.v1.ClassFeatureEntry
+	(*ClassFeaturesResponse)(nil),         // 136: game.v1.ClassFeaturesResponse
+	(*InteractRequest)(nil),               // 137: game.v1.InteractRequest
+	(*InteractResponse)(nil),              // 138: game.v1.InteractResponse
+	(*AoeTemplate)(nil),                   // 139: game.v1.AoeTemplate
+	(*UseRequest)(nil),                    // 140: game.v1.UseRequest
+	(*UseResponse)(nil),                   // 141: game.v1.UseResponse
+	(*PreparedSlotView)(nil),              // 142: game.v1.PreparedSlotView
+	(*HardwiredSlotView)(nil),             // 143: game.v1.HardwiredSlotView
+	(*SpontaneousKnownEntry)(nil),         // 144: game.v1.SpontaneousKnownEntry
+	(*CharacterSheetView)(nil),            // 145: game.v1.CharacterSheetView
+	(*InnateSlotView)(nil),                // 146: game.v1.InnateSlotView
+	(*SpontaneousUsePoolView)(nil),        // 147: game.v1.SpontaneousUsePoolView
+	(*ResistanceEntry)(nil),               // 148: game.v1.ResistanceEntry
+	(*ProficienciesRequest)(nil),          // 149: game.v1.ProficienciesRequest
+	(*ProficiencyEntry)(nil),              // 150: game.v1.ProficiencyEntry
+	(*ProficienciesResponse)(nil),         // 151: game.v1.ProficienciesResponse
+	(*LevelUpRequest)(nil),                // 152: game.v1.LevelUpRequest
+	(*CombatDefaultRequest)(nil),          // 153: game.v1.CombatDefaultRequest
+	(*TrainSkillRequest)(nil),             // 154: game.v1.TrainSkillRequest
+	(*ActionRequest)(nil),                 // 155: game.v1.ActionRequest
+	(*RaiseShieldRequest)(nil),            // 156: game.v1.RaiseShieldRequest
+	(*TakeCoverRequest)(nil),              // 157: game.v1.TakeCoverRequest
+	(*FirstAidRequest)(nil),               // 158: game.v1.FirstAidRequest
+	(*FeintRequest)(nil),                  // 159: game.v1.FeintRequest
+	(*DemoralizeRequest)(nil),             // 160: game.v1.DemoralizeRequest
+	(*GrappleRequest)(nil),                // 161: game.v1.GrappleRequest
+	(*TripRequest)(nil),                   // 162: game.v1.TripRequest
+	(*DisarmRequest)(nil),                 // 163: game.v1.DisarmRequest
+	(*StrideRequest)(nil),                 // 164: game.v1.StrideRequest
+	(*MoveToRequest)(nil),                 // 165: game.v1.MoveToRequest
+	(*ShoveRequest)(nil),                  // 166: game.v1.ShoveRequest
+	(*StepRequest)(nil),                   // 167: game.v1.StepRequest
+	(*HideRequest)(nil),                   // 168: game.v1.HideRequest
+	(*SneakRequest)(nil),                  // 169: game.v1.SneakRequest
+	(*DivertRequest)(nil),                 // 170: game.v1.DivertRequest
+	(*EscapeRequest)(nil),                 // 171: game.v1.EscapeRequest
+	(*TumbleRequest)(nil),                 // 172: game.v1.TumbleRequest
+	(*SeekRequest)(nil),                   // 173: game.v1.SeekRequest
+	(*ClimbRequest)(nil),                  // 174: game.v1.ClimbRequest
+	(*SwimRequest)(nil),                   // 175: game.v1.SwimRequest
+	(*CalmRequest)(nil),                   // 176: game.v1.CalmRequest
+	(*HeroPointRequest)(nil),              // 177: game.v1.HeroPointRequest
+	(*DelayRequest)(nil),                  // 178: game.v1.DelayRequest
+	(*JoinRequest)(nil),                   // 179: game.v1.JoinRequest
+	(*DeclineRequest)(nil),                // 180: game.v1.DeclineRequest
+	(*GroupRequest)(nil),                  // 181: game.v1.GroupRequest
+	(*InviteRequest)(nil),                 // 182: game.v1.InviteRequest
+	(*AcceptGroupRequest)(nil),            // 183: game.v1.AcceptGroupRequest
+	(*DeclineGroupRequest)(nil),           // 184: game.v1.DeclineGroupRequest
+	(*UngroupRequest)(nil),                // 185: game.v1.UngroupRequest
+	(*KickRequest)(nil),                   // 186: game.v1.KickRequest
+	(*MotiveRequest)(nil),                 // 187: game.v1.MotiveRequest
+	(*GrantRequest)(nil),                  // 188: game.v1.GrantRequest
+	(*SpawnNPCRequest)(nil),               // 189: game.v1.SpawnNPCRequest
+	(*KillNPCRequest)(nil),                // 190: game.v1.KillNPCRequest
+	(*AddRoomRequest)(nil),                // 191: game.v1.AddRoomRequest
+	(*AddLinkRequest)(nil),                // 192: game.v1.AddLinkRequest
+	(*RemoveLinkRequest)(nil),             // 193: game.v1.RemoveLinkRequest
+	(*SetRoomRequest)(nil),                // 194: game.v1.SetRoomRequest
+	(*EditorCmdsRequest)(nil),             // 195: game.v1.EditorCmdsRequest
+	(*SpawnCharRequest)(nil),              // 196: game.v1.SpawnCharRequest
+	(*DeleteCharRequest)(nil),             // 197: game.v1.DeleteCharRequest
+	(*FactionRequest)(nil),                // 198: game.v1.FactionRequest
+	(*FactionInfoRequest)(nil),            // 199: game.v1.FactionInfoRequest
+	(*FactionStandingRequest)(nil),        // 200: game.v1.FactionStandingRequest
+	(*ChangeRepRequest)(nil),              // 201: game.v1.ChangeRepRequest
+	(*TabCompleteRequest)(nil),            // 202: game.v1.TabCompleteRequest
+	(*TabCompleteResponse)(nil),           // 203: game.v1.TabCompleteResponse
+	(*MaterialsRequest)(nil),              // 204: game.v1.MaterialsRequest
+	(*CraftListRequest)(nil),              // 205: game.v1.CraftListRequest
+	(*CraftRequest)(nil),                  // 206: game.v1.CraftRequest
+	(*CraftConfirmRequest)(nil),           // 207: game.v1.CraftConfirmRequest
+	(*ScavengeRequest)(nil),               // 208: game.v1.ScavengeRequest
+	(*AffixRequest)(nil),                  // 209: game.v1.AffixRequest
+	(*ExploreRequest)(nil),                // 210: game.v1.ExploreRequest
+	(*RefocusRequest)(nil),                // 211: game.v1.RefocusRequest
+	(*SeduceRequest)(nil),                 // 212: game.v1.SeduceRequest
+	(*HotbarSlot)(nil),                    // 213: game.v1.HotbarSlot
+	(*HotbarRequest)(nil),                 // 214: game.v1.HotbarRequest
+	(*HotbarUpdateEvent)(nil),             // 215: game.v1.HotbarUpdateEvent
+	(*DowntimeRequest)(nil),               // 216: game.v1.DowntimeRequest
+	(*QuestRequest)(nil),                  // 217: game.v1.QuestRequest
+	(*MaterialLoss)(nil),                  // 218: game.v1.MaterialLoss
+	(*CraftResultEvent)(nil),              // 219: game.v1.CraftResultEvent
+	(*UncurseRequest)(nil),                // 220: game.v1.UncurseRequest
+	(*WeatherEvent)(nil),                  // 221: game.v1.WeatherEvent
+	(*JobGrantsRequest)(nil),              // 222: game.v1.JobGrantsRequest
+	(*JobFeatGrant)(nil),                  // 223: game.v1.JobFeatGrant
+	(*JobTechGrant)(nil),                  // 224: game.v1.JobTechGrant
+	(*JobGrantsResponse)(nil),             // 225: game.v1.JobGrantsResponse
+	(*FeatOption)(nil),                    // 226: game.v1.FeatOption
+	(*PendingFeatChoice)(nil),             // 227: game.v1.PendingFeatChoice
+	(*ChooseFeatRequest)(nil),             // 228: game.v1.ChooseFeatRequest
+	(*AdminSessionInfo)(nil),              // 229: game.v1.AdminSessionInfo
+	(*AdminListSessionsRequest)(nil),      // 230: game.v1.AdminListSessionsRequest
+	(*AdminListSessionsResponse)(nil),     // 231: game.v1.AdminListSessionsResponse
+	(*AdminKickRequest)(nil),              // 232: game.v1.AdminKickRequest
+	(*AdminKickResponse)(nil),             // 233: game.v1.AdminKickResponse
+	(*AdminMessageRequest)(nil),           // 234: game.v1.AdminMessageRequest
+	(*AdminMessageResponse)(nil),          // 235: game.v1.AdminMessageResponse
+	(*AdminTeleportRequest)(nil),          // 236: game.v1.AdminTeleportRequest
+	(*AdminTeleportResponse)(nil),         // 237: game.v1.AdminTeleportResponse
+	(*AdminListZonesRequest)(nil),         // 238: game.v1.AdminListZonesRequest
+	(*AdminZoneSummary)(nil),              // 239: game.v1.AdminZoneSummary
+	(*AdminListZonesResponse)(nil),        // 240: game.v1.AdminListZonesResponse
+	(*AdminListRoomsRequest)(nil),         // 241: game.v1.AdminListRoomsRequest
+	(*AdminRoomSummary)(nil),              // 242: game.v1.AdminRoomSummary
+	(*AdminListRoomsResponse)(nil),        // 243: game.v1.AdminListRoomsResponse
+	(*AdminUpdateRoomRequest)(nil),        // 244: game.v1.AdminUpdateRoomRequest
+	(*AdminUpdateRoomResponse)(nil),       // 245: game.v1.AdminUpdateRoomResponse
+	(*AdminListNPCTemplatesRequest)(nil),  // 246: game.v1.AdminListNPCTemplatesRequest
+	(*AdminNPCTemplateSummary)(nil),       // 247: game.v1.AdminNPCTemplateSummary
+	(*AdminListNPCTemplatesResponse)(nil), // 248: game.v1.AdminListNPCTemplatesResponse
+	(*AdminSpawnNPCRequest)(nil),          // 249: game.v1.AdminSpawnNPCRequest
+	(*AdminSpawnNPCResponse)(nil),         // 250: game.v1.AdminSpawnNPCResponse
+	(*AdminGiveItemRequest)(nil),          // 251: game.v1.AdminGiveItemRequest
+	(*AdminGiveItemResponse)(nil),         // 252: game.v1.AdminGiveItemResponse
+	(*AdminGiveCurrencyRequest)(nil),      // 253: game.v1.AdminGiveCurrencyRequest
+	(*AdminGiveCurrencyResponse)(nil),     // 254: game.v1.AdminGiveCurrencyResponse
+	nil,                                   // 255: game.v1.FixerView.BribeCostsEntry
+	(*AoeTemplate_Cell)(nil),              // 256: game.v1.AoeTemplate.Cell
+	nil,                                   // 257: game.v1.CharacterSheetView.ArmorEntry
+	nil,                                   // 258: game.v1.CharacterSheetView.AccessoriesEntry
+	nil,                                   // 259: game.v1.CharacterSheetView.ArmorCategoriesEntry
 }
 var file_game_v1_game_proto_depIdxs = []int32{
-	41,  // 0: game.v1.ClientMessage.join_world:type_name -> game.v1.JoinWorldRequest
-	42,  // 1: game.v1.ClientMessage.move:type_name -> game.v1.MoveRequest
-	43,  // 2: game.v1.ClientMessage.look:type_name -> game.v1.LookRequest
-	44,  // 3: game.v1.ClientMessage.say:type_name -> game.v1.SayRequest
-	45,  // 4: game.v1.ClientMessage.emote:type_name -> game.v1.EmoteRequest
-	46,  // 5: game.v1.ClientMessage.who:type_name -> game.v1.WhoRequest
-	47,  // 6: game.v1.ClientMessage.exits:type_name -> game.v1.ExitsRequest
-	48,  // 7: game.v1.ClientMessage.quit:type_name -> game.v1.QuitRequest
-	62,  // 8: game.v1.ClientMessage.examine:type_name -> game.v1.ExamineRequest
-	71,  // 9: game.v1.ClientMessage.attack:type_name -> game.v1.AttackRequest
-	72,  // 10: game.v1.ClientMessage.flee:type_name -> game.v1.FleeRequest
-	73,  // 11: game.v1.ClientMessage.pass:type_name -> game.v1.PassRequest
-	74,  // 12: game.v1.ClientMessage.strike:type_name -> game.v1.StrikeRequest
-	122, // 13: game.v1.ClientMessage.status:type_name -> game.v1.StatusRequest
-	75,  // 14: game.v1.ClientMessage.equip:type_name -> game.v1.EquipRequest
-	76,  // 15: game.v1.ClientMessage.reload:type_name -> game.v1.ReloadRequest
-	77,  // 16: game.v1.ClientMessage.fire_burst:type_name -> game.v1.FireBurstRequest
-	78,  // 17: game.v1.ClientMessage.fire_automatic:type_name -> game.v1.FireAutomaticRequest
-	79,  // 18: game.v1.ClientMessage.throw:type_name -> game.v1.ThrowRequest
-	80,  // 19: game.v1.ClientMessage.inventory_req:type_name -> game.v1.InventoryRequest
-	81,  // 20: game.v1.ClientMessage.get_item:type_name -> game.v1.GetItemRequest
-	82,  // 21: game.v1.ClientMessage.drop_item:type_name -> game.v1.DropItemRequest
-	83,  // 22: game.v1.ClientMessage.balance:type_name -> game.v1.BalanceRequest
-	84,  // 23: game.v1.ClientMessage.set_role:type_name -> game.v1.SetRoleRequest
-	96,  // 24: game.v1.ClientMessage.teleport:type_name -> game.v1.TeleportRequest
-	85,  // 25: game.v1.ClientMessage.loadout:type_name -> game.v1.LoadoutRequest
-	94,  // 26: game.v1.ClientMessage.unequip:type_name -> game.v1.UnequipRequest
-	95,  // 27: game.v1.ClientMessage.equipment:type_name -> game.v1.EquipmentRequest
-	49,  // 28: game.v1.ClientMessage.switch_character:type_name -> game.v1.SwitchCharacterRequest
-	124, // 29: game.v1.ClientMessage.wear:type_name -> game.v1.WearRequest
-	125, // 30: game.v1.ClientMessage.remove_armor:type_name -> game.v1.RemoveArmorRequest
-	127, // 31: game.v1.ClientMessage.char_sheet:type_name -> game.v1.CharacterSheetRequest
-	128, // 32: game.v1.ClientMessage.archetype_selection:type_name -> game.v1.ArchetypeSelectionRequest
-	100, // 33: game.v1.ClientMessage.use_equipment:type_name -> game.v1.UseEquipmentRequest
-	112, // 34: game.v1.ClientMessage.room_equip:type_name -> game.v1.RoomEquipRequest
-	101, // 35: game.v1.ClientMessage.map:type_name -> game.v1.MapRequest
-	109, // 36: game.v1.ClientMessage.skills_request:type_name -> game.v1.SkillsRequest
-	129, // 37: game.v1.ClientMessage.feats_request:type_name -> game.v1.FeatsRequest
-	135, // 38: game.v1.ClientMessage.interact_request:type_name -> game.v1.InteractRequest
-	137, // 39: game.v1.ClientMessage.use_request:type_name -> game.v1.UseRequest
-	132, // 40: game.v1.ClientMessage.class_features_request:type_name -> game.v1.ClassFeaturesRequest
-	97,  // 41: game.v1.ClientMessage.summon_item:type_name -> game.v1.SummonItemRequest
-	146, // 42: game.v1.ClientMessage.proficiencies_request:type_name -> game.v1.ProficienciesRequest
-	149, // 43: game.v1.ClientMessage.level_up:type_name -> game.v1.LevelUpRequest
-	150, // 44: game.v1.ClientMessage.combat_default:type_name -> game.v1.CombatDefaultRequest
-	151, // 45: game.v1.ClientMessage.train_skill:type_name -> game.v1.TrainSkillRequest
-	152, // 46: game.v1.ClientMessage.action:type_name -> game.v1.ActionRequest
-	153, // 47: game.v1.ClientMessage.raise_shield:type_name -> game.v1.RaiseShieldRequest
-	154, // 48: game.v1.ClientMessage.take_cover:type_name -> game.v1.TakeCoverRequest
-	155, // 49: game.v1.ClientMessage.first_aid:type_name -> game.v1.FirstAidRequest
-	156, // 50: game.v1.ClientMessage.feint:type_name -> game.v1.FeintRequest
-	157, // 51: game.v1.ClientMessage.demoralize:type_name -> game.v1.DemoralizeRequest
-	158, // 52: game.v1.ClientMessage.grapple:type_name -> game.v1.GrappleRequest
-	159, // 53: game.v1.ClientMessage.trip:type_name -> game.v1.TripRequest
-	165, // 54: game.v1.ClientMessage.hide:type_name -> game.v1.HideRequest
-	166, // 55: game.v1.ClientMessage.sneak:type_name -> game.v1.SneakRequest
-	167, // 56: game.v1.ClientMessage.divert:type_name -> game.v1.DivertRequest
-	168, // 57: game.v1.ClientMessage.escape:type_name -> game.v1.EscapeRequest
-	185, // 58: game.v1.ClientMessage.grant:type_name -> game.v1.GrantRequest
-	160, // 59: game.v1.ClientMessage.disarm:type_name -> game.v1.DisarmRequest
-	161, // 60: game.v1.ClientMessage.stride:type_name -> game.v1.StrideRequest
-	163, // 61: game.v1.ClientMessage.shove:type_name -> game.v1.ShoveRequest
-	164, // 62: game.v1.ClientMessage.step:type_name -> game.v1.StepRequest
-	169, // 63: game.v1.ClientMessage.tumble:type_name -> game.v1.TumbleRequest
-	170, // 64: game.v1.ClientMessage.seek:type_name -> game.v1.SeekRequest
-	171, // 65: game.v1.ClientMessage.climb:type_name -> game.v1.ClimbRequest
-	172, // 66: game.v1.ClientMessage.swim:type_name -> game.v1.SwimRequest
-	184, // 67: game.v1.ClientMessage.motive:type_name -> game.v1.MotiveRequest
-	173, // 68: game.v1.ClientMessage.calm:type_name -> game.v1.CalmRequest
-	174, // 69: game.v1.ClientMessage.hero_point:type_name -> game.v1.HeroPointRequest
-	175, // 70: game.v1.ClientMessage.delay:type_name -> game.v1.DelayRequest
-	176, // 71: game.v1.ClientMessage.join:type_name -> game.v1.JoinRequest
-	177, // 72: game.v1.ClientMessage.decline:type_name -> game.v1.DeclineRequest
-	178, // 73: game.v1.ClientMessage.group:type_name -> game.v1.GroupRequest
-	179, // 74: game.v1.ClientMessage.invite:type_name -> game.v1.InviteRequest
-	180, // 75: game.v1.ClientMessage.accept_group:type_name -> game.v1.AcceptGroupRequest
-	181, // 76: game.v1.ClientMessage.decline_group:type_name -> game.v1.DeclineGroupRequest
-	182, // 77: game.v1.ClientMessage.ungroup:type_name -> game.v1.UngroupRequest
-	183, // 78: game.v1.ClientMessage.kick:type_name -> game.v1.KickRequest
-	6,   // 79: game.v1.ClientMessage.rest:type_name -> game.v1.RestRequest
-	7,   // 80: game.v1.ClientMessage.select_tech:type_name -> game.v1.SelectTechRequest
-	8,   // 81: game.v1.ClientMessage.aid:type_name -> game.v1.AidRequest
-	9,   // 82: game.v1.ClientMessage.disarm_trap:type_name -> game.v1.DisarmTrapRequest
-	31,  // 83: game.v1.ClientMessage.deploy_trap:type_name -> game.v1.DeployTrapRequest
-	10,  // 84: game.v1.ClientMessage.ready:type_name -> game.v1.ReadyRequest
-	11,  // 85: game.v1.ClientMessage.browse:type_name -> game.v1.BrowseRequest
-	12,  // 86: game.v1.ClientMessage.buy:type_name -> game.v1.BuyRequest
-	13,  // 87: game.v1.ClientMessage.sell:type_name -> game.v1.SellRequest
-	14,  // 88: game.v1.ClientMessage.negotiate:type_name -> game.v1.NegotiateRequest
-	15,  // 89: game.v1.ClientMessage.stash_deposit:type_name -> game.v1.StashDepositRequest
-	16,  // 90: game.v1.ClientMessage.stash_withdraw:type_name -> game.v1.StashWithdrawRequest
-	17,  // 91: game.v1.ClientMessage.stash_balance:type_name -> game.v1.StashBalanceRequest
-	18,  // 92: game.v1.ClientMessage.heal:type_name -> game.v1.HealRequest
-	19,  // 93: game.v1.ClientMessage.heal_amount:type_name -> game.v1.HealAmountRequest
-	20,  // 94: game.v1.ClientMessage.train_job:type_name -> game.v1.TrainJobRequest
-	22,  // 95: game.v1.ClientMessage.list_jobs:type_name -> game.v1.ListJobsRequest
-	23,  // 96: game.v1.ClientMessage.set_job:type_name -> game.v1.SetJobRequest
-	24,  // 97: game.v1.ClientMessage.hire:type_name -> game.v1.HireRequest
-	25,  // 98: game.v1.ClientMessage.dismiss:type_name -> game.v1.DismissRequest
-	26,  // 99: game.v1.ClientMessage.talk:type_name -> game.v1.TalkRequest
-	27,  // 100: game.v1.ClientMessage.bribe_request:type_name -> game.v1.BribeRequest
-	28,  // 101: game.v1.ClientMessage.bribe_confirm_request:type_name -> game.v1.BribeConfirmRequest
-	29,  // 102: game.v1.ClientMessage.surrender_request:type_name -> game.v1.SurrenderRequest
-	30,  // 103: game.v1.ClientMessage.release_request:type_name -> game.v1.ReleaseRequest
-	186, // 104: game.v1.ClientMessage.spawn_npc:type_name -> game.v1.SpawnNPCRequest
-	188, // 105: game.v1.ClientMessage.add_room:type_name -> game.v1.AddRoomRequest
-	189, // 106: game.v1.ClientMessage.add_link:type_name -> game.v1.AddLinkRequest
-	190, // 107: game.v1.ClientMessage.remove_link:type_name -> game.v1.RemoveLinkRequest
-	191, // 108: game.v1.ClientMessage.set_room:type_name -> game.v1.SetRoomRequest
-	192, // 109: game.v1.ClientMessage.editor_cmds:type_name -> game.v1.EditorCmdsRequest
-	32,  // 110: game.v1.ClientMessage.travel:type_name -> game.v1.TravelRequest
-	33,  // 111: game.v1.ClientMessage.activate_item:type_name -> game.v1.ActivateItemRequest
-	195, // 112: game.v1.ClientMessage.faction_request:type_name -> game.v1.FactionRequest
-	196, // 113: game.v1.ClientMessage.faction_info_request:type_name -> game.v1.FactionInfoRequest
-	197, // 114: game.v1.ClientMessage.faction_standing_request:type_name -> game.v1.FactionStandingRequest
-	198, // 115: game.v1.ClientMessage.change_rep_request:type_name -> game.v1.ChangeRepRequest
-	199, // 116: game.v1.ClientMessage.tab_complete:type_name -> game.v1.TabCompleteRequest
-	201, // 117: game.v1.ClientMessage.materials_request:type_name -> game.v1.MaterialsRequest
-	202, // 118: game.v1.ClientMessage.craft_list_request:type_name -> game.v1.CraftListRequest
-	203, // 119: game.v1.ClientMessage.craft_request:type_name -> game.v1.CraftRequest
-	204, // 120: game.v1.ClientMessage.craft_confirm_request:type_name -> game.v1.CraftConfirmRequest
-	205, // 121: game.v1.ClientMessage.scavenge_request:type_name -> game.v1.ScavengeRequest
-	206, // 122: game.v1.ClientMessage.affix_request:type_name -> game.v1.AffixRequest
-	207, // 123: game.v1.ClientMessage.explore_request:type_name -> game.v1.ExploreRequest
-	214, // 124: game.v1.ClientMessage.quest_request:type_name -> game.v1.QuestRequest
-	217, // 125: game.v1.ClientMessage.uncurse_request:type_name -> game.v1.UncurseRequest
-	213, // 126: game.v1.ClientMessage.downtime_request:type_name -> game.v1.DowntimeRequest
-	208, // 127: game.v1.ClientMessage.refocus_request:type_name -> game.v1.RefocusRequest
-	209, // 128: game.v1.ClientMessage.seduce_request:type_name -> game.v1.SeduceRequest
-	211, // 129: game.v1.ClientMessage.hotbar_request:type_name -> game.v1.HotbarRequest
-	193, // 130: game.v1.ClientMessage.spawn_char_request:type_name -> game.v1.SpawnCharRequest
-	194, // 131: game.v1.ClientMessage.delete_char_request:type_name -> game.v1.DeleteCharRequest
-	187, // 132: game.v1.ClientMessage.kill_npc_request:type_name -> game.v1.KillNPCRequest
-	5,   // 133: game.v1.ClientMessage.uncover_request:type_name -> game.v1.UncoverRequest
-	219, // 134: game.v1.ClientMessage.job_grants_request:type_name -> game.v1.JobGrantsRequest
-	93,  // 135: game.v1.ClientMessage.quest_log_request:type_name -> game.v1.QuestLogRequest
-	21,  // 136: game.v1.ClientMessage.train_tech:type_name -> game.v1.TrainTechRequest
-	225, // 137: game.v1.ClientMessage.choose_feat:type_name -> game.v1.ChooseFeatRequest
-	162, // 138: game.v1.ClientMessage.move_to:type_name -> game.v1.MoveToRequest
-	37,  // 139: game.v1.ClientMessage.reaction_response:type_name -> game.v1.ReactionResponse
-	50,  // 140: game.v1.ServerEvent.room_view:type_name -> game.v1.RoomView
-	52,  // 141: game.v1.ServerEvent.message:type_name -> game.v1.MessageEvent
-	53,  // 142: game.v1.ServerEvent.room_event:type_name -> game.v1.RoomEvent
-	54,  // 143: game.v1.ServerEvent.player_list:type_name -> game.v1.PlayerList
-	56,  // 144: game.v1.ServerEvent.exit_list:type_name -> game.v1.ExitList
-	57,  // 145: game.v1.ServerEvent.error:type_name -> game.v1.ErrorEvent
-	58,  // 146: game.v1.ServerEvent.disconnected:type_name -> game.v1.Disconnected
-	60,  // 147: game.v1.ServerEvent.character_info:type_name -> game.v1.CharacterInfo
-	63,  // 148: game.v1.ServerEvent.npc_view:type_name -> game.v1.NpcView
-	121, // 149: game.v1.ServerEvent.combat_event:type_name -> game.v1.CombatEvent
-	118, // 150: game.v1.ServerEvent.round_start:type_name -> game.v1.RoundStartEvent
-	119, // 151: game.v1.ServerEvent.round_end:type_name -> game.v1.RoundEndEvent
-	123, // 152: game.v1.ServerEvent.condition_event:type_name -> game.v1.ConditionEvent
-	114, // 153: game.v1.ServerEvent.inventory_view:type_name -> game.v1.InventoryView
-	59,  // 154: game.v1.ServerEvent.time_of_day:type_name -> game.v1.TimeOfDayEvent
-	142, // 155: game.v1.ServerEvent.character_sheet:type_name -> game.v1.CharacterSheetView
-	108, // 156: game.v1.ServerEvent.map:type_name -> game.v1.MapResponse
-	111, // 157: game.v1.ServerEvent.skills_response:type_name -> game.v1.SkillsResponse
-	131, // 158: game.v1.ServerEvent.feats_response:type_name -> game.v1.FeatsResponse
-	136, // 159: game.v1.ServerEvent.interact_response:type_name -> game.v1.InteractResponse
-	138, // 160: game.v1.ServerEvent.use_response:type_name -> game.v1.UseResponse
-	134, // 161: game.v1.ServerEvent.class_features_response:type_name -> game.v1.ClassFeaturesResponse
-	148, // 162: game.v1.ServerEvent.proficiencies_response:type_name -> game.v1.ProficienciesResponse
-	40,  // 163: game.v1.ServerEvent.hp_update:type_name -> game.v1.HpUpdateEvent
-	200, // 164: game.v1.ServerEvent.tab_complete:type_name -> game.v1.TabCompleteResponse
-	216, // 165: game.v1.ServerEvent.craft_result:type_name -> game.v1.CraftResultEvent
-	212, // 166: game.v1.ServerEvent.hotbar_update:type_name -> game.v1.HotbarUpdateEvent
-	39,  // 167: game.v1.ServerEvent.shop_view:type_name -> game.v1.ShopView
-	64,  // 168: game.v1.ServerEvent.healer_view:type_name -> game.v1.HealerView
-	66,  // 169: game.v1.ServerEvent.trainer_view:type_name -> game.v1.TrainerView
-	218, // 170: game.v1.ServerEvent.weather:type_name -> game.v1.WeatherEvent
-	87,  // 171: game.v1.ServerEvent.loadout_view:type_name -> game.v1.LoadoutView
-	69,  // 172: game.v1.ServerEvent.fixer_view:type_name -> game.v1.FixerView
-	222, // 173: game.v1.ServerEvent.job_grants_response:type_name -> game.v1.JobGrantsResponse
-	70,  // 174: game.v1.ServerEvent.rest_view:type_name -> game.v1.RestView
-	120, // 175: game.v1.ServerEvent.ap_update:type_name -> game.v1.APUpdateEvent
-	90,  // 176: game.v1.ServerEvent.quest_giver_view:type_name -> game.v1.QuestGiverView
-	91,  // 177: game.v1.ServerEvent.quest_log_view:type_name -> game.v1.QuestLogView
-	92,  // 178: game.v1.ServerEvent.quest_complete:type_name -> game.v1.QuestCompleteEvent
-	67,  // 179: game.v1.ServerEvent.tech_trainer_view:type_name -> game.v1.TechTrainerView
-	107, // 180: game.v1.ServerEvent.game_config:type_name -> game.v1.GameConfig
-	35,  // 181: game.v1.ServerEvent.reaction_prompt:type_name -> game.v1.ReactionPromptEvent
-	36,  // 182: game.v1.ReactionPromptEvent.options:type_name -> game.v1.ReactionPromptOption
-	38,  // 183: game.v1.ShopView.items:type_name -> game.v1.ShopItem
-	51,  // 184: game.v1.RoomView.exits:type_name -> game.v1.ExitInfo
-	61,  // 185: game.v1.RoomView.npcs:type_name -> game.v1.NpcInfo
-	126, // 186: game.v1.RoomView.active_conditions:type_name -> game.v1.ConditionInfo
-	98,  // 187: game.v1.RoomView.floor_items:type_name -> game.v1.FloorItem
-	99,  // 188: game.v1.RoomView.equipment:type_name -> game.v1.RoomEquipmentItem
+	43,  // 0: game.v1.ClientMessage.join_world:type_name -> game.v1.JoinWorldRequest
+	44,  // 1: game.v1.ClientMessage.move:type_name -> game.v1.MoveRequest
+	45,  // 2: game.v1.ClientMessage.look:type_name -> game.v1.LookRequest
+	46,  // 3: game.v1.ClientMessage.say:type_name -> game.v1.SayRequest
+	47,  // 4: game.v1.ClientMessage.emote:type_name -> game.v1.EmoteRequest
+	48,  // 5: game.v1.ClientMessage.who:type_name -> game.v1.WhoRequest
+	49,  // 6: game.v1.ClientMessage.exits:type_name -> game.v1.ExitsRequest
+	50,  // 7: game.v1.ClientMessage.quit:type_name -> game.v1.QuitRequest
+	64,  // 8: game.v1.ClientMessage.examine:type_name -> game.v1.ExamineRequest
+	73,  // 9: game.v1.ClientMessage.attack:type_name -> game.v1.AttackRequest
+	74,  // 10: game.v1.ClientMessage.flee:type_name -> game.v1.FleeRequest
+	75,  // 11: game.v1.ClientMessage.pass:type_name -> game.v1.PassRequest
+	76,  // 12: game.v1.ClientMessage.strike:type_name -> game.v1.StrikeRequest
+	124, // 13: game.v1.ClientMessage.status:type_name -> game.v1.StatusRequest
+	77,  // 14: game.v1.ClientMessage.equip:type_name -> game.v1.EquipRequest
+	78,  // 15: game.v1.ClientMessage.reload:type_name -> game.v1.ReloadRequest
+	79,  // 16: game.v1.ClientMessage.fire_burst:type_name -> game.v1.FireBurstRequest
+	80,  // 17: game.v1.ClientMessage.fire_automatic:type_name -> game.v1.FireAutomaticRequest
+	81,  // 18: game.v1.ClientMessage.throw:type_name -> game.v1.ThrowRequest
+	82,  // 19: game.v1.ClientMessage.inventory_req:type_name -> game.v1.InventoryRequest
+	83,  // 20: game.v1.ClientMessage.get_item:type_name -> game.v1.GetItemRequest
+	84,  // 21: game.v1.ClientMessage.drop_item:type_name -> game.v1.DropItemRequest
+	85,  // 22: game.v1.ClientMessage.balance:type_name -> game.v1.BalanceRequest
+	86,  // 23: game.v1.ClientMessage.set_role:type_name -> game.v1.SetRoleRequest
+	98,  // 24: game.v1.ClientMessage.teleport:type_name -> game.v1.TeleportRequest
+	87,  // 25: game.v1.ClientMessage.loadout:type_name -> game.v1.LoadoutRequest
+	96,  // 26: game.v1.ClientMessage.unequip:type_name -> game.v1.UnequipRequest
+	97,  // 27: game.v1.ClientMessage.equipment:type_name -> game.v1.EquipmentRequest
+	51,  // 28: game.v1.ClientMessage.switch_character:type_name -> game.v1.SwitchCharacterRequest
+	126, // 29: game.v1.ClientMessage.wear:type_name -> game.v1.WearRequest
+	127, // 30: game.v1.ClientMessage.remove_armor:type_name -> game.v1.RemoveArmorRequest
+	129, // 31: game.v1.ClientMessage.char_sheet:type_name -> game.v1.CharacterSheetRequest
+	130, // 32: game.v1.ClientMessage.archetype_selection:type_name -> game.v1.ArchetypeSelectionRequest
+	102, // 33: game.v1.ClientMessage.use_equipment:type_name -> game.v1.UseEquipmentRequest
+	114, // 34: game.v1.ClientMessage.room_equip:type_name -> game.v1.RoomEquipRequest
+	103, // 35: game.v1.ClientMessage.map:type_name -> game.v1.MapRequest
+	111, // 36: game.v1.ClientMessage.skills_request:type_name -> game.v1.SkillsRequest
+	131, // 37: game.v1.ClientMessage.feats_request:type_name -> game.v1.FeatsRequest
+	137, // 38: game.v1.ClientMessage.interact_request:type_name -> game.v1.InteractRequest
+	140, // 39: game.v1.ClientMessage.use_request:type_name -> game.v1.UseRequest
+	134, // 40: game.v1.ClientMessage.class_features_request:type_name -> game.v1.ClassFeaturesRequest
+	99,  // 41: game.v1.ClientMessage.summon_item:type_name -> game.v1.SummonItemRequest
+	149, // 42: game.v1.ClientMessage.proficiencies_request:type_name -> game.v1.ProficienciesRequest
+	152, // 43: game.v1.ClientMessage.level_up:type_name -> game.v1.LevelUpRequest
+	153, // 44: game.v1.ClientMessage.combat_default:type_name -> game.v1.CombatDefaultRequest
+	154, // 45: game.v1.ClientMessage.train_skill:type_name -> game.v1.TrainSkillRequest
+	155, // 46: game.v1.ClientMessage.action:type_name -> game.v1.ActionRequest
+	156, // 47: game.v1.ClientMessage.raise_shield:type_name -> game.v1.RaiseShieldRequest
+	157, // 48: game.v1.ClientMessage.take_cover:type_name -> game.v1.TakeCoverRequest
+	158, // 49: game.v1.ClientMessage.first_aid:type_name -> game.v1.FirstAidRequest
+	159, // 50: game.v1.ClientMessage.feint:type_name -> game.v1.FeintRequest
+	160, // 51: game.v1.ClientMessage.demoralize:type_name -> game.v1.DemoralizeRequest
+	161, // 52: game.v1.ClientMessage.grapple:type_name -> game.v1.GrappleRequest
+	162, // 53: game.v1.ClientMessage.trip:type_name -> game.v1.TripRequest
+	168, // 54: game.v1.ClientMessage.hide:type_name -> game.v1.HideRequest
+	169, // 55: game.v1.ClientMessage.sneak:type_name -> game.v1.SneakRequest
+	170, // 56: game.v1.ClientMessage.divert:type_name -> game.v1.DivertRequest
+	171, // 57: game.v1.ClientMessage.escape:type_name -> game.v1.EscapeRequest
+	188, // 58: game.v1.ClientMessage.grant:type_name -> game.v1.GrantRequest
+	163, // 59: game.v1.ClientMessage.disarm:type_name -> game.v1.DisarmRequest
+	164, // 60: game.v1.ClientMessage.stride:type_name -> game.v1.StrideRequest
+	166, // 61: game.v1.ClientMessage.shove:type_name -> game.v1.ShoveRequest
+	167, // 62: game.v1.ClientMessage.step:type_name -> game.v1.StepRequest
+	172, // 63: game.v1.ClientMessage.tumble:type_name -> game.v1.TumbleRequest
+	173, // 64: game.v1.ClientMessage.seek:type_name -> game.v1.SeekRequest
+	174, // 65: game.v1.ClientMessage.climb:type_name -> game.v1.ClimbRequest
+	175, // 66: game.v1.ClientMessage.swim:type_name -> game.v1.SwimRequest
+	187, // 67: game.v1.ClientMessage.motive:type_name -> game.v1.MotiveRequest
+	176, // 68: game.v1.ClientMessage.calm:type_name -> game.v1.CalmRequest
+	177, // 69: game.v1.ClientMessage.hero_point:type_name -> game.v1.HeroPointRequest
+	178, // 70: game.v1.ClientMessage.delay:type_name -> game.v1.DelayRequest
+	179, // 71: game.v1.ClientMessage.join:type_name -> game.v1.JoinRequest
+	180, // 72: game.v1.ClientMessage.decline:type_name -> game.v1.DeclineRequest
+	181, // 73: game.v1.ClientMessage.group:type_name -> game.v1.GroupRequest
+	182, // 74: game.v1.ClientMessage.invite:type_name -> game.v1.InviteRequest
+	183, // 75: game.v1.ClientMessage.accept_group:type_name -> game.v1.AcceptGroupRequest
+	184, // 76: game.v1.ClientMessage.decline_group:type_name -> game.v1.DeclineGroupRequest
+	185, // 77: game.v1.ClientMessage.ungroup:type_name -> game.v1.UngroupRequest
+	186, // 78: game.v1.ClientMessage.kick:type_name -> game.v1.KickRequest
+	8,   // 79: game.v1.ClientMessage.rest:type_name -> game.v1.RestRequest
+	9,   // 80: game.v1.ClientMessage.select_tech:type_name -> game.v1.SelectTechRequest
+	10,  // 81: game.v1.ClientMessage.aid:type_name -> game.v1.AidRequest
+	11,  // 82: game.v1.ClientMessage.disarm_trap:type_name -> game.v1.DisarmTrapRequest
+	33,  // 83: game.v1.ClientMessage.deploy_trap:type_name -> game.v1.DeployTrapRequest
+	12,  // 84: game.v1.ClientMessage.ready:type_name -> game.v1.ReadyRequest
+	13,  // 85: game.v1.ClientMessage.browse:type_name -> game.v1.BrowseRequest
+	14,  // 86: game.v1.ClientMessage.buy:type_name -> game.v1.BuyRequest
+	15,  // 87: game.v1.ClientMessage.sell:type_name -> game.v1.SellRequest
+	16,  // 88: game.v1.ClientMessage.negotiate:type_name -> game.v1.NegotiateRequest
+	17,  // 89: game.v1.ClientMessage.stash_deposit:type_name -> game.v1.StashDepositRequest
+	18,  // 90: game.v1.ClientMessage.stash_withdraw:type_name -> game.v1.StashWithdrawRequest
+	19,  // 91: game.v1.ClientMessage.stash_balance:type_name -> game.v1.StashBalanceRequest
+	20,  // 92: game.v1.ClientMessage.heal:type_name -> game.v1.HealRequest
+	21,  // 93: game.v1.ClientMessage.heal_amount:type_name -> game.v1.HealAmountRequest
+	22,  // 94: game.v1.ClientMessage.train_job:type_name -> game.v1.TrainJobRequest
+	24,  // 95: game.v1.ClientMessage.list_jobs:type_name -> game.v1.ListJobsRequest
+	25,  // 96: game.v1.ClientMessage.set_job:type_name -> game.v1.SetJobRequest
+	26,  // 97: game.v1.ClientMessage.hire:type_name -> game.v1.HireRequest
+	27,  // 98: game.v1.ClientMessage.dismiss:type_name -> game.v1.DismissRequest
+	28,  // 99: game.v1.ClientMessage.talk:type_name -> game.v1.TalkRequest
+	29,  // 100: game.v1.ClientMessage.bribe_request:type_name -> game.v1.BribeRequest
+	30,  // 101: game.v1.ClientMessage.bribe_confirm_request:type_name -> game.v1.BribeConfirmRequest
+	31,  // 102: game.v1.ClientMessage.surrender_request:type_name -> game.v1.SurrenderRequest
+	32,  // 103: game.v1.ClientMessage.release_request:type_name -> game.v1.ReleaseRequest
+	189, // 104: game.v1.ClientMessage.spawn_npc:type_name -> game.v1.SpawnNPCRequest
+	191, // 105: game.v1.ClientMessage.add_room:type_name -> game.v1.AddRoomRequest
+	192, // 106: game.v1.ClientMessage.add_link:type_name -> game.v1.AddLinkRequest
+	193, // 107: game.v1.ClientMessage.remove_link:type_name -> game.v1.RemoveLinkRequest
+	194, // 108: game.v1.ClientMessage.set_room:type_name -> game.v1.SetRoomRequest
+	195, // 109: game.v1.ClientMessage.editor_cmds:type_name -> game.v1.EditorCmdsRequest
+	34,  // 110: game.v1.ClientMessage.travel:type_name -> game.v1.TravelRequest
+	35,  // 111: game.v1.ClientMessage.activate_item:type_name -> game.v1.ActivateItemRequest
+	198, // 112: game.v1.ClientMessage.faction_request:type_name -> game.v1.FactionRequest
+	199, // 113: game.v1.ClientMessage.faction_info_request:type_name -> game.v1.FactionInfoRequest
+	200, // 114: game.v1.ClientMessage.faction_standing_request:type_name -> game.v1.FactionStandingRequest
+	201, // 115: game.v1.ClientMessage.change_rep_request:type_name -> game.v1.ChangeRepRequest
+	202, // 116: game.v1.ClientMessage.tab_complete:type_name -> game.v1.TabCompleteRequest
+	204, // 117: game.v1.ClientMessage.materials_request:type_name -> game.v1.MaterialsRequest
+	205, // 118: game.v1.ClientMessage.craft_list_request:type_name -> game.v1.CraftListRequest
+	206, // 119: game.v1.ClientMessage.craft_request:type_name -> game.v1.CraftRequest
+	207, // 120: game.v1.ClientMessage.craft_confirm_request:type_name -> game.v1.CraftConfirmRequest
+	208, // 121: game.v1.ClientMessage.scavenge_request:type_name -> game.v1.ScavengeRequest
+	209, // 122: game.v1.ClientMessage.affix_request:type_name -> game.v1.AffixRequest
+	210, // 123: game.v1.ClientMessage.explore_request:type_name -> game.v1.ExploreRequest
+	217, // 124: game.v1.ClientMessage.quest_request:type_name -> game.v1.QuestRequest
+	220, // 125: game.v1.ClientMessage.uncurse_request:type_name -> game.v1.UncurseRequest
+	216, // 126: game.v1.ClientMessage.downtime_request:type_name -> game.v1.DowntimeRequest
+	211, // 127: game.v1.ClientMessage.refocus_request:type_name -> game.v1.RefocusRequest
+	212, // 128: game.v1.ClientMessage.seduce_request:type_name -> game.v1.SeduceRequest
+	214, // 129: game.v1.ClientMessage.hotbar_request:type_name -> game.v1.HotbarRequest
+	196, // 130: game.v1.ClientMessage.spawn_char_request:type_name -> game.v1.SpawnCharRequest
+	197, // 131: game.v1.ClientMessage.delete_char_request:type_name -> game.v1.DeleteCharRequest
+	190, // 132: game.v1.ClientMessage.kill_npc_request:type_name -> game.v1.KillNPCRequest
+	7,   // 133: game.v1.ClientMessage.uncover_request:type_name -> game.v1.UncoverRequest
+	222, // 134: game.v1.ClientMessage.job_grants_request:type_name -> game.v1.JobGrantsRequest
+	95,  // 135: game.v1.ClientMessage.quest_log_request:type_name -> game.v1.QuestLogRequest
+	23,  // 136: game.v1.ClientMessage.train_tech:type_name -> game.v1.TrainTechRequest
+	228, // 137: game.v1.ClientMessage.choose_feat:type_name -> game.v1.ChooseFeatRequest
+	165, // 138: game.v1.ClientMessage.move_to:type_name -> game.v1.MoveToRequest
+	39,  // 139: game.v1.ClientMessage.reaction_response:type_name -> game.v1.ReactionResponse
+	52,  // 140: game.v1.ServerEvent.room_view:type_name -> game.v1.RoomView
+	54,  // 141: game.v1.ServerEvent.message:type_name -> game.v1.MessageEvent
+	55,  // 142: game.v1.ServerEvent.room_event:type_name -> game.v1.RoomEvent
+	56,  // 143: game.v1.ServerEvent.player_list:type_name -> game.v1.PlayerList
+	58,  // 144: game.v1.ServerEvent.exit_list:type_name -> game.v1.ExitList
+	59,  // 145: game.v1.ServerEvent.error:type_name -> game.v1.ErrorEvent
+	60,  // 146: game.v1.ServerEvent.disconnected:type_name -> game.v1.Disconnected
+	62,  // 147: game.v1.ServerEvent.character_info:type_name -> game.v1.CharacterInfo
+	65,  // 148: game.v1.ServerEvent.npc_view:type_name -> game.v1.NpcView
+	123, // 149: game.v1.ServerEvent.combat_event:type_name -> game.v1.CombatEvent
+	120, // 150: game.v1.ServerEvent.round_start:type_name -> game.v1.RoundStartEvent
+	121, // 151: game.v1.ServerEvent.round_end:type_name -> game.v1.RoundEndEvent
+	125, // 152: game.v1.ServerEvent.condition_event:type_name -> game.v1.ConditionEvent
+	116, // 153: game.v1.ServerEvent.inventory_view:type_name -> game.v1.InventoryView
+	61,  // 154: game.v1.ServerEvent.time_of_day:type_name -> game.v1.TimeOfDayEvent
+	145, // 155: game.v1.ServerEvent.character_sheet:type_name -> game.v1.CharacterSheetView
+	110, // 156: game.v1.ServerEvent.map:type_name -> game.v1.MapResponse
+	113, // 157: game.v1.ServerEvent.skills_response:type_name -> game.v1.SkillsResponse
+	133, // 158: game.v1.ServerEvent.feats_response:type_name -> game.v1.FeatsResponse
+	138, // 159: game.v1.ServerEvent.interact_response:type_name -> game.v1.InteractResponse
+	141, // 160: game.v1.ServerEvent.use_response:type_name -> game.v1.UseResponse
+	136, // 161: game.v1.ServerEvent.class_features_response:type_name -> game.v1.ClassFeaturesResponse
+	151, // 162: game.v1.ServerEvent.proficiencies_response:type_name -> game.v1.ProficienciesResponse
+	42,  // 163: game.v1.ServerEvent.hp_update:type_name -> game.v1.HpUpdateEvent
+	203, // 164: game.v1.ServerEvent.tab_complete:type_name -> game.v1.TabCompleteResponse
+	219, // 165: game.v1.ServerEvent.craft_result:type_name -> game.v1.CraftResultEvent
+	215, // 166: game.v1.ServerEvent.hotbar_update:type_name -> game.v1.HotbarUpdateEvent
+	41,  // 167: game.v1.ServerEvent.shop_view:type_name -> game.v1.ShopView
+	66,  // 168: game.v1.ServerEvent.healer_view:type_name -> game.v1.HealerView
+	68,  // 169: game.v1.ServerEvent.trainer_view:type_name -> game.v1.TrainerView
+	221, // 170: game.v1.ServerEvent.weather:type_name -> game.v1.WeatherEvent
+	89,  // 171: game.v1.ServerEvent.loadout_view:type_name -> game.v1.LoadoutView
+	71,  // 172: game.v1.ServerEvent.fixer_view:type_name -> game.v1.FixerView
+	225, // 173: game.v1.ServerEvent.job_grants_response:type_name -> game.v1.JobGrantsResponse
+	72,  // 174: game.v1.ServerEvent.rest_view:type_name -> game.v1.RestView
+	122, // 175: game.v1.ServerEvent.ap_update:type_name -> game.v1.APUpdateEvent
+	92,  // 176: game.v1.ServerEvent.quest_giver_view:type_name -> game.v1.QuestGiverView
+	93,  // 177: game.v1.ServerEvent.quest_log_view:type_name -> game.v1.QuestLogView
+	94,  // 178: game.v1.ServerEvent.quest_complete:type_name -> game.v1.QuestCompleteEvent
+	69,  // 179: game.v1.ServerEvent.tech_trainer_view:type_name -> game.v1.TechTrainerView
+	109, // 180: game.v1.ServerEvent.game_config:type_name -> game.v1.GameConfig
+	37,  // 181: game.v1.ServerEvent.reaction_prompt:type_name -> game.v1.ReactionPromptEvent
+	38,  // 182: game.v1.ReactionPromptEvent.options:type_name -> game.v1.ReactionPromptOption
+	40,  // 183: game.v1.ShopView.items:type_name -> game.v1.ShopItem
+	53,  // 184: game.v1.RoomView.exits:type_name -> game.v1.ExitInfo
+	63,  // 185: game.v1.RoomView.npcs:type_name -> game.v1.NpcInfo
+	128, // 186: game.v1.RoomView.active_conditions:type_name -> game.v1.ConditionInfo
+	100, // 187: game.v1.RoomView.floor_items:type_name -> game.v1.FloorItem
+	101, // 188: game.v1.RoomView.equipment:type_name -> game.v1.RoomEquipmentItem
 	0,   // 189: game.v1.MessageEvent.type:type_name -> game.v1.MessageType
 	1,   // 190: game.v1.RoomEvent.type:type_name -> game.v1.RoomEventType
-	55,  // 191: game.v1.PlayerList.players:type_name -> game.v1.PlayerInfo
+	57,  // 191: game.v1.PlayerList.players:type_name -> game.v1.PlayerInfo
 	2,   // 192: game.v1.PlayerInfo.status:type_name -> game.v1.CombatStatus
-	51,  // 193: game.v1.ExitList.exits:type_name -> game.v1.ExitInfo
-	65,  // 194: game.v1.TrainerView.jobs:type_name -> game.v1.JobOfferEntry
-	68,  // 195: game.v1.TechTrainerView.offers:type_name -> game.v1.TechOfferEntry
-	252, // 196: game.v1.FixerView.bribe_costs:type_name -> game.v1.FixerView.BribeCostsEntry
-	86,  // 197: game.v1.LoadoutView.presets:type_name -> game.v1.LoadoutWeaponPreset
-	88,  // 198: game.v1.QuestEntryView.objectives:type_name -> game.v1.QuestObjectiveView
-	89,  // 199: game.v1.QuestGiverView.quests:type_name -> game.v1.QuestEntryView
-	89,  // 200: game.v1.QuestLogView.quests:type_name -> game.v1.QuestEntryView
-	102, // 201: game.v1.MapTile.poi_npcs:type_name -> game.v1.PoiWithNpc
-	103, // 202: game.v1.MapTile.zone_exits:type_name -> game.v1.ZoneExitInfo
-	104, // 203: game.v1.MapTile.same_zone_exit_targets:type_name -> game.v1.SameZoneExitTarget
-	105, // 204: game.v1.MapResponse.tiles:type_name -> game.v1.MapTile
-	106, // 205: game.v1.MapResponse.world_tiles:type_name -> game.v1.WorldZoneTile
-	110, // 206: game.v1.SkillsResponse.skills:type_name -> game.v1.SkillEntry
-	113, // 207: game.v1.InventoryView.items:type_name -> game.v1.InventoryItem
-	115, // 208: game.v1.RoundStartEvent.initial_positions:type_name -> game.v1.CombatantPosition
-	116, // 209: game.v1.RoundStartEvent.cover_objects:type_name -> game.v1.CoverObjectPosition
-	117, // 210: game.v1.RoundStartEvent.terrain:type_name -> game.v1.TerrainCell
+	53,  // 193: game.v1.ExitList.exits:type_name -> game.v1.ExitInfo
+	67,  // 194: game.v1.TrainerView.jobs:type_name -> game.v1.JobOfferEntry
+	70,  // 195: game.v1.TechTrainerView.offers:type_name -> game.v1.TechOfferEntry
+	255, // 196: game.v1.FixerView.bribe_costs:type_name -> game.v1.FixerView.BribeCostsEntry
+	88,  // 197: game.v1.LoadoutView.presets:type_name -> game.v1.LoadoutWeaponPreset
+	90,  // 198: game.v1.QuestEntryView.objectives:type_name -> game.v1.QuestObjectiveView
+	91,  // 199: game.v1.QuestGiverView.quests:type_name -> game.v1.QuestEntryView
+	91,  // 200: game.v1.QuestLogView.quests:type_name -> game.v1.QuestEntryView
+	104, // 201: game.v1.MapTile.poi_npcs:type_name -> game.v1.PoiWithNpc
+	105, // 202: game.v1.MapTile.zone_exits:type_name -> game.v1.ZoneExitInfo
+	106, // 203: game.v1.MapTile.same_zone_exit_targets:type_name -> game.v1.SameZoneExitTarget
+	107, // 204: game.v1.MapResponse.tiles:type_name -> game.v1.MapTile
+	108, // 205: game.v1.MapResponse.world_tiles:type_name -> game.v1.WorldZoneTile
+	112, // 206: game.v1.SkillsResponse.skills:type_name -> game.v1.SkillEntry
+	115, // 207: game.v1.InventoryView.items:type_name -> game.v1.InventoryItem
+	117, // 208: game.v1.RoundStartEvent.initial_positions:type_name -> game.v1.CombatantPosition
+	118, // 209: game.v1.RoundStartEvent.cover_objects:type_name -> game.v1.CoverObjectPosition
+	119, // 210: game.v1.RoundStartEvent.terrain:type_name -> game.v1.TerrainCell
 	3,   // 211: game.v1.CombatEvent.type:type_name -> game.v1.CombatEventType
-	130, // 212: game.v1.FeatsResponse.feats:type_name -> game.v1.FeatEntry
-	133, // 213: game.v1.ClassFeaturesResponse.archetype_features:type_name -> game.v1.ClassFeatureEntry
-	133, // 214: game.v1.ClassFeaturesResponse.job_features:type_name -> game.v1.ClassFeatureEntry
-	130, // 215: game.v1.UseResponse.choices:type_name -> game.v1.FeatEntry
-	253, // 216: game.v1.CharacterSheetView.armor:type_name -> game.v1.CharacterSheetView.ArmorEntry
-	254, // 217: game.v1.CharacterSheetView.accessories:type_name -> game.v1.CharacterSheetView.AccessoriesEntry
-	145, // 218: game.v1.CharacterSheetView.player_resistances:type_name -> game.v1.ResistanceEntry
-	145, // 219: game.v1.CharacterSheetView.player_weaknesses:type_name -> game.v1.ResistanceEntry
-	110, // 220: game.v1.CharacterSheetView.skills:type_name -> game.v1.SkillEntry
-	130, // 221: game.v1.CharacterSheetView.feats:type_name -> game.v1.FeatEntry
-	133, // 222: game.v1.CharacterSheetView.class_features:type_name -> game.v1.ClassFeatureEntry
-	147, // 223: game.v1.CharacterSheetView.proficiencies:type_name -> game.v1.ProficiencyEntry
-	139, // 224: game.v1.CharacterSheetView.prepared_slots:type_name -> game.v1.PreparedSlotView
-	144, // 225: game.v1.CharacterSheetView.spontaneous_use_pools:type_name -> game.v1.SpontaneousUsePoolView
-	143, // 226: game.v1.CharacterSheetView.innate_slots:type_name -> game.v1.InnateSlotView
-	140, // 227: game.v1.CharacterSheetView.hardwired_slots:type_name -> game.v1.HardwiredSlotView
-	141, // 228: game.v1.CharacterSheetView.spontaneous_known:type_name -> game.v1.SpontaneousKnownEntry
-	255, // 229: game.v1.CharacterSheetView.armor_categories:type_name -> game.v1.CharacterSheetView.ArmorCategoriesEntry
-	147, // 230: game.v1.ProficienciesResponse.proficiencies:type_name -> game.v1.ProficiencyEntry
-	210, // 231: game.v1.HotbarUpdateEvent.slots:type_name -> game.v1.HotbarSlot
-	215, // 232: game.v1.CraftResultEvent.materials_lost:type_name -> game.v1.MaterialLoss
-	220, // 233: game.v1.JobGrantsResponse.feat_grants:type_name -> game.v1.JobFeatGrant
-	221, // 234: game.v1.JobGrantsResponse.tech_grants:type_name -> game.v1.JobTechGrant
-	224, // 235: game.v1.JobGrantsResponse.pending_feat_choices:type_name -> game.v1.PendingFeatChoice
-	223, // 236: game.v1.PendingFeatChoice.options:type_name -> game.v1.FeatOption
-	226, // 237: game.v1.AdminListSessionsResponse.sessions:type_name -> game.v1.AdminSessionInfo
-	236, // 238: game.v1.AdminListZonesResponse.zones:type_name -> game.v1.AdminZoneSummary
-	239, // 239: game.v1.AdminListRoomsResponse.rooms:type_name -> game.v1.AdminRoomSummary
-	244, // 240: game.v1.AdminListNPCTemplatesResponse.templates:type_name -> game.v1.AdminNPCTemplateSummary
-	4,   // 241: game.v1.GameService.Session:input_type -> game.v1.ClientMessage
-	227, // 242: game.v1.GameService.AdminListSessions:input_type -> game.v1.AdminListSessionsRequest
-	229, // 243: game.v1.GameService.AdminKickPlayer:input_type -> game.v1.AdminKickRequest
-	231, // 244: game.v1.GameService.AdminMessagePlayer:input_type -> game.v1.AdminMessageRequest
-	233, // 245: game.v1.GameService.AdminTeleportPlayer:input_type -> game.v1.AdminTeleportRequest
-	235, // 246: game.v1.GameService.AdminListZones:input_type -> game.v1.AdminListZonesRequest
-	238, // 247: game.v1.GameService.AdminListRooms:input_type -> game.v1.AdminListRoomsRequest
-	241, // 248: game.v1.GameService.AdminUpdateRoom:input_type -> game.v1.AdminUpdateRoomRequest
-	243, // 249: game.v1.GameService.AdminListNPCTemplates:input_type -> game.v1.AdminListNPCTemplatesRequest
-	246, // 250: game.v1.GameService.AdminSpawnNPC:input_type -> game.v1.AdminSpawnNPCRequest
-	248, // 251: game.v1.GameService.AdminGiveItem:input_type -> game.v1.AdminGiveItemRequest
-	250, // 252: game.v1.GameService.AdminGiveCurrency:input_type -> game.v1.AdminGiveCurrencyRequest
-	34,  // 253: game.v1.GameService.Session:output_type -> game.v1.ServerEvent
-	228, // 254: game.v1.GameService.AdminListSessions:output_type -> game.v1.AdminListSessionsResponse
-	230, // 255: game.v1.GameService.AdminKickPlayer:output_type -> game.v1.AdminKickResponse
-	232, // 256: game.v1.GameService.AdminMessagePlayer:output_type -> game.v1.AdminMessageResponse
-	234, // 257: game.v1.GameService.AdminTeleportPlayer:output_type -> game.v1.AdminTeleportResponse
-	237, // 258: game.v1.GameService.AdminListZones:output_type -> game.v1.AdminListZonesResponse
-	240, // 259: game.v1.GameService.AdminListRooms:output_type -> game.v1.AdminListRoomsResponse
-	242, // 260: game.v1.GameService.AdminUpdateRoom:output_type -> game.v1.AdminUpdateRoomResponse
-	245, // 261: game.v1.GameService.AdminListNPCTemplates:output_type -> game.v1.AdminListNPCTemplatesResponse
-	247, // 262: game.v1.GameService.AdminSpawnNPC:output_type -> game.v1.AdminSpawnNPCResponse
-	249, // 263: game.v1.GameService.AdminGiveItem:output_type -> game.v1.AdminGiveItemResponse
-	251, // 264: game.v1.GameService.AdminGiveCurrency:output_type -> game.v1.AdminGiveCurrencyResponse
-	253, // [253:265] is the sub-list for method output_type
-	241, // [241:253] is the sub-list for method input_type
-	241, // [241:241] is the sub-list for extension type_name
-	241, // [241:241] is the sub-list for extension extendee
-	0,   // [0:241] is the sub-list for field type_name
+	132, // 212: game.v1.FeatsResponse.feats:type_name -> game.v1.FeatEntry
+	135, // 213: game.v1.ClassFeaturesResponse.archetype_features:type_name -> game.v1.ClassFeatureEntry
+	135, // 214: game.v1.ClassFeaturesResponse.job_features:type_name -> game.v1.ClassFeatureEntry
+	4,   // 215: game.v1.AoeTemplate.shape:type_name -> game.v1.AoeTemplate.Shape
+	5,   // 216: game.v1.AoeTemplate.facing:type_name -> game.v1.AoeTemplate.Direction
+	256, // 217: game.v1.AoeTemplate.cells:type_name -> game.v1.AoeTemplate.Cell
+	139, // 218: game.v1.UseRequest.template:type_name -> game.v1.AoeTemplate
+	132, // 219: game.v1.UseResponse.choices:type_name -> game.v1.FeatEntry
+	257, // 220: game.v1.CharacterSheetView.armor:type_name -> game.v1.CharacterSheetView.ArmorEntry
+	258, // 221: game.v1.CharacterSheetView.accessories:type_name -> game.v1.CharacterSheetView.AccessoriesEntry
+	148, // 222: game.v1.CharacterSheetView.player_resistances:type_name -> game.v1.ResistanceEntry
+	148, // 223: game.v1.CharacterSheetView.player_weaknesses:type_name -> game.v1.ResistanceEntry
+	112, // 224: game.v1.CharacterSheetView.skills:type_name -> game.v1.SkillEntry
+	132, // 225: game.v1.CharacterSheetView.feats:type_name -> game.v1.FeatEntry
+	135, // 226: game.v1.CharacterSheetView.class_features:type_name -> game.v1.ClassFeatureEntry
+	150, // 227: game.v1.CharacterSheetView.proficiencies:type_name -> game.v1.ProficiencyEntry
+	142, // 228: game.v1.CharacterSheetView.prepared_slots:type_name -> game.v1.PreparedSlotView
+	147, // 229: game.v1.CharacterSheetView.spontaneous_use_pools:type_name -> game.v1.SpontaneousUsePoolView
+	146, // 230: game.v1.CharacterSheetView.innate_slots:type_name -> game.v1.InnateSlotView
+	143, // 231: game.v1.CharacterSheetView.hardwired_slots:type_name -> game.v1.HardwiredSlotView
+	144, // 232: game.v1.CharacterSheetView.spontaneous_known:type_name -> game.v1.SpontaneousKnownEntry
+	259, // 233: game.v1.CharacterSheetView.armor_categories:type_name -> game.v1.CharacterSheetView.ArmorCategoriesEntry
+	150, // 234: game.v1.ProficienciesResponse.proficiencies:type_name -> game.v1.ProficiencyEntry
+	213, // 235: game.v1.HotbarUpdateEvent.slots:type_name -> game.v1.HotbarSlot
+	218, // 236: game.v1.CraftResultEvent.materials_lost:type_name -> game.v1.MaterialLoss
+	223, // 237: game.v1.JobGrantsResponse.feat_grants:type_name -> game.v1.JobFeatGrant
+	224, // 238: game.v1.JobGrantsResponse.tech_grants:type_name -> game.v1.JobTechGrant
+	227, // 239: game.v1.JobGrantsResponse.pending_feat_choices:type_name -> game.v1.PendingFeatChoice
+	226, // 240: game.v1.PendingFeatChoice.options:type_name -> game.v1.FeatOption
+	229, // 241: game.v1.AdminListSessionsResponse.sessions:type_name -> game.v1.AdminSessionInfo
+	239, // 242: game.v1.AdminListZonesResponse.zones:type_name -> game.v1.AdminZoneSummary
+	242, // 243: game.v1.AdminListRoomsResponse.rooms:type_name -> game.v1.AdminRoomSummary
+	247, // 244: game.v1.AdminListNPCTemplatesResponse.templates:type_name -> game.v1.AdminNPCTemplateSummary
+	6,   // 245: game.v1.GameService.Session:input_type -> game.v1.ClientMessage
+	230, // 246: game.v1.GameService.AdminListSessions:input_type -> game.v1.AdminListSessionsRequest
+	232, // 247: game.v1.GameService.AdminKickPlayer:input_type -> game.v1.AdminKickRequest
+	234, // 248: game.v1.GameService.AdminMessagePlayer:input_type -> game.v1.AdminMessageRequest
+	236, // 249: game.v1.GameService.AdminTeleportPlayer:input_type -> game.v1.AdminTeleportRequest
+	238, // 250: game.v1.GameService.AdminListZones:input_type -> game.v1.AdminListZonesRequest
+	241, // 251: game.v1.GameService.AdminListRooms:input_type -> game.v1.AdminListRoomsRequest
+	244, // 252: game.v1.GameService.AdminUpdateRoom:input_type -> game.v1.AdminUpdateRoomRequest
+	246, // 253: game.v1.GameService.AdminListNPCTemplates:input_type -> game.v1.AdminListNPCTemplatesRequest
+	249, // 254: game.v1.GameService.AdminSpawnNPC:input_type -> game.v1.AdminSpawnNPCRequest
+	251, // 255: game.v1.GameService.AdminGiveItem:input_type -> game.v1.AdminGiveItemRequest
+	253, // 256: game.v1.GameService.AdminGiveCurrency:input_type -> game.v1.AdminGiveCurrencyRequest
+	36,  // 257: game.v1.GameService.Session:output_type -> game.v1.ServerEvent
+	231, // 258: game.v1.GameService.AdminListSessions:output_type -> game.v1.AdminListSessionsResponse
+	233, // 259: game.v1.GameService.AdminKickPlayer:output_type -> game.v1.AdminKickResponse
+	235, // 260: game.v1.GameService.AdminMessagePlayer:output_type -> game.v1.AdminMessageResponse
+	237, // 261: game.v1.GameService.AdminTeleportPlayer:output_type -> game.v1.AdminTeleportResponse
+	240, // 262: game.v1.GameService.AdminListZones:output_type -> game.v1.AdminListZonesResponse
+	243, // 263: game.v1.GameService.AdminListRooms:output_type -> game.v1.AdminListRoomsResponse
+	245, // 264: game.v1.GameService.AdminUpdateRoom:output_type -> game.v1.AdminUpdateRoomResponse
+	248, // 265: game.v1.GameService.AdminListNPCTemplates:output_type -> game.v1.AdminListNPCTemplatesResponse
+	250, // 266: game.v1.GameService.AdminSpawnNPC:output_type -> game.v1.AdminSpawnNPCResponse
+	252, // 267: game.v1.GameService.AdminGiveItem:output_type -> game.v1.AdminGiveItemResponse
+	254, // 268: game.v1.GameService.AdminGiveCurrency:output_type -> game.v1.AdminGiveCurrencyResponse
+	257, // [257:269] is the sub-list for method output_type
+	245, // [245:257] is the sub-list for method input_type
+	245, // [245:245] is the sub-list for extension type_name
+	245, // [245:245] is the sub-list for extension extendee
+	0,   // [0:245] is the sub-list for field type_name
 }
 
 func init() { file_game_v1_game_proto_init() }
@@ -19669,8 +19966,8 @@ func file_game_v1_game_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_game_v1_game_proto_rawDesc), len(file_game_v1_game_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   252,
+			NumEnums:      6,
+			NumMessages:   254,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/gameserver/grpc_service.go
+++ b/internal/gameserver/grpc_service.go
@@ -2483,7 +2483,7 @@ func (s *GameServiceServer) dispatch(uid string, msg *gamev1.ClientMessage) (*ga
 		if err := s.validateUseRequestAoeTemplate(p.UseRequest); err != nil {
 			return nil, err
 		}
-		return s.handleUse(uid, p.UseRequest.FeatId, p.UseRequest.GetTarget(), p.UseRequest.GetTargetX(), p.UseRequest.GetTargetY())
+		return s.handleUseWithTemplate(uid, p.UseRequest.FeatId, p.UseRequest.GetTarget(), p.UseRequest.GetTargetX(), p.UseRequest.GetTargetY(), p.UseRequest.GetTemplate())
 	case *gamev1.ClientMessage_Action:
 		return s.handleAction(uid, p.Action)
 	case *gamev1.ClientMessage_RaiseShield:
@@ -8316,7 +8316,15 @@ func (s *GameServiceServer) handleTabComplete(uid, prefix string) (*gamev1.Serve
 // Precondition: uid must resolve to an active session with a loaded character.
 // Postcondition: Returns a ServerEvent with UseResponse containing choices or an activation message.
 // targetX and targetY are the 0-based grid coordinates of the AoE burst center; -1 means unset / no AoE.
+// This is the legacy entry point; cone/line content arrives via handleUseWithTemplate.
 func (s *GameServiceServer) handleUse(uid, abilityID, targetID string, targetX, targetY int32) (*gamev1.ServerEvent, error) {
+	return s.handleUseWithTemplate(uid, abilityID, targetID, targetX, targetY, nil)
+}
+
+// handleUseWithTemplate is handleUse with an optional client-supplied AoeTemplate (AOE-13).
+// When template is nil and AoeRadius > 0, a burst template is synthesised from
+// targetX/targetY for back-compat (AOE-16).
+func (s *GameServiceServer) handleUseWithTemplate(uid, abilityID, targetID string, targetX, targetY int32, template *gamev1.AoeTemplate) (*gamev1.ServerEvent, error) {
 	sess, ok := s.sessions.GetPlayer(uid)
 	if !ok {
 		return nil, fmt.Errorf("player %q not found", uid)
@@ -8594,11 +8602,15 @@ func (s *GameServiceServer) handleUse(uid, abilityID, targetID string, targetX, 
 				}
 				condID := f.ConditionID
 				if condID != "" && s.condRegistry != nil {
-					// REQ-AOE-2: When feat has aoe_radius > 0 and target coordinates are provided,
-					// apply the condition to every living combatant within Chebyshev distance aoe_radius.
-					// REQ-2D-5e: AoE does not distinguish friend from foe — all combatants in radius are affected.
-					// Sentinel: targetX < 0 or targetY < 0 means no AoE target (use single-target path instead).
-					if f.AoeRadius > 0 && (targetX >= 0 && targetY >= 0) {
+					// REQ-AOE-2: When feat has aoe_radius > 0 (or shape == cone/line) and a template /
+					// target coordinates are provided, resolve the AoE template into a cell set and
+					// apply the condition to every living combatant whose grid square intersects.
+					// REQ-2D-5e: AoE does not distinguish friend from foe — all combatants in the
+					// resolved cells are affected.
+					// AOE-16: targetX/targetY < 0 with no template falls through to single-target.
+					hasTemplate := template != nil
+					hasLegacyBurst := f.AoeRadius > 0 && (targetX >= 0 && targetY >= 0)
+					if hasTemplate || hasLegacyBurst {
 						var cbt *combat.Combat
 						if s.combatH != nil {
 							cbt = s.combatH.ActiveCombatForPlayer(uid)
@@ -8606,9 +8618,9 @@ func (s *GameServiceServer) handleUse(uid, abilityID, targetID string, targetX, 
 						if cbt == nil {
 							return messageEvent(fmt.Sprintf("You must be in combat to use %s.", f.Name)), nil
 						}
-						center := combat.Combatant{GridX: int(targetX), GridY: int(targetY)}
+						affected, _ := resolveAoeCells(template, f.AoeRadius, f.AoeLength, f.AoeWidth, targetX, targetY, cbt)
 						if def, ok := s.condRegistry.Get(condID); ok {
-							for _, c := range combat.CombatantsInRadius(cbt, center, f.AoeRadius) {
+							for _, c := range affected {
 								if condSet := cbt.Conditions[c.ID]; condSet != nil {
 									if err := condSet.Apply(c.ID, def, 1, -1); err != nil {
 										s.logger.Warn("failed to apply feat AoE condition",
@@ -8865,7 +8877,7 @@ func (s *GameServiceServer) handleUse(uid, abilityID, targetID string, targetX, 
 					}
 					return nil, nil
 				}
-				return s.activateTechWithEffectsAndHeighten(sess, uid, techID, targetID, fmt.Sprintf("You activate %s.", techDisplay), nil, targetX, targetY, heightenDelta)
+				return s.activateTechWithEffectsAndHeighten(sess, uid, techID, targetID, fmt.Sprintf("You activate %s.", techDisplay), nil, targetX, targetY, heightenDelta, template)
 			}
 		}
 		if foundInPrepared {
@@ -8949,7 +8961,7 @@ func (s *GameServiceServer) handleUse(uid, abilityID, targetID string, targetX, 
 			}
 			return nil, nil
 		}
-		return s.activateTechWithEffects(sess, uid, abilityID, targetID, fmt.Sprintf("You activate %s. (%d uses remaining at level %d.)", spontaneousDisplay, pool.Remaining, foundLevel), nil, targetX, targetY)
+		return s.activateTechWithEffectsAndTemplate(sess, uid, abilityID, targetID, fmt.Sprintf("You activate %s. (%d uses remaining at level %d.)", spontaneousDisplay, pool.Remaining, foundLevel), nil, targetX, targetY, template)
 	}
 // innateCheck is the target for goto from the spontaneous path when the tech is not
 // found in KnownTechs. This allows innate techs to be checked even when the player
@@ -8998,9 +9010,9 @@ innateCheck:
 				slot.UsesRemaining--
 				sess.InnateTechs[innateTechBaseID] = slot
 				s.pushEventToUID(uid, s.hotbarUpdateEvent(sess))
-				return s.activateTechWithEffects(sess, uid, innateTechBaseID, targetID, fmt.Sprintf("You activate %s. (%d uses remaining.)", name, slot.UsesRemaining), nil, targetX, targetY)
+				return s.activateTechWithEffectsAndTemplate(sess, uid, innateTechBaseID, targetID, fmt.Sprintf("You activate %s. (%d uses remaining.)", name, slot.UsesRemaining), nil, targetX, targetY, template)
 			}
-			return s.activateTechWithEffects(sess, uid, innateTechBaseID, targetID, fmt.Sprintf("You activate %s.", name), nil, targetX, targetY)
+			return s.activateTechWithEffectsAndTemplate(sess, uid, innateTechBaseID, targetID, fmt.Sprintf("You activate %s.", name), nil, targetX, targetY, template)
 		}
 		// REQ-USE-1: fall through to room equipment before reporting no match.
 		if evt, err := s.tryRoomEquipFallback(uid, sess.RoomID, abilityID); evt != nil || err != nil {
@@ -9186,14 +9198,17 @@ func (s *GameServiceServer) handleAmpedUse(
 		cbt = s.combatH.ActiveCombatForPlayer(uid)
 	}
 
-	// REQ-AOE-1: When tech has aoe_radius > 0 and target coordinates are provided,
-	// collect all living combatants within Chebyshev distance aoe_radius of the target square.
-	// Sentinel: techTargetX < 0 or techTargetY < 0 means no AoE target (use single-target path instead).
+	// REQ-AOE-1: When tech has aoe_radius > 0 (or shape == cone/line) and a template /
+	// target coordinates are provided, resolve the AoE template to a cell set and collect
+	// every living combatant in that cell set.
+	// AOE-16: legacy techTargetX/techTargetY with no template synthesises a burst template.
 	var techTargets []*combat.Combatant
 	techTargetX, techTargetY := req.GetTargetX(), req.GetTargetY()
-	if resolvedTech.AoeRadius > 0 && (techTargetX >= 0 && techTargetY >= 0) && cbt != nil {
-		center := combat.Combatant{GridX: int(techTargetX), GridY: int(techTargetY)}
-		techTargets = combat.CombatantsInRadius(cbt, center, resolvedTech.AoeRadius)
+	tmpl := req.GetTemplate()
+	hasTemplate := tmpl != nil
+	hasLegacyBurst := resolvedTech.AoeRadius > 0 && (techTargetX >= 0 && techTargetY >= 0)
+	if (hasTemplate || hasLegacyBurst) && cbt != nil {
+		techTargets, _ = resolveAoeCells(tmpl, resolvedTech.AoeRadius, resolvedTech.AoeLength, resolvedTech.AoeWidth, techTargetX, techTargetY, cbt)
 	} else {
 		target, errMsg := s.resolveUseTarget(uid, targetID, resolvedTech)
 		if errMsg != "" {
@@ -9282,14 +9297,26 @@ func (s *GameServiceServer) resolveUseTarget(uid, targetID string, tech *technol
 //   - If s.techRegistry is nil or the tech is not registered, falls back to fallbackMsg.
 //   - Returns a non-nil ServerEvent on success.
 func (s *GameServiceServer) activateTechWithEffects(sess *session.PlayerSession, uid, abilityID, targetID, fallbackMsg string, querier RoomQuerier, targetX, targetY int32) (*gamev1.ServerEvent, error) {
-	return s.activateTechWithEffectsAndHeighten(sess, uid, abilityID, targetID, fallbackMsg, querier, targetX, targetY, 0)
+	return s.activateTechWithEffectsAndHeighten(sess, uid, abilityID, targetID, fallbackMsg, querier, targetX, targetY, 0, nil)
+}
+
+// activateTechWithEffectsAndTemplate is activateTechWithEffects with an
+// optional client-supplied AoeTemplate (AOE-13). Pass nil for legacy burst
+// flows that rely on targetX/targetY (AOE-16); pass non-nil for cone/line
+// content where the template is required.
+func (s *GameServiceServer) activateTechWithEffectsAndTemplate(sess *session.PlayerSession, uid, abilityID, targetID, fallbackMsg string, querier RoomQuerier, targetX, targetY int32, template *gamev1.AoeTemplate) (*gamev1.ServerEvent, error) {
+	return s.activateTechWithEffectsAndHeighten(sess, uid, abilityID, targetID, fallbackMsg, querier, targetX, targetY, 0, template)
 }
 
 // activateTechWithEffectsAndHeighten is activateTechWithEffects plus a
 // heighten delta (slotLevel - techLevel). The delta propagates through
 // ResolveTechEffectsWithHeighten so damage effects with Projectiles > 0
 // scale up by one projectile per heighten level (GH #224).
-func (s *GameServiceServer) activateTechWithEffectsAndHeighten(sess *session.PlayerSession, uid, abilityID, targetID, fallbackMsg string, querier RoomQuerier, targetX, targetY int32, heightenDelta int) (*gamev1.ServerEvent, error) {
+//
+// template (AOE-13) is the optional client-supplied AoE template; cone/line
+// techs require a non-nil template, while burst techs may pass nil and rely
+// on legacy targetX/targetY (AOE-16).
+func (s *GameServiceServer) activateTechWithEffectsAndHeighten(sess *session.PlayerSession, uid, abilityID, targetID, fallbackMsg string, querier RoomQuerier, targetX, targetY int32, heightenDelta int, template *gamev1.AoeTemplate) (*gamev1.ServerEvent, error) {
 	if s.techRegistry == nil {
 		return messageEvent(fallbackMsg), nil
 	}
@@ -9317,12 +9344,14 @@ func (s *GameServiceServer) activateTechWithEffectsAndHeighten(sess *session.Pla
 	}
 
 	var techTargets []*combat.Combatant
-	// REQ-AOE-1: When tech has aoe_radius > 0 and target coordinates are provided,
-	// collect all living combatants within Chebyshev distance aoe_radius of the target square.
-	// Sentinel: targetX < 0 or targetY < 0 means no AoE target (use single-target path instead).
-	if techDef.AoeRadius > 0 && (targetX >= 0 && targetY >= 0) && cbt != nil {
-		center := combat.Combatant{GridX: int(targetX), GridY: int(targetY)}
-		techTargets = combat.CombatantsInRadius(cbt, center, techDef.AoeRadius)
+	// REQ-AOE-1: When tech has an AoE shape (legacy burst via aoe_radius, or cone/line via template)
+	// and the corresponding inputs are present, resolve the template to a cell set and collect every
+	// living combatant in that cell set.
+	// AOE-16: legacy targetX/targetY with no template synthesises a burst template at runtime.
+	hasTemplate := template != nil
+	hasLegacyBurst := techDef.AoeRadius > 0 && (targetX >= 0 && targetY >= 0)
+	if (hasTemplate || hasLegacyBurst) && cbt != nil {
+		techTargets, _ = resolveAoeCells(template, techDef.AoeRadius, techDef.AoeLength, techDef.AoeWidth, targetX, targetY, cbt)
 	} else {
 		target, errMsg := s.resolveUseTarget(uid, targetID, techDef)
 		if errMsg != "" {
@@ -9396,9 +9425,9 @@ func (s *GameServiceServer) activateTechWithEffectsWithCombat(sess *session.Play
 	// Use the pre-acquired cbt directly instead of calling resolveUseTarget (which would
 	// re-acquire combatMu and deadlock since the caller already holds it).
 	var techTargets []*combat.Combatant
+	// AOE-16: queued tech-use legacy path synthesises a burst template from targetX/targetY.
 	if techDef.AoeRadius > 0 && (targetX >= 0 && targetY >= 0) && cbt != nil {
-		center := combat.Combatant{GridX: int(targetX), GridY: int(targetY)}
-		techTargets = combat.CombatantsInRadius(cbt, center, techDef.AoeRadius)
+		techTargets, _ = resolveAoeCells(nil, techDef.AoeRadius, techDef.AoeLength, techDef.AoeWidth, targetX, targetY, cbt)
 	} else if techDef.Targets == technology.TargetsAllEnemies && cbt != nil {
 		for _, c := range cbt.Combatants {
 			if c.Kind == combat.KindNPC && !c.IsDead() {

--- a/internal/gameserver/grpc_service.go
+++ b/internal/gameserver/grpc_service.go
@@ -2479,6 +2479,10 @@ func (s *GameServiceServer) dispatch(uid string, msg *gamev1.ClientMessage) (*ga
 	case *gamev1.ClientMessage_InteractRequest:
 		return s.handleInteract(uid, p.InteractRequest.InstanceId)
 	case *gamev1.ClientMessage_UseRequest:
+		// AOE-13: validate AoeTemplate contract before dispatching.
+		if err := s.validateUseRequestAoeTemplate(p.UseRequest); err != nil {
+			return nil, err
+		}
 		return s.handleUse(uid, p.UseRequest.FeatId, p.UseRequest.GetTarget(), p.UseRequest.GetTargetX(), p.UseRequest.GetTargetY())
 	case *gamev1.ClientMessage_Action:
 		return s.handleAction(uid, p.Action)

--- a/internal/gameserver/grpc_service_aoe.go
+++ b/internal/gameserver/grpc_service_aoe.go
@@ -1,0 +1,94 @@
+package gameserver
+
+import (
+	"github.com/cory-johannsen/mud/internal/game/aoe"
+	gamev1 "github.com/cory-johannsen/mud/internal/gameserver/gamev1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// resolveContentAoeShape returns the AoeShape declared by the content (feat,
+// class feature, technology, or explosive item) identified by abilityID, or
+// AoeShapeNone if no matching content is found or the content has no shape.
+//
+// The lookup mirrors the resolution order in handleUse: techs (with
+// short-name resolution), then feats, then class features, then explosive
+// inventory items. The first matching content's shape is returned.
+//
+// Precondition: none — empty abilityID is permitted and yields AoeShapeNone.
+// Postcondition: returned shape is a valid aoe.AoeShape value (possibly the
+// AoeShapeNone empty value).
+func (s *GameServiceServer) resolveContentAoeShape(abilityID string) aoe.AoeShape {
+	if abilityID == "" {
+		return aoe.AoeShapeNone
+	}
+
+	// Resolve tech short-name to canonical ID, mirroring handleUse.
+	techID := abilityID
+	if s.techRegistry != nil {
+		if def, ok := s.techRegistry.GetByShortName(abilityID); ok {
+			techID = def.ID
+		}
+	}
+
+	if s.techRegistry != nil {
+		if def, ok := s.techRegistry.Get(techID); ok {
+			return def.AoeShape
+		}
+	}
+	if s.featRegistry != nil {
+		if f, ok := s.featRegistry.Feat(abilityID); ok {
+			return f.AoeShape
+		}
+	}
+	if s.classFeatureRegistry != nil {
+		if cf, ok := s.classFeatureRegistry.ClassFeature(abilityID); ok {
+			return cf.AoeShape
+		}
+	}
+	if s.invRegistry != nil {
+		if exp := s.invRegistry.Explosive(abilityID); exp != nil {
+			return exp.AoeShape
+		}
+	}
+
+	return aoe.AoeShapeNone
+}
+
+// validateUseRequestAoeTemplate enforces (AOE-13) the proto contract for
+// AoeTemplate on inbound UseRequest messages.
+//
+// Rules:
+//   - Content with AoeShape == cone or line: req.Template MUST be non-nil.
+//     Missing template returns codes.InvalidArgument "AoE template required".
+//   - Content with AoeShape == burst: req.Template OR non-negative
+//     target_x/target_y both satisfy the contract (back-compat with the
+//     legacy burst path; AOE-16).
+//   - Content with AoeShape == none (single-target / non-AoE) or content not
+//     found in any registry: no template required; nil is returned.
+//
+// Precondition: req may be nil; the validator treats nil as a no-op.
+// Postcondition: returns nil iff the request satisfies the contract; otherwise
+// returns a gRPC status error with codes.InvalidArgument.
+func (s *GameServiceServer) validateUseRequestAoeTemplate(req *gamev1.UseRequest) error {
+	if req == nil {
+		return nil
+	}
+	abilityID := req.GetFeatId()
+	if abilityID == "" {
+		// Empty feat_id is the choices-list request — no template required.
+		return nil
+	}
+	shape := s.resolveContentAoeShape(abilityID)
+	switch shape {
+	case aoe.AoeShapeCone, aoe.AoeShapeLine:
+		if req.GetTemplate() == nil {
+			return status.Error(codes.InvalidArgument, "AoE template required")
+		}
+	case aoe.AoeShapeBurst:
+		if req.GetTemplate() == nil && (req.GetTargetX() < 0 || req.GetTargetY() < 0) {
+			return status.Error(codes.InvalidArgument, "AoE template required")
+		}
+	}
+	return nil
+}

--- a/internal/gameserver/grpc_service_aoe_validator_test.go
+++ b/internal/gameserver/grpc_service_aoe_validator_test.go
@@ -1,0 +1,214 @@
+package gameserver
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/aoe"
+	"github.com/cory-johannsen/mud/internal/game/inventory"
+	"github.com/cory-johannsen/mud/internal/game/ruleset"
+	"github.com/cory-johannsen/mud/internal/game/technology"
+	gamev1 "github.com/cory-johannsen/mud/internal/gameserver/gamev1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// validatorSvc builds a minimal GameServiceServer with the registries needed
+// to exercise resolveContentAoeShape and validateUseRequestAoeTemplate.
+func validatorSvc(t *testing.T) *GameServiceServer {
+	t.Helper()
+
+	techReg := technology.NewRegistry()
+	techReg.Register(&technology.TechnologyDef{
+		ID:        "tech_cone",
+		Name:      "Cone Tech",
+		AoeShape:  aoe.AoeShapeCone,
+		AoeLength: 30,
+	})
+	techReg.Register(&technology.TechnologyDef{
+		ID:        "tech_burst",
+		Name:      "Burst Tech",
+		AoeShape:  aoe.AoeShapeBurst,
+		AoeRadius: 2,
+	})
+	techReg.Register(&technology.TechnologyDef{
+		ID:   "tech_single",
+		Name: "Single Tech",
+	})
+
+	featReg := ruleset.NewFeatRegistryFromSlice([]*ruleset.Feat{
+		{
+			ID:         "feat_line",
+			Name:       "Line Feat",
+			Category:   "combat",
+			Active:     true,
+			ActionCost: 1,
+			AoeShape:   aoe.AoeShapeLine,
+			AoeLength:  20,
+		},
+		{
+			ID:         "feat_burst",
+			Name:       "Burst Feat",
+			Category:   "combat",
+			Active:     true,
+			ActionCost: 1,
+			AoeShape:   aoe.AoeShapeBurst,
+			AoeRadius:  2,
+		},
+	})
+
+	cfReg := ruleset.NewClassFeatureRegistry([]*ruleset.ClassFeature{
+		{
+			ID:         "cf_cone",
+			Name:       "Cone Feature",
+			Active:     true,
+			ActionCost: 1,
+			AoeShape:   aoe.AoeShapeCone,
+			AoeLength:  30,
+		},
+	})
+
+	invReg := inventory.NewRegistry()
+	if err := invReg.RegisterExplosive(&inventory.ExplosiveDef{
+		ID:        "exp_line",
+		Name:      "Line Explosive",
+		AoeShape:  aoe.AoeShapeLine,
+		AoeLength: 30,
+	}); err != nil {
+		t.Fatalf("register exp_line: %v", err)
+	}
+
+	return &GameServiceServer{
+		featRegistry:         featReg,
+		classFeatureRegistry: cfReg,
+		techRegistry:         techReg,
+		invRegistry:          invReg,
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_ConeRequiresTemplate(t *testing.T) {
+	svc := validatorSvc(t)
+	req := &gamev1.UseRequest{FeatId: "tech_cone"}
+	err := svc.validateUseRequestAoeTemplate(req)
+	if err == nil {
+		t.Fatal("expected InvalidArgument error for cone tech without template; got nil")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument; got code=%s err=%v", status.Code(err), err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_LineRequiresTemplate(t *testing.T) {
+	svc := validatorSvc(t)
+	req := &gamev1.UseRequest{FeatId: "feat_line", TargetX: 3, TargetY: 4}
+	err := svc.validateUseRequestAoeTemplate(req)
+	if err == nil {
+		t.Fatal("expected InvalidArgument for line content with target_x/y but no template")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument; got code=%s", status.Code(err))
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_LineWithTemplateAccepted(t *testing.T) {
+	svc := validatorSvc(t)
+	req := &gamev1.UseRequest{
+		FeatId: "feat_line",
+		Template: &gamev1.AoeTemplate{
+			Shape:   gamev1.AoeTemplate_SHAPE_LINE,
+			AnchorX: 1,
+			AnchorY: 2,
+			Facing:  gamev1.AoeTemplate_DIR_E,
+		},
+	}
+	if err := svc.validateUseRequestAoeTemplate(req); err != nil {
+		t.Fatalf("expected nil error for line with template; got %v", err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_BurstAcceptsLegacyCoords(t *testing.T) {
+	svc := validatorSvc(t)
+	req := &gamev1.UseRequest{
+		FeatId:  "feat_burst",
+		TargetX: 3,
+		TargetY: 4,
+	}
+	if err := svc.validateUseRequestAoeTemplate(req); err != nil {
+		t.Fatalf("expected nil error for burst with target_x/y back-compat; got %v", err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_BurstWithTemplateAccepted(t *testing.T) {
+	svc := validatorSvc(t)
+	req := &gamev1.UseRequest{
+		FeatId: "feat_burst",
+		Template: &gamev1.AoeTemplate{
+			Shape:   gamev1.AoeTemplate_SHAPE_BURST,
+			AnchorX: 5,
+			AnchorY: 5,
+		},
+	}
+	if err := svc.validateUseRequestAoeTemplate(req); err != nil {
+		t.Fatalf("expected nil error for burst with template; got %v", err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_BurstNoCoordsNoTemplateRejected(t *testing.T) {
+	svc := validatorSvc(t)
+	req := &gamev1.UseRequest{
+		FeatId:  "feat_burst",
+		TargetX: -1,
+		TargetY: -1,
+	}
+	err := svc.validateUseRequestAoeTemplate(req)
+	if err == nil {
+		t.Fatal("expected InvalidArgument when burst has no template and negative coords")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument; got %s", status.Code(err))
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_SingleTargetNoTemplateOk(t *testing.T) {
+	svc := validatorSvc(t)
+	req := &gamev1.UseRequest{FeatId: "tech_single"}
+	if err := svc.validateUseRequestAoeTemplate(req); err != nil {
+		t.Fatalf("single-target tech should not require template; got %v", err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_EmptyFeatIdOk(t *testing.T) {
+	svc := validatorSvc(t)
+	if err := svc.validateUseRequestAoeTemplate(&gamev1.UseRequest{}); err != nil {
+		t.Fatalf("empty feat_id (choices list) should not require template; got %v", err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_UnknownContentOk(t *testing.T) {
+	svc := validatorSvc(t)
+	if err := svc.validateUseRequestAoeTemplate(&gamev1.UseRequest{FeatId: "no_such_id"}); err != nil {
+		t.Fatalf("unknown content should not require template; got %v", err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_ClassFeatureConeRequiresTemplate(t *testing.T) {
+	svc := validatorSvc(t)
+	err := svc.validateUseRequestAoeTemplate(&gamev1.UseRequest{FeatId: "cf_cone"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument for class-feature cone without template; got %v", err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_ExplosiveLineRequiresTemplate(t *testing.T) {
+	svc := validatorSvc(t)
+	err := svc.validateUseRequestAoeTemplate(&gamev1.UseRequest{FeatId: "exp_line"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument for explosive line without template; got %v", err)
+	}
+}
+
+func TestValidateUseRequestAoeTemplate_NilRequestOk(t *testing.T) {
+	svc := validatorSvc(t)
+	if err := svc.validateUseRequestAoeTemplate(nil); err != nil {
+		t.Fatalf("nil request should be a no-op; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Typed AoE templates (burst/cone/line) flow through the resolver pipeline. Issue #250. Follow-up #327 for interactive placement UX.

- **Geometry**: `internal/game/combat/geometry.go` — `Cell`, `Direction`, `BurstCells`, `ConeCells`, `LineCells`, `FacingFrom`. Property-tested.
- **CombatantsInCells**: `internal/game/combat/aoe.go` — sparse-cell intersection. `CombatantsInRadius` retrofitted to delegate (AOE-19 back-compat).
- **Content model**: `internal/game/aoe/aoe_shape.go` — `AoeShape` enum + `ValidateAoeFields`. New `AoeShape`/`AoeLength`/`AoeWidth` fields on `Feat`, `ClassFeature`, `TechnologyDef`, `ExplosiveDef`.
- **Proto**: `AoeTemplate{shape, anchor_x, anchor_y, facing, cells}` added; `UseRequest.template` optional.
- **Validator**: cone/line require `template`; burst accepts `template` OR legacy `target_x/y`.
- **Resolver**: `internal/gameserver/aoe_resolver.go` — `CellsForTemplate`, `PostFilterAffectedCells` (identity stub for #267 visibility), `dirFromProto`. 4 grpc_service.go call sites swapped to `CombatantsInCells`.
- **Content tags**: 9 existing burst entries in `class_features.yaml` get explicit `aoe_shape: burst`.
- **Docs**: `docs/architecture/combat.md` AOE section.

Plan: `docs/superpowers/plans/2026-04-25-aoe-drawing-in-combat.md` (9 tasks; tasks 6/7/8-cone/line deferred to follow-up #327).

## Test plan

- [ ] Full Go suite green
- [ ] Smoke: existing burst-shaped class features still resolve (AOE-4 back-compat)
- [ ] Smoke: cone/line content rejected without `template` (validator)
- [ ] Smoke: programmatic `UseRequest{template: cone@30ft N}` resolves to expected cell set
- [ ] Follow-up: interactive placement UX (#327)

🤖 Generated with [Claude Code](https://claude.com/claude-code)