### PR TITLE
fix(trap): apply real damage + condition on random room trap fire (#319)

### DIFF
--- a/internal/game/danger/trap.go
+++ b/internal/game/danger/trap.go
@@ -29,6 +29,30 @@ func RollRoomTrap(level DangerLevel, override *int, rng Roller) bool {
 	return rng.Roll(100) < pct
 }
 
+// RoomTrapPayload describes the default damage and condition for a random room trap
+// firing at the given danger level.
+type RoomTrapPayload struct {
+	DamageDice  string // dice expression; "" means no damage
+	DamageType  string // e.g. "piercing"
+	ConditionID string // e.g. "bleeding"; "" means no condition
+}
+
+// DefaultRoomTrapPayload returns the canonical room-trap payload by danger level.
+// Safe and Sketchy levels never roll room traps (see defaultTrapPcts), so they
+// have no payload. Dangerous and AllOutWar return progressively heavier payloads.
+//
+// Postcondition: returned payload's DamageDice is non-empty for Dangerous/AllOutWar.
+func DefaultRoomTrapPayload(level DangerLevel) RoomTrapPayload {
+	switch level {
+	case Dangerous:
+		return RoomTrapPayload{DamageDice: "2d6", DamageType: "piercing", ConditionID: "bleeding"}
+	case AllOutWar:
+		return RoomTrapPayload{DamageDice: "4d6", DamageType: "piercing", ConditionID: "prone"}
+	default:
+		return RoomTrapPayload{}
+	}
+}
+
 // RollCoverTrap returns true if a cover trap should trigger.
 // override is nil to use the danger level default; non-nil uses the explicit value (including 0).
 // Precondition: rng MUST NOT be nil.

--- a/internal/gameserver/grpc_service.go
+++ b/internal/gameserver/grpc_service.go
@@ -2999,10 +2999,32 @@ func (s *GameServiceServer) handleMove(uid string, req *gamev1.MoveRequest) (*ga
 			effectiveLevel := danger.EffectiveDangerLevel(newZone.DangerLevel, newRoom.DangerLevel)
 			if danger.RollRoomTrap(effectiveLevel, newRoom.RoomTrapChance, danger.RandRoller{}) {
 				s.logger.Info("room trap triggered", zap.String("uid", uid), zap.String("room", newRoom.ID))
+				// #319: room traps now apply real damage + a condition based on danger level.
+				payload := danger.DefaultRoomTrapPayload(effectiveLevel)
+				narrative := "You trigger a hidden trap!"
+				if payload.DamageDice != "" && s.dice != nil {
+					rolled, rollErr := s.dice.RollExpr(payload.DamageDice)
+					if rollErr == nil {
+						total := rolled.Total()
+						resistance := sess.Resistances[payload.DamageType]
+						dmg := total - resistance
+						if dmg < 0 {
+							dmg = 0
+						}
+						sess.CurrentHP -= dmg
+						narrative += fmt.Sprintf(" %d %s damage.", dmg, payload.DamageType)
+					}
+				}
+				if payload.ConditionID != "" && sess.Conditions != nil && s.condRegistry != nil {
+					if condDef, condOK := s.condRegistry.Get(payload.ConditionID); condOK {
+						_ = sess.Conditions.Apply(sess.UID, condDef, 1, -1)
+						narrative += fmt.Sprintf(" You are now %s.", payload.ConditionID)
+					}
+				}
 				trapEvt := &gamev1.ServerEvent{
 					Payload: &gamev1.ServerEvent_Message{
 						Message: &gamev1.MessageEvent{
-							Content: "You trigger a hidden trap!",
+							Content: narrative,
 							Type:    gamev1.MessageType_MESSAGE_TYPE_UNSPECIFIED,
 						},
 					},
@@ -3015,6 +3037,7 @@ func (s *GameServiceServer) handleMove(uid string, req *gamev1.MoveRequest) (*ga
 						)
 					}
 				}
+				s.checkNonCombatDeath(uid, sess)
 			}
 		}
 		// Wanted-level guard check: initiate guard combat if player is wanted in this zone.


### PR DESCRIPTION
Closes #319. Random room-trap path now applies damage and condition based on danger level: Dangerous = 2d6 piercing + bleeding; AllOutWar = 4d6 piercing + prone. Narrative reports the actual effect.