### PR TITLE
feat(targeting): core types + ValidateSingleTarget + CombatTargeting (#249)

### DIFF
--- a/docs/architecture/combat.md
+++ b/docs/architecture/combat.md
@@ -495,3 +495,48 @@ Ready entries expire at the end of the round in which they were registered — `
 ### Configuration
 
 - `config.GameServerConfig.ReactionPromptTimeout` (valid range 500ms–30s; defaults to 3s) is clamped by `ValidateReactionPromptTimeout`. Plumbed into `CombatHandler.SetReactionPromptTimeout` at startup.
+
+## Targeting
+
+The targeting subsystem (`internal/game/combat/targeting.go`, `internal/game/combat/targeting_state.go`) provides the enqueue-time validation seam for player combat actions (#249). It is intentionally split from the resolver pipeline: `Combat.QueueAction` validates, the resolver consumes already-validated `QueuedAction.TargetUID` values without re-checking allegiance or range.
+
+### Categories (TARGET-1)
+
+`combat.TargetCategory` enumerates seven action target shapes:
+
+| Category | Meaning |
+| --- | --- |
+| `self` | actor targets self; no UID required |
+| `single_ally` | exactly one living ally |
+| `single_enemy` | exactly one living enemy |
+| `single_any` | any single living combatant |
+| `aoe_burst` | burst centered on a grid cell (cell layout via #250 `gamev1.AoeTemplate`) |
+| `aoe_cone` | cone originating from the actor |
+| `aoe_line` | line originating from the actor |
+
+### Error codes (TARGET-2)
+
+`combat.TargetingError` exposes eight discrete codes. `TargetOK` is the success sentinel; the others are terminal failures and the action MUST be refused:
+
+`target_missing`, `target_not_in_combat`, `target_dead`, `out_of_range`, `line_of_fire_blocked`, `wrong_category`, `aoe_shape_invalid`.
+
+`TargetingResult{Err, Detail}` carries the code plus a human-readable reason for narration. The zero value is `{TargetOK, ""}`.
+
+### Two-phase validation
+
+1. **Enqueue phase — `combat.ValidateSingleTarget(cbt, actor, uid, category, maxRangeFt, requiresLOF)`.** Six stages run in order: presence → combatant lookup → liveness → category match (allegiance) → range (Chebyshev × 5 ft) → line of fire. The line-of-fire stage is currently a no-op and reserved for a future LOF feature; AoE shape validation (`ValidateAoE`) is deferred to the same follow-up that wires #250's `CellsForTemplate` output through this pipeline.
+2. **Resolution phase — combat resolver.** Already-validated `TargetUID` values flow through `QueuedAction.TargetUID` (additive field on `combat.QueuedAction`). The resolver does not re-validate allegiance.
+
+### Sticky selection (TARGET-3)
+
+`combat.CombatTargeting` holds per-player sticky selection. The auto-target rule fires from `OnCombatStart` and `OnTargetDeath`: when exactly one living enemy remains, that enemy becomes the sticky target. Selections survive across turns inside one combat and are cleared by `Clear()`, by combat end, or when the chosen target dies (post-death the rule re-evaluates).
+
+`CombatTargeting` lives in the `combat` package — not in `session.PlayerSession` — because `combat` already imports `session`; closing the cycle would break the build. Per-player instances are held in a small registry on the gameserver side: `internal/gameserver/combat_targeting.go::targetingRegistry` (keyed by player UID, lazy-create, drop on combat end).
+
+### Resolution helper (TARGET-4)
+
+`(*CombatTargeting).ResolveAndValidate(cbt, actor, category, maxRangeFt, inlineUID)` is the single entry point for action handlers. Inline UID wins when non-empty; otherwise the sticky value is used. On a successful validation the sticky is updated to the resolved UID; on failure the sticky is left intact.
+
+### Wiring status
+
+The handler wiring (telnet `attack` / `strike` / `use` and the corresponding gRPC handlers) is **deferred to a follow-up of #249**. The same follow-up brings telnet/web `target` commands, AoE-cell validation, and feat/tech YAML targeting blocks online. The seam shipped in this iteration is the type and helper surface only.

--- a/internal/game/combat/action.go
+++ b/internal/game/combat/action.go
@@ -112,6 +112,12 @@ type QueuedAction struct {
 	AbilityCost int    // for ActionUseAbility and ActionUseTech; AP cost
 	TargetX     int32  // for ActionUseTech AoE burst center; -1 means unset
 	TargetY     int32  // for ActionUseTech AoE burst center; -1 means unset
+	// TargetUID is the canonical combatant UID for the action's primary target.
+	// Populated by the targeting pipeline (see combat.ValidateSingleTarget and
+	// gameserver.ResolveAndValidate, #249). May be empty for self/AoE-only
+	// actions or for legacy code paths that still resolve targets via Target
+	// (NPC display name). New code MUST prefer TargetUID over Target.
+	TargetUID string
 	// Ready fields — only meaningful when Type == ActionReady.
 	ReadyTrigger    reaction.ReactionTriggerType // trigger that fires the prepared action
 	ReadyAction     *QueuedAction                // the 1-AP action to execute on trigger

--- a/internal/game/combat/targeting.go
+++ b/internal/game/combat/targeting.go
@@ -1,0 +1,250 @@
+package combat
+
+import "fmt"
+
+// TargetCategory enumerates the kinds of targeting an action may require.
+//
+// The seven categories cover the minimum-viable-scope of issue #249. AoE
+// shape categories (burst/cone/line) are present here so callers can branch
+// on category, but AoE-cell validation is deferred (see #250 for shape cell
+// generation).
+type TargetCategory int
+
+const (
+	// TargetUnknown is the zero value; intentionally invalid.
+	TargetUnknown TargetCategory = iota
+	// TargetSelf — the actor targets themselves; no UID required.
+	TargetSelf
+	// TargetSingleAlly — exactly one living ally.
+	TargetSingleAlly
+	// TargetSingleEnemy — exactly one living enemy.
+	TargetSingleEnemy
+	// TargetSingleAny — any single living combatant.
+	TargetSingleAny
+	// TargetAoEBurst — a burst centered on a grid cell.
+	TargetAoEBurst
+	// TargetAoECone — a cone originating from the actor.
+	TargetAoECone
+	// TargetAoELine — a line originating from the actor.
+	TargetAoELine
+)
+
+// String returns the canonical category name used in logs and tests.
+func (t TargetCategory) String() string {
+	switch t {
+	case TargetSelf:
+		return "self"
+	case TargetSingleAlly:
+		return "single_ally"
+	case TargetSingleEnemy:
+		return "single_enemy"
+	case TargetSingleAny:
+		return "single_any"
+	case TargetAoEBurst:
+		return "aoe_burst"
+	case TargetAoECone:
+		return "aoe_cone"
+	case TargetAoELine:
+		return "aoe_line"
+	default:
+		return "unknown"
+	}
+}
+
+// IsAoE reports whether the category names an area-of-effect template.
+func (t TargetCategory) IsAoE() bool {
+	switch t {
+	case TargetAoEBurst, TargetAoECone, TargetAoELine:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsSingle reports whether the category names a single-target selection that
+// requires a target UID.
+func (t TargetCategory) IsSingle() bool {
+	switch t {
+	case TargetSingleAlly, TargetSingleEnemy, TargetSingleAny:
+		return true
+	default:
+		return false
+	}
+}
+
+// TargetingError enumerates the discrete failure modes for target validation.
+//
+// TargetOK is the zero value and indicates no error. All other values are
+// terminal errors; the caller MUST refuse to enqueue the action.
+type TargetingError int
+
+const (
+	// TargetOK indicates no validation error.
+	TargetOK TargetingError = iota
+	// ErrTargetMissing — no target was supplied where one was required.
+	ErrTargetMissing
+	// ErrTargetNotInCombat — the supplied UID is not present in the combat.
+	ErrTargetNotInCombat
+	// ErrTargetDead — the target combatant is dead.
+	ErrTargetDead
+	// ErrOutOfRange — the target is beyond the action's max range.
+	ErrOutOfRange
+	// ErrLineOfFireBlocked — line of fire is obstructed (deferred — currently
+	// always returns TargetOK from the LOF stage; reserved for future use).
+	ErrLineOfFireBlocked
+	// ErrWrongCategory — the target's allegiance does not match the
+	// requested category (e.g. ally requested but an enemy supplied).
+	ErrWrongCategory
+	// ErrAoEShapeInvalid — the AoE template produced no valid cells (reserved
+	// for ValidateAoE; see #250).
+	ErrAoEShapeInvalid
+)
+
+// String returns the canonical error code used in logs and tests.
+func (e TargetingError) String() string {
+	switch e {
+	case TargetOK:
+		return "ok"
+	case ErrTargetMissing:
+		return "target_missing"
+	case ErrTargetNotInCombat:
+		return "target_not_in_combat"
+	case ErrTargetDead:
+		return "target_dead"
+	case ErrOutOfRange:
+		return "out_of_range"
+	case ErrLineOfFireBlocked:
+		return "line_of_fire_blocked"
+	case ErrWrongCategory:
+		return "wrong_category"
+	case ErrAoEShapeInvalid:
+		return "aoe_shape_invalid"
+	default:
+		return "unknown"
+	}
+}
+
+// OK reports whether the error code is the success sentinel.
+func (e TargetingError) OK() bool { return e == TargetOK }
+
+// TargetingResult is the structured output of every validation call.
+//
+// When Err == TargetOK the action MAY proceed; Detail is empty.
+// Otherwise the action MUST be refused and Detail SHOULD be surfaced to the
+// caller for narration.
+type TargetingResult struct {
+	Err    TargetingError
+	Detail string
+}
+
+// OK reports whether validation succeeded.
+func (r TargetingResult) OK() bool { return r.Err == TargetOK }
+
+// okResult is the canonical success result.
+var okResult = TargetingResult{Err: TargetOK}
+
+// fail builds a TargetingResult with the given error code and detail.
+func fail(code TargetingError, format string, args ...any) TargetingResult {
+	return TargetingResult{Err: code, Detail: fmt.Sprintf(format, args...)}
+}
+
+// areAllies reports whether two combatants are on the same side.
+//
+// Players are always allied with other players. NPCs with matching FactionID
+// are allied; NPCs with empty FactionID are treated as a faction of one
+// (allied only with themselves). Players and NPCs are never allied (the
+// faction-based PvP/recruitment system is out of scope here).
+func areAllies(a, b *Combatant) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.ID == b.ID {
+		return true
+	}
+	if a.IsPlayer() && b.IsPlayer() {
+		return true
+	}
+	if !a.IsPlayer() && !b.IsPlayer() {
+		if a.FactionID == "" || b.FactionID == "" {
+			return false
+		}
+		return a.FactionID == b.FactionID
+	}
+	return false
+}
+
+// ValidateSingleTarget runs the six-stage validation pipeline for a single
+// target action.
+//
+// Stages, in order:
+//  1. Target presence — reject empty UID for single-target categories.
+//  2. Combatant lookup — reject UIDs not in cbt.Combatants.
+//  3. Liveness — reject dead targets.
+//  4. Category match — reject ally/enemy mismatches.
+//  5. Range — reject targets beyond maxRangeFt (zero or negative means
+//     unlimited range).
+//  6. Line of fire — currently a no-op (returns TargetOK); reserved for the
+//     LOF feature.
+//
+// Precondition: cbt and actor MUST be non-nil.
+// Postcondition: returns okResult on success, or a structured failure with a
+// descriptive Detail message.
+func ValidateSingleTarget(cbt *Combat, actor *Combatant, targetID string, category TargetCategory, maxRangeFt int, requiresLOF bool) TargetingResult {
+	if cbt == nil {
+		return fail(ErrTargetNotInCombat, "no active combat")
+	}
+	if actor == nil {
+		return fail(ErrTargetMissing, "actor is nil")
+	}
+
+	// Self category short-circuits — no UID required.
+	if category == TargetSelf {
+		return okResult
+	}
+
+	// Stage 1: presence.
+	if targetID == "" {
+		return fail(ErrTargetMissing, "no target selected")
+	}
+
+	// Stage 2: combatant lookup.
+	target := cbt.GetCombatant(targetID)
+	if target == nil {
+		return fail(ErrTargetNotInCombat, "target %q is not in this combat", targetID)
+	}
+
+	// Stage 3: liveness.
+	if target.IsDead() {
+		return fail(ErrTargetDead, "%s is dead", target.Name)
+	}
+
+	// Stage 4: category match.
+	switch category {
+	case TargetSingleAlly:
+		if !areAllies(actor, target) {
+			return fail(ErrWrongCategory, "%s is not an ally", target.Name)
+		}
+	case TargetSingleEnemy:
+		if areAllies(actor, target) {
+			return fail(ErrWrongCategory, "%s is not an enemy", target.Name)
+		}
+	case TargetSingleAny:
+		// any living combatant is acceptable.
+	default:
+		// Unknown / AoE categories are not handled by this function.
+		return fail(ErrWrongCategory, "category %s is not a single-target category", category)
+	}
+
+	// Stage 5: range.
+	if maxRangeFt > 0 {
+		dist := CombatRange(*actor, *target)
+		if dist > maxRangeFt {
+			return fail(ErrOutOfRange, "%s is %d ft away (max %d ft)", target.Name, dist, maxRangeFt)
+		}
+	}
+
+	// Stage 6: line of fire — deferred.
+	_ = requiresLOF
+
+	return okResult
+}

--- a/internal/game/combat/targeting_state.go
+++ b/internal/game/combat/targeting_state.go
@@ -1,0 +1,146 @@
+package combat
+
+import "sync"
+
+// CombatTargeting holds the per-player sticky-target selection used by
+// gameserver enqueue-time targeting (#249). The selection persists across
+// turns within a single combat and is cleared on combat end / target death /
+// explicit clear.
+//
+// CombatTargeting lives in the combat package (not gameserver) so that
+// session.PlayerSession can hold it without inducing a session→gameserver
+// import cycle. Higher layers wire its lifecycle into combat-start /
+// target-death / combat-end events.
+//
+// CombatTargeting is concurrency-safe.
+type CombatTargeting struct {
+	mu       sync.Mutex
+	targetID string
+}
+
+// NewCombatTargeting constructs an empty CombatTargeting.
+func NewCombatTargeting() *CombatTargeting {
+	return &CombatTargeting{}
+}
+
+// TargetID returns the currently selected target UID, or "" when none.
+func (s *CombatTargeting) TargetID() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.targetID
+}
+
+// Set updates the sticky target to uid. Empty string is treated as Clear.
+func (s *CombatTargeting) Set(uid string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.targetID = uid
+	s.mu.Unlock()
+}
+
+// Clear drops the current sticky target.
+func (s *CombatTargeting) Clear() {
+	s.Set("")
+}
+
+// OnCombatStart re-evaluates the sticky target at the moment combat begins.
+//
+// If actor has exactly one living enemy in the combat, that enemy becomes the
+// sticky target. Otherwise the existing selection is left untouched (callers
+// may invoke Clear first if they want to reset).
+//
+// Precondition: cbt and actor MUST be non-nil.
+func (s *CombatTargeting) OnCombatStart(cbt *Combat, actor *Combatant) {
+	if s == nil || cbt == nil || actor == nil {
+		return
+	}
+	s.autoSelect(cbt, actor)
+}
+
+// OnTargetDeath is invoked when any combatant dies. If deadID matches the
+// current sticky target the selection is cleared and re-evaluated against
+// the post-death combatant list.
+func (s *CombatTargeting) OnTargetDeath(cbt *Combat, actor *Combatant, deadID string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.targetID != deadID {
+		s.mu.Unlock()
+		return
+	}
+	s.targetID = ""
+	s.mu.Unlock()
+	if cbt == nil || actor == nil {
+		return
+	}
+	s.autoSelect(cbt, actor)
+}
+
+// autoSelect applies the single-living-enemy auto-target rule.
+//
+// When exactly one living enemy remains in cbt, it becomes the sticky target.
+// When the existing selection is already a living enemy, it is preserved.
+// Otherwise the selection is left empty (caller must explicitly choose).
+func (s *CombatTargeting) autoSelect(cbt *Combat, actor *Combatant) {
+	enemies := livingEnemies(cbt, actor)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.targetID != "" {
+		for _, e := range enemies {
+			if e.ID == s.targetID {
+				return
+			}
+		}
+		s.targetID = ""
+	}
+	if len(enemies) == 1 {
+		s.targetID = enemies[0].ID
+	}
+}
+
+// ResolveAndValidate selects the target UID to use for an action and runs
+// ValidateSingleTarget against it.
+//
+// Selection rule: when inlineUID is non-empty, it is used (the player typed
+// an explicit override). Otherwise the sticky selection is used.
+//
+// Precondition: cbt and actor MUST be non-nil.
+// Postcondition: returns (resolvedUID, validation result). On success the
+// sticky selection is updated to the resolved UID so the next call without
+// an inline override reuses it.
+func (s *CombatTargeting) ResolveAndValidate(cbt *Combat, actor *Combatant, category TargetCategory, maxRangeFt int, inlineUID string) (string, TargetingResult) {
+	uid := inlineUID
+	if uid == "" {
+		uid = s.TargetID()
+	}
+	res := ValidateSingleTarget(cbt, actor, uid, category, maxRangeFt, false)
+	if res.OK() && uid != "" {
+		s.Set(uid)
+	}
+	return uid, res
+}
+
+// livingEnemies returns the living combatants in cbt that are NOT allies of
+// actor.
+func livingEnemies(cbt *Combat, actor *Combatant) []*Combatant {
+	var out []*Combatant
+	if cbt == nil || actor == nil {
+		return out
+	}
+	for _, c := range cbt.Combatants {
+		if c == nil || c.ID == actor.ID || c.IsDead() {
+			continue
+		}
+		if areAllies(actor, c) {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}

--- a/internal/game/combat/targeting_state_test.go
+++ b/internal/game/combat/targeting_state_test.go
@@ -1,0 +1,141 @@
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+// TestCombatTargeting_ZeroValueSafe verifies nil and zero-value safety.
+func TestCombatTargeting_ZeroValueSafe(t *testing.T) {
+	var s *combat.CombatTargeting
+	if got := s.TargetID(); got != "" {
+		t.Errorf("nil.TargetID() = %q; want empty", got)
+	}
+	s.Set("anything")
+	s.Clear()
+	s.OnCombatStart(nil, nil)
+	s.OnTargetDeath(nil, nil, "x")
+
+	s2 := combat.NewCombatTargeting()
+	if s2.TargetID() != "" {
+		t.Errorf("new targeting has non-empty target")
+	}
+}
+
+// TestCombatTargeting_SingleEnemyAutoStick verifies the auto-target rule:
+// at combat start with exactly one living enemy, that enemy becomes sticky.
+func TestCombatTargeting_SingleEnemyAutoStick(t *testing.T) {
+	cbt := newTargetingCombat(t)
+	// remove n2 so only n1 is alive on the enemy side; n3 is already dead.
+	cbt.Combatants = []*combat.Combatant{
+		cbt.GetCombatant("p1"),
+		cbt.GetCombatant("n1"),
+	}
+	actor := cbt.GetCombatant("p1")
+
+	s := combat.NewCombatTargeting()
+	s.OnCombatStart(cbt, actor)
+	if got := s.TargetID(); got != "n1" {
+		t.Errorf("auto-stick TargetID = %q; want n1", got)
+	}
+}
+
+// TestCombatTargeting_MultipleEnemiesNoAutoStick verifies that when more
+// than one enemy is alive the sticky selection is left empty.
+func TestCombatTargeting_MultipleEnemiesNoAutoStick(t *testing.T) {
+	cbt := newTargetingCombat(t)
+	actor := cbt.GetCombatant("p1")
+
+	s := combat.NewCombatTargeting()
+	s.OnCombatStart(cbt, actor)
+	if got := s.TargetID(); got != "" {
+		t.Errorf("auto-stick with 2 enemies = %q; want empty", got)
+	}
+}
+
+// TestCombatTargeting_TargetDeathReselect verifies that when the sticky
+// target dies and exactly one living enemy remains, the survivor is selected.
+func TestCombatTargeting_TargetDeathReselect(t *testing.T) {
+	cbt := newTargetingCombat(t)
+	actor := cbt.GetCombatant("p1")
+	s := combat.NewCombatTargeting()
+	s.Set("n1")
+
+	// kill n1, leaving only n2 alive among enemies.
+	cbt.GetCombatant("n1").CurrentHP = 0
+	s.OnTargetDeath(cbt, actor, "n1")
+	if got := s.TargetID(); got != "n2" {
+		t.Errorf("post-death reselect TargetID = %q; want n2", got)
+	}
+}
+
+// TestCombatTargeting_TargetDeathOtherIgnored verifies that the death of a
+// non-target combatant does not affect the sticky selection.
+func TestCombatTargeting_TargetDeathOtherIgnored(t *testing.T) {
+	cbt := newTargetingCombat(t)
+	actor := cbt.GetCombatant("p1")
+	s := combat.NewCombatTargeting()
+	s.Set("n1")
+
+	cbt.GetCombatant("n2").CurrentHP = 0
+	s.OnTargetDeath(cbt, actor, "n2")
+	if got := s.TargetID(); got != "n1" {
+		t.Errorf("unrelated death changed TargetID = %q; want n1", got)
+	}
+}
+
+// TestCombatTargeting_ClearReselect verifies Clear() drops the selection
+// without re-evaluating.
+func TestCombatTargeting_ClearReselect(t *testing.T) {
+	s := combat.NewCombatTargeting()
+	s.Set("n1")
+	s.Clear()
+	if got := s.TargetID(); got != "" {
+		t.Errorf("Clear left TargetID = %q; want empty", got)
+	}
+}
+
+// TestCombatTargeting_ResolveAndValidate covers inline override + sticky
+// fallback + sticky update on success.
+func TestCombatTargeting_ResolveAndValidate(t *testing.T) {
+	cbt := newTargetingCombat(t)
+	actor := cbt.GetCombatant("p1")
+	s := combat.NewCombatTargeting()
+
+	// no sticky, no inline → ErrTargetMissing.
+	uid, res := s.ResolveAndValidate(cbt, actor, combat.TargetSingleEnemy, 0, "")
+	if res.OK() || res.Err != combat.ErrTargetMissing {
+		t.Errorf("expected ErrTargetMissing, got %v", res)
+	}
+	if uid != "" {
+		t.Errorf("expected empty uid, got %q", uid)
+	}
+
+	// inline override succeeds → sticky updated.
+	uid, res = s.ResolveAndValidate(cbt, actor, combat.TargetSingleEnemy, 0, "n1")
+	if !res.OK() {
+		t.Fatalf("expected OK, got %v", res)
+	}
+	if uid != "n1" {
+		t.Errorf("uid = %q; want n1", uid)
+	}
+	if s.TargetID() != "n1" {
+		t.Errorf("sticky not updated after success: TargetID = %q", s.TargetID())
+	}
+
+	// no inline → sticky reused.
+	uid, res = s.ResolveAndValidate(cbt, actor, combat.TargetSingleEnemy, 0, "")
+	if !res.OK() || uid != "n1" {
+		t.Errorf("sticky reuse failed: uid=%q res=%v", uid, res)
+	}
+
+	// inline override to a dead target → failure, sticky NOT clobbered.
+	_, res = s.ResolveAndValidate(cbt, actor, combat.TargetSingleEnemy, 0, "n3")
+	if res.OK() || res.Err != combat.ErrTargetDead {
+		t.Errorf("expected ErrTargetDead, got %v", res)
+	}
+	if s.TargetID() != "n1" {
+		t.Errorf("sticky clobbered on failure: %q", s.TargetID())
+	}
+}

--- a/internal/game/combat/targeting_test.go
+++ b/internal/game/combat/targeting_test.go
@@ -1,0 +1,161 @@
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+// TestTargetCategory_String ensures every named category renders its canonical name.
+func TestTargetCategory_String(t *testing.T) {
+	cases := []struct {
+		c    combat.TargetCategory
+		want string
+	}{
+		{combat.TargetUnknown, "unknown"},
+		{combat.TargetSelf, "self"},
+		{combat.TargetSingleAlly, "single_ally"},
+		{combat.TargetSingleEnemy, "single_enemy"},
+		{combat.TargetSingleAny, "single_any"},
+		{combat.TargetAoEBurst, "aoe_burst"},
+		{combat.TargetAoECone, "aoe_cone"},
+		{combat.TargetAoELine, "aoe_line"},
+	}
+	for _, tc := range cases {
+		if got := tc.c.String(); got != tc.want {
+			t.Errorf("TargetCategory(%d).String() = %q; want %q", tc.c, got, tc.want)
+		}
+	}
+}
+
+// TestTargetCategory_Predicates verifies IsAoE / IsSingle classification.
+func TestTargetCategory_Predicates(t *testing.T) {
+	if !combat.TargetAoEBurst.IsAoE() || !combat.TargetAoECone.IsAoE() || !combat.TargetAoELine.IsAoE() {
+		t.Errorf("IsAoE missed an AoE category")
+	}
+	if combat.TargetSelf.IsAoE() || combat.TargetSingleEnemy.IsAoE() {
+		t.Errorf("IsAoE returned true for non-AoE")
+	}
+	if !combat.TargetSingleAlly.IsSingle() || !combat.TargetSingleEnemy.IsSingle() || !combat.TargetSingleAny.IsSingle() {
+		t.Errorf("IsSingle missed a single-target category")
+	}
+	if combat.TargetSelf.IsSingle() || combat.TargetAoEBurst.IsSingle() {
+		t.Errorf("IsSingle returned true for non-single")
+	}
+}
+
+// TestTargetingError_String ensures every error code renders its canonical name.
+func TestTargetingError_String(t *testing.T) {
+	cases := []struct {
+		e    combat.TargetingError
+		want string
+	}{
+		{combat.TargetOK, "ok"},
+		{combat.ErrTargetMissing, "target_missing"},
+		{combat.ErrTargetNotInCombat, "target_not_in_combat"},
+		{combat.ErrTargetDead, "target_dead"},
+		{combat.ErrOutOfRange, "out_of_range"},
+		{combat.ErrLineOfFireBlocked, "line_of_fire_blocked"},
+		{combat.ErrWrongCategory, "wrong_category"},
+		{combat.ErrAoEShapeInvalid, "aoe_shape_invalid"},
+	}
+	for _, tc := range cases {
+		if got := tc.e.String(); got != tc.want {
+			t.Errorf("TargetingError(%d).String() = %q; want %q", tc.e, got, tc.want)
+		}
+	}
+	if !combat.TargetOK.OK() {
+		t.Errorf("TargetOK.OK() = false; want true")
+	}
+	if combat.ErrTargetMissing.OK() {
+		t.Errorf("ErrTargetMissing.OK() = true; want false")
+	}
+}
+
+// TestTargetingResult_ZeroValueOK confirms the zero value represents success.
+func TestTargetingResult_ZeroValueOK(t *testing.T) {
+	var r combat.TargetingResult
+	if !r.OK() {
+		t.Errorf("zero-value TargetingResult.OK() = false; want true")
+	}
+	if r.Err != combat.TargetOK {
+		t.Errorf("zero-value Err = %v; want TargetOK", r.Err)
+	}
+}
+
+// newTargetingCombat builds a small two-row combat for validation tests.
+// Player p1 sits at (0,0); enemy n1 at (0,1) (5 ft away);
+// enemy n2 at (5,5) (25 ft Chebyshev = 25 ft); ally NPC af1 at (1,0).
+func newTargetingCombat(t *testing.T) *combat.Combat {
+	t.Helper()
+	cbt := &combat.Combat{
+		RoomID:     "room",
+		GridWidth:  10,
+		GridHeight: 10,
+	}
+	p1 := &combat.Combatant{ID: "p1", Kind: combat.KindPlayer, Name: "P1", MaxHP: 10, CurrentHP: 10, GridX: 0, GridY: 0}
+	p2 := &combat.Combatant{ID: "p2", Kind: combat.KindPlayer, Name: "P2", MaxHP: 10, CurrentHP: 10, GridX: 1, GridY: 0}
+	n1 := &combat.Combatant{ID: "n1", Kind: combat.KindNPC, Name: "Goblin", MaxHP: 10, CurrentHP: 10, GridX: 0, GridY: 1, FactionID: "monsters"}
+	n2 := &combat.Combatant{ID: "n2", Kind: combat.KindNPC, Name: "DistantOrc", MaxHP: 10, CurrentHP: 10, GridX: 5, GridY: 5, FactionID: "monsters"}
+	dead := &combat.Combatant{ID: "n3", Kind: combat.KindNPC, Name: "Corpse", MaxHP: 10, CurrentHP: 0, GridX: 1, GridY: 1, FactionID: "monsters"}
+	cbt.Combatants = []*combat.Combatant{p1, p2, n1, n2, dead}
+	return cbt
+}
+
+// TestValidateSingleTarget_Table exercises every stage of the pipeline.
+func TestValidateSingleTarget_Table(t *testing.T) {
+	cbt := newTargetingCombat(t)
+	actor := cbt.GetCombatant("p1")
+
+	cases := []struct {
+		name     string
+		targetID string
+		cat      combat.TargetCategory
+		maxRange int
+		want     combat.TargetingError
+	}{
+		{"self ok no uid", "", combat.TargetSelf, 0, combat.TargetOK},
+		{"missing uid", "", combat.TargetSingleEnemy, 0, combat.ErrTargetMissing},
+		{"not in combat", "ghost", combat.TargetSingleEnemy, 0, combat.ErrTargetNotInCombat},
+		{"dead target", "n3", combat.TargetSingleEnemy, 0, combat.ErrTargetDead},
+		{"single enemy ok", "n1", combat.TargetSingleEnemy, 0, combat.TargetOK},
+		{"ally requested but enemy supplied", "n1", combat.TargetSingleAlly, 0, combat.ErrWrongCategory},
+		{"single ally ok (player ally)", "p2", combat.TargetSingleAlly, 0, combat.TargetOK},
+		{"single any (enemy)", "n1", combat.TargetSingleAny, 0, combat.TargetOK},
+		{"single any (ally)", "p2", combat.TargetSingleAny, 0, combat.TargetOK},
+		{"out of range", "n2", combat.TargetSingleEnemy, 10, combat.ErrOutOfRange},
+		{"in range", "n2", combat.TargetSingleEnemy, 25, combat.TargetOK},
+		{"unlimited range allows distant target", "n2", combat.TargetSingleEnemy, 0, combat.TargetOK},
+		{"unsupported category routed here", "n1", combat.TargetAoEBurst, 0, combat.ErrWrongCategory},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := combat.ValidateSingleTarget(cbt, actor, tc.targetID, tc.cat, tc.maxRange, false)
+			if got.Err != tc.want {
+				t.Errorf("ValidateSingleTarget err = %s (%q); want %s", got.Err, got.Detail, tc.want)
+			}
+			if tc.want == combat.TargetOK && !got.OK() {
+				t.Errorf("expected OK result, got %+v", got)
+			}
+			if tc.want != combat.TargetOK && got.OK() {
+				t.Errorf("expected failure, got OK")
+			}
+			if tc.want != combat.TargetOK && got.Detail == "" {
+				t.Errorf("expected non-empty Detail on failure, got empty")
+			}
+		})
+	}
+}
+
+// TestValidateSingleTarget_NilGuards covers defensive nil checks.
+func TestValidateSingleTarget_NilGuards(t *testing.T) {
+	cbt := newTargetingCombat(t)
+	actor := cbt.GetCombatant("p1")
+
+	if r := combat.ValidateSingleTarget(nil, actor, "n1", combat.TargetSingleEnemy, 0, false); r.OK() {
+		t.Errorf("expected failure with nil cbt")
+	}
+	if r := combat.ValidateSingleTarget(cbt, nil, "n1", combat.TargetSingleEnemy, 0, false); r.OK() {
+		t.Errorf("expected failure with nil actor")
+	}
+}

--- a/internal/gameserver/combat_targeting.go
+++ b/internal/gameserver/combat_targeting.go
@@ -1,0 +1,61 @@
+package gameserver
+
+import (
+	"sync"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+// targetingRegistry is a per-player CombatTargeting registry keyed by player
+// UID. The state is held in gameserver (rather than session.PlayerSession)
+// because combat already imports session — a *combat.CombatTargeting field
+// on PlayerSession would close the import cycle session→combat→session.
+//
+// This registry is the canonical home for sticky-target state at enqueue
+// time. The handler wiring (telnet attack/strike/use) is deferred to a
+// follow-up of #249; this scaffolding gives the wiring layer a stable
+// callable surface.
+//
+// targetingRegistry is concurrency-safe.
+type targetingRegistry struct {
+	mu      sync.RWMutex
+	byOwner map[string]*combat.CombatTargeting
+}
+
+// newTargetingRegistry constructs an empty registry.
+func newTargetingRegistry() *targetingRegistry {
+	return &targetingRegistry{byOwner: map[string]*combat.CombatTargeting{}}
+}
+
+// For returns the CombatTargeting bound to ownerUID, lazily creating one on
+// first access. The returned value is safe to retain across calls.
+func (r *targetingRegistry) For(ownerUID string) *combat.CombatTargeting {
+	if r == nil || ownerUID == "" {
+		return nil
+	}
+	r.mu.RLock()
+	if s, ok := r.byOwner[ownerUID]; ok {
+		r.mu.RUnlock()
+		return s
+	}
+	r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.byOwner[ownerUID]; ok {
+		return s
+	}
+	s := combat.NewCombatTargeting()
+	r.byOwner[ownerUID] = s
+	return s
+}
+
+// Drop removes the targeting state for ownerUID — invoked when the player
+// leaves combat or disconnects.
+func (r *targetingRegistry) Drop(ownerUID string) {
+	if r == nil || ownerUID == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.byOwner, ownerUID)
+	r.mu.Unlock()
+}

--- a/internal/gameserver/combat_targeting_test.go
+++ b/internal/gameserver/combat_targeting_test.go
@@ -1,0 +1,51 @@
+package gameserver
+
+import "testing"
+
+// TestTargetingRegistry_LazyCreate verifies first-access creates state and
+// subsequent accesses return the same pointer.
+func TestTargetingRegistry_LazyCreate(t *testing.T) {
+	r := newTargetingRegistry()
+	a := r.For("p1")
+	if a == nil {
+		t.Fatalf("For returned nil")
+	}
+	b := r.For("p1")
+	if a != b {
+		t.Errorf("For returned different instances for same owner")
+	}
+	c := r.For("p2")
+	if c == a {
+		t.Errorf("different owners share state")
+	}
+}
+
+// TestTargetingRegistry_Drop verifies Drop removes state and a fresh
+// instance is created on next access.
+func TestTargetingRegistry_Drop(t *testing.T) {
+	r := newTargetingRegistry()
+	a := r.For("p1")
+	a.Set("n1")
+	r.Drop("p1")
+	b := r.For("p1")
+	if b == a {
+		t.Errorf("Drop did not remove state")
+	}
+	if b.TargetID() != "" {
+		t.Errorf("post-Drop fresh state has TargetID = %q", b.TargetID())
+	}
+}
+
+// TestTargetingRegistry_NilSafe verifies nil receiver and empty owner safety.
+func TestTargetingRegistry_NilSafe(t *testing.T) {
+	var r *targetingRegistry
+	if got := r.For("p1"); got != nil {
+		t.Errorf("nil registry For returned non-nil")
+	}
+	r.Drop("p1") // must not panic
+
+	r2 := newTargetingRegistry()
+	if got := r2.For(""); got != nil {
+		t.Errorf("empty-owner For returned non-nil")
+	}
+}


### PR DESCRIPTION
Closes #249. Server-side targeting infrastructure: 7 categories, 8 error codes, ValidateSingleTarget six-stage pipeline (line-of-fire stage no-op pending #267), CombatTargeting per-player registry with auto-stick/death-reselect/clear-reselect lifecycle. UI wiring (telnet target command, web TargetPanel) deferred to #344.