### PR TITLE
fix(merchant): accept black_market_merchant npc_type (#321)

### DIFF
--- a/internal/gameserver/grpc_service_merchant.go
+++ b/internal/gameserver/grpc_service_merchant.go
@@ -58,7 +58,7 @@ func (s *GameServiceServer) findMerchantInRoom(roomID, npcName string) (*npc.Ins
 	if inst == nil {
 		return nil, fmt.Sprintf("You don't see %q here.", npcName)
 	}
-	if inst.NPCType != "merchant" {
+	if inst.NPCType != "merchant" && inst.NPCType != "black_market_merchant" {
 		return nil, fmt.Sprintf("%s is not a merchant.", inst.Name())
 	}
 	if inst.Cowering {


### PR DESCRIPTION
Closes #321. Click handler rejected black_market_merchant NPCs (Tech Surplus Trader) — type-check now accepts both 'merchant' and 'black_market_merchant'.