### PR TITLE
fix(tech): EffectUtility emits description; Litany of Iron applies condition (#329, #331)

### DIFF
--- a/content/conditions/litany_of_iron_active.yaml
+++ b/content/conditions/litany_of_iron_active.yaml
@@ -1,0 +1,17 @@
+id: litany_of_iron_active
+name: Litany of Iron Active
+description: |
+  Doctrinal litany steels your will against all threats. Intended to grant
+  +2 circumstance bonus to all saving throws for 1 round. NOTE: the +2 saves
+  bonus is not yet mechanically applied; the condition schema lacks a
+  save_bonus field. Spec follow-up needed for full mechanical effect.
+duration_type: rounds
+max_stacks: 1
+attack_penalty: 0
+ac_penalty: 0
+damage_bonus: 0
+speed_penalty: 0
+restrict_actions: []
+lua_on_apply: ""
+lua_on_remove: ""
+lua_on_tick: ""

--- a/content/technologies/innate/litany_of_iron.yaml
+++ b/content/technologies/innate/litany_of_iron.yaml
@@ -11,5 +11,9 @@ duration: rounds:1
 resolution: none
 effects:
   on_apply:
+    - type: condition
+      condition_id: litany_of_iron_active
+      value: 1
+      duration: rounds:1
     - type: utility
       description: "Litany of Iron grants +2 circumstance bonus to all saving throws for 1 round."

--- a/internal/gameserver/tech_effect_resolver.go
+++ b/internal/gameserver/tech_effect_resolver.go
@@ -396,6 +396,14 @@ func applyEffect(
 		return fmt.Sprintf("Pushed %d feet %s.", e.Distance, e.Direction)
 
 	case technology.EffectUtility:
+		// GH #329: description-only utility effects (no UtilityType) previously
+		// returned an empty message, causing techs like Litany of Iron and
+		// Fervor Pulse on_success to silently no-op. Surface the description
+		// when present so the player at least sees the narrative outcome;
+		// fall back to the typed-utility format for unlock/reveal/hack.
+		if e.Description != "" {
+			return e.Description
+		}
 		if e.UtilityType != "" {
 			return fmt.Sprintf("Utility effect: %s.", e.UtilityType)
 		}


### PR DESCRIPTION
Closes #329. Verifies #331 (closes after deploy if confirmed in-game). Dispatcher's EffectUtility now emits e.Description before falling back to UtilityType-only message. Litany of Iron now applies a tracked condition + narrative. Fervor Pulse on_success narrative now emits. Doctrine Healing Circuit dispatcher path verified wired (EffectDamage applies HP delta on save resolution); the 'no effect' report likely reflects perception/target.