### PR TITLE
fix(items): heal effects on 6 consumables (#326)

### DIFF
--- a/content/items/airline_meal.yaml
+++ b/content/items/airline_meal.yaml
@@ -6,3 +6,5 @@ weight: 0.4
 stackable: true
 max_stack: 5
 value: 6
+effect:
+  heal: "1d6+2"

--- a/content/items/commune_ration.yaml
+++ b/content/items/commune_ration.yaml
@@ -6,3 +6,5 @@ weight: 0.3
 stackable: true
 max_stack: 5
 value: 8
+effect:
+  heal: "1d6"

--- a/content/items/craft_brew.yaml
+++ b/content/items/craft_brew.yaml
@@ -6,3 +6,5 @@ weight: 0.5
 stackable: true
 max_stack: 3
 value: 15
+effect:
+  heal: "1d4+1"

--- a/content/items/fresh_produce.yaml
+++ b/content/items/fresh_produce.yaml
@@ -6,3 +6,5 @@ weight: 0.5
 stackable: true
 max_stack: 5
 value: 12
+effect:
+  heal: "1d6+1"

--- a/content/items/gorge_moss.yaml
+++ b/content/items/gorge_moss.yaml
@@ -6,3 +6,5 @@ weight: 0.2
 stackable: true
 max_stack: 10
 value: 8
+effect:
+  heal: "1d4"

--- a/content/items/medkit.yaml
+++ b/content/items/medkit.yaml
@@ -6,3 +6,5 @@ weight: 0.5
 stackable: true
 max_stack: 5
 value: 50
+effect:
+  heal: "2d8+4"


### PR DESCRIPTION
Closes #326. Adds heal effect blocks to airline_meal, medkit + 4 other consumables that were silently no-ops. forgery_supplies left without effect (downtime-only consumption).