### PR TITLE
fix(zone): PDX Concourse E ↔ The Carpet (#317)

### DIFF
--- a/content/zones/pdx_international.yaml
+++ b/content/zones/pdx_international.yaml
@@ -322,6 +322,8 @@ zone:
     - direction: west
       target: pdx_concourse_d
     - direction: east
+      target: pdx_the_carpet
+    - direction: southeast
       target: pdx_the_tarmac
     map_x: 2
     map_y: -4
@@ -401,7 +403,7 @@ zone:
 
       '
     exits:
-    - direction: west
+    - direction: northwest
       target: pdx_concourse_e
     - direction: east
       target: pdx_hangar_row


### PR DESCRIPTION
Closes #317. Concourse E east → The Carpet (was misrouted to The Tarmac, isolating players). New SE exit to The Tarmac; Tarmac's reciprocal exit relabelled NW.