### PR TITLE
fix(hotbar): HotbarUpdate camelCase field reads (#310)

### DIFF
--- a/cmd/webclient/ui/src/game/GameContext.tsx
+++ b/cmd/webclient/ui/src/game/GameContext.tsx
@@ -656,10 +656,18 @@ export function GameProvider({ children }: { children: ReactNode }) {
           break
         }
         case 'HotbarUpdate': {
+          // protojson emits camelCase by default. Earlier code read only snake_case
+          // and so always saw undefined → fell back to defaults (count=1, max=4).
+          // That made every switch button auto-create a new hotbar, which the
+          // server rejected once 4 hotbars existed (#310). Read camelCase first
+          // and accept snake_case as a defensive fallback.
           const hu = payload as {
             slots?: HotbarSlot[]
+            activeHotbarIndex?: number
             active_hotbar_index?: number
+            hotbarCount?: number
             hotbar_count?: number
+            maxHotbars?: number
             max_hotbars?: number
           }
           const slots = hu.slots && hu.slots.length > 0
@@ -668,9 +676,9 @@ export function GameProvider({ children }: { children: ReactNode }) {
           dispatch({
             type: 'SET_HOTBAR',
             slots,
-            activeHotbarIndex: hu.active_hotbar_index ?? 1,
-            hotbarCount: hu.hotbar_count ?? 1,
-            maxHotbars: hu.max_hotbars ?? 4,
+            activeHotbarIndex: hu.activeHotbarIndex ?? hu.active_hotbar_index ?? 1,
+            hotbarCount: hu.hotbarCount ?? hu.hotbar_count ?? 1,
+            maxHotbars: hu.maxHotbars ?? hu.max_hotbars ?? 4,
           })
           break
         }


### PR DESCRIPTION
## Summary

Closes #310. The web client read \`hotbar_count\` / \`active_hotbar_index\` / \`max_hotbars\` from \`HotbarUpdate\` messages, but \`protojson.Marshal\` (default config used at \`internal/gameserver/grpc_service.go:6193\`) emits camelCase. All three reads returned \`undefined\`, falling through to defaults of \`hotbarCount=1\` and \`maxHotbars=4\`.

With those defaults, every switch button hit the \`hotbarCount <= 1\` branch in \`HotbarPanel.tsx\`, calling \`requestCreateOnce()\`. Once the player had 4 persisted hotbars, the server's \`case "create"\` returned \`Hotbar limit reached (max 4)\` for all hotbar controls — matching the bug report.

Fix: read camelCase first, snake_case as a defensive fallback.

## Test plan

- [ ] All 309 existing vitest tests still pass.
- [ ] Smoke: in a session with 4 hotbars, switch buttons cycle without hitting the limit error.
- [ ] Smoke: with hotbarCount=1, clicking switch correctly auto-creates a 2nd hotbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)