### PR TITLE
fix(map): danger display name in hover tooltip (#315)

### DIFF
--- a/cmd/webclient/ui/src/game/RoomTooltip.test.tsx
+++ b/cmd/webclient/ui/src/game/RoomTooltip.test.tsx
@@ -22,7 +22,7 @@ describe('RoomTooltip', () => {
 
   it('renders the danger level', () => {
     render(<RoomTooltip tile={tile} pos={{ x: 100, y: 200 }} />)
-    expect(screen.getByText('safe')).toBeDefined()
+    expect(screen.getByText('Safe')).toBeDefined()
   })
 
   it('renders all POI labels', () => {
@@ -71,7 +71,7 @@ describe('RoomTooltip', () => {
   it('renders danger level from snake_case danger_level field', () => {
     const snakeTile: MapTile = { ...tile, dangerLevel: undefined, danger_level: 'dangerous' }
     render(<RoomTooltip tile={snakeTile} pos={{ x: 100, y: 200 }} />)
-    expect(screen.getByText('dangerous')).toBeDefined()
+    expect(screen.getByText('Dangerous')).toBeDefined()
   })
 
   it('shows NPC name alongside POI label when poiNpcs is provided', () => {

--- a/cmd/webclient/ui/src/game/RoomTooltip.tsx
+++ b/cmd/webclient/ui/src/game/RoomTooltip.tsx
@@ -8,6 +8,13 @@ const DANGER_COLOR: Record<string, string> = {
   all_out_war: '#f44',
 }
 
+const DANGER_LABEL: Record<string, string> = {
+  safe:        'Safe',
+  sketchy:     'Sketchy',
+  dangerous:   'Dangerous',
+  all_out_war: 'All-Out War',
+}
+
 const ZONE_EXIT_COLOR = '#c8f'
 
 const POI_TYPES: Array<{ id: string; symbol: string; color: string; label: string }> = [
@@ -88,7 +95,7 @@ export function RoomTooltip({ tile, pos, overrideText }: RoomTooltipProps) {
       {danger && (
         <div style={{ marginBottom: '0.2rem' }}>
           <span style={{ color: '#666' }}>Danger: </span>
-          <span style={{ color: dangerColor }}>{danger}</span>
+          <span style={{ color: dangerColor }}>{DANGER_LABEL[danger] ?? danger}</span>
         </div>
       )}
 


### PR DESCRIPTION
Closes #315. Added DANGER_LABEL table to RoomTooltip; renders 'All-Out War' instead of 'all_out_war'.