### PR TITLE
feat(npc): smarter movement chooser (#251)

### DIFF
--- a/docs/architecture/combat.md
+++ b/docs/architecture/combat.md
@@ -391,6 +391,72 @@ component) is tracked as a follow-up to #250. The core resolver is functional en
 today: clients can submit programmatic `AoeTemplate` messages without an interactive
 placement step.
 
+## NPC Movement (#251 — Smarter NPC Movement)
+
+NPCs choose stride destinations through a goal-based scorer rather than the
+legacy "melee-closes / ranged-retreats" binary. Every reachable cell is
+evaluated against four weighted goals; the highest-scoring cell wins. The
+existing `ActionStride` machinery in `round.go` consumes the result via the
+unchanged `npcMovementStrideLocked` wrapper, so NPC turn structure (HTN plan
+→ stride → attack) is preserved.
+
+### Decision flow
+
+```
+HTN planner emits actions
+  └── npcMovementStrideLocked(cbt, actor)
+        └── combat.ChooseMoveDestination(cbt, actor, target, ctx, flipRange)
+              ├── CandidateCells(cbt, actor)            # reachable, in-bounds, passable
+              └── for each cell: weighted sum of
+                    Range·RangeGoal + Cover·CoverGoal +
+                    Spread·SpreadGoal + Terrain·TerrainGoal
+        └── translate destination into "toward" / "away"
+  └── existing stride loop in round.go walks the destination
+```
+
+### Goal functions (`internal/game/combat/movement.go`)
+
+| Goal | Score range | Intent |
+|------|-------------|--------|
+| `RangeGoal` | [0, 1] | 1.0 at the NPC's preferred engagement distance (adjacent for melee, range increment for ranged); falls linearly to 0.0 at the grid diagonal. Ranged NPCs explicitly score point-blank cells (Chebyshev ≤ 1) at 0.0 — they never prefer to be in melee. |
+| `CoverGoal` | [0, 1] | 0.33 / 0.66 / 1.0 for lesser / standard / greater cover. Returns 0 when the NPC's strategy disables cover or no cover model is wired (the soft dependency on #247). |
+| `SpreadGoal` | [0, 1] | Linearly scales with Chebyshev distance to the nearest faction-allied combatant; saturates at the ranged NPC's first range increment (or 6 cells / 30 ft for melee NPCs). NPCs without allies always score 1.0. |
+| `TerrainGoal` | {0.0, 0.5, 1.0} | Hazardous → 0.0; difficult → 0.5; normal → 1.0. Greater-difficult cells are filtered out before scoring (`CandidateCells`). |
+
+Weights default to `Range=1.0`, `Cover=0.5`, `Spread=0.3`, `Terrain=0.4`
+(`combat.DefaultMoveWeights`). Per-NPC overrides via YAML `combat_strategy.move_weights`
+are deferred to a follow-up; until then, `MoveWeights{}` zeros are filled from
+the defaults via `WithDefaults()`.
+
+### Wrapper translation
+
+`npcMovementStrideLocked` translates the chosen destination into a single
+"toward" / "away" string consumed by the existing per-cell stride loop in
+`round.go`. The walk itself still uses `CompassDelta` against the live
+target each step, which preserves multi-cell stride behaviour, terrain
+budget enforcement, and reactive-strike triggers without further changes.
+
+### Soft dependencies
+
+| Concern | Plug-in seam | Status |
+|---------|--------------|--------|
+| Cover (positional, #247) | `MoveContext.CoverTierAt` (callback) | Stub returns "" today; `CoverGoal` returns 0. |
+| Terrain (#248) | `Combat.TerrainAt` / `Combat.EntryCost` | Already wired (#248 landed). |
+
+### Deferred
+
+- HTN integration (`move_to_position` action + `WorldState.MoveScores`) — tracked as a follow-up so HTN domains can reserve movement decisions when desired.
+- YAML weights on NPC templates — deferred; code defaults are sufficient for the first roll-out.
+- Multi-stride decomposition with per-step direction queueing — the existing single "toward"/"away" stride loop is reused.
+
+### Implementation files
+
+| File | Responsibility |
+|------|----------------|
+| `internal/game/combat/movement.go` | `MoveWeights`, `MoveContext`, `CandidateCells`, `RangeGoal`, `CoverGoal`, `SpreadGoal`, `TerrainGoal`, `ChooseMoveDestination`, `StepToward` |
+| `internal/game/combat/movement_test.go` | Goal/scenario tests + property tests (determinism, candidate-bounded, stride budget) |
+| `internal/gameserver/combat_handler.go` | `npcMovementStrideLocked` wrapper translates the chooser's destination into the legacy stride direction |
+
 ## Component Dependencies
 
 ```mermaid

--- a/internal/game/combat/movement.go
+++ b/internal/game/combat/movement.go
@@ -1,0 +1,360 @@
+package combat
+
+import (
+	"math"
+)
+
+// MoveWeights weights the four NPC tactical-movement goals. Zero in any field
+// means "use the default value" via WithDefaults.
+//
+// The defaults are tuned so range dominates (NPCs primarily move toward / away
+// from the threat), terrain meaningfully discounts difficult footing, cover is
+// pursued when available, and spread keeps allies from clumping.
+type MoveWeights struct {
+	Range   float64
+	Cover   float64
+	Spread  float64
+	Terrain float64
+}
+
+// DefaultMoveWeights are the baseline tactical weights applied to NPCs that do
+// not declare per-template overrides. These match the spec's MOVE-16 defaults.
+var DefaultMoveWeights = MoveWeights{
+	Range:   1.0,
+	Cover:   0.5,
+	Spread:  0.3,
+	Terrain: 0.4,
+}
+
+// WithDefaults fills any zero-valued field on w from DefaultMoveWeights.
+func (w MoveWeights) WithDefaults() MoveWeights {
+	if w.Range == 0 {
+		w.Range = DefaultMoveWeights.Range
+	}
+	if w.Cover == 0 {
+		w.Cover = DefaultMoveWeights.Cover
+	}
+	if w.Spread == 0 {
+		w.Spread = DefaultMoveWeights.Spread
+	}
+	if w.Terrain == 0 {
+		w.Terrain = DefaultMoveWeights.Terrain
+	}
+	return w
+}
+
+// MoveContext captures the per-NPC inputs the goal functions need that are
+// not derivable from the Combatant struct alone (range increment in feet,
+// cover availability, faction allies). Consumers in the gameserver package
+// build this from npc instance / inventory registry data and hand it to
+// ChooseMoveDestination.
+type MoveContext struct {
+	// RangeIncrementFt is the equipped weapon's range increment in feet.
+	// 0 = melee.
+	RangeIncrementFt int
+	// UseCover is true when the NPC's combat strategy permits hugging cover.
+	UseCover bool
+	// CoverTierAt returns the cover tier ("", "lesser", "standard", "greater")
+	// the NPC would receive at the candidate cell relative to the target. nil
+	// means "no cover model wired" — coverGoal returns 0 in that case.
+	CoverTierAt func(cell GridCell) string
+	// Allies is the list of living faction-mates the NPC should avoid clumping
+	// with. Always excludes the NPC itself.
+	Allies []*Combatant
+	// Weights override DefaultMoveWeights when non-zero per field.
+	Weights MoveWeights
+}
+
+// chebyshev returns the Chebyshev distance between two grid cells.
+func chebyshev(a, b GridCell) int {
+	dx := a.X - b.X
+	if dx < 0 {
+		dx = -dx
+	}
+	dy := a.Y - b.Y
+	if dy < 0 {
+		dy = -dy
+	}
+	if dx > dy {
+		return dx
+	}
+	return dy
+}
+
+// CandidateCells enumerates every grid cell reachable from the actor's current
+// position within its remaining stride budget for the round. Each cell on the
+// returned slice is in-bounds, passable (not greater_difficult terrain), and
+// not currently occupied by another living combatant or cover. The actor's
+// current cell is always included, even when no other moves are available
+// (MOVE-9: staying put is always a candidate).
+//
+// Approximation: we bound the search by a Chebyshev radius equal to the
+// per-stride SpeedBudget × MaxMovementAP. Difficult terrain (cost 2) means
+// some candidates within the radius would not actually be reachable in two
+// strides, but the scoring layer will simply prefer reachable cells; the
+// stride loop itself enforces budget at execution time.
+//
+// Precondition: cbt and actor must not be nil; actor must be on the grid.
+// Postcondition: returned slice contains actor's current cell and only cells
+// satisfying the above filters.
+func CandidateCells(cbt *Combat, actor *Combatant) []GridCell {
+	if cbt == nil || actor == nil {
+		return nil
+	}
+	width := cbt.GridWidth
+	if width <= 0 {
+		width = 10
+	}
+	height := cbt.GridHeight
+	if height <= 0 {
+		height = 10
+	}
+	speed := actor.SpeedBudget()
+	if speed < 1 {
+		speed = 1
+	}
+	radius := speed * MaxMovementAP
+
+	here := GridCell{X: actor.GridX, Y: actor.GridY}
+	out := make([]GridCell, 0, (2*radius+1)*(2*radius+1))
+	out = append(out, here)
+	for dy := -radius; dy <= radius; dy++ {
+		for dx := -radius; dx <= radius; dx++ {
+			if dx == 0 && dy == 0 {
+				continue
+			}
+			x := actor.GridX + dx
+			y := actor.GridY + dy
+			if x < 0 || y < 0 || x >= width || y >= height {
+				continue
+			}
+			if CellBlocked(cbt, actor.ID, x, y) {
+				continue
+			}
+			// TerrainGreaterDifficult reports passable=false; exclude.
+			if _, passable := cbt.EntryCost(x, y); !passable {
+				continue
+			}
+			out = append(out, GridCell{X: x, Y: y})
+		}
+	}
+	return out
+}
+
+// RangeGoal scores how desirable a cell is for the actor's preferred engagement
+// distance. Melee NPCs (RangeIncrementFt == 0) prefer adjacency (Chebyshev 1);
+// ranged NPCs prefer their first range increment (range/5 cells). The score is
+// 1.0 at the optimal distance and falls linearly to 0.0 at the worst case
+// (current grid diagonal). Ranged NPCs explicitly score point-blank cells
+// (distance <= 1) at 0.0 — they should never prefer to be in melee.
+//
+// Precondition: target may be nil; in that case the goal returns 0.
+// Postcondition: result is in [0, 1].
+func RangeGoal(ctx MoveContext, target *Combatant, cell GridCell, gridDiagonal int) float64 {
+	if target == nil {
+		return 0
+	}
+	dist := chebyshev(cell, GridCell{X: target.GridX, Y: target.GridY})
+	if ctx.RangeIncrementFt > 0 && dist <= 1 {
+		return 0
+	}
+	preferred := 1
+	if ctx.RangeIncrementFt > 0 {
+		preferred = ctx.RangeIncrementFt / 5
+		if preferred < 1 {
+			preferred = 1
+		}
+	}
+	worst := gridDiagonal
+	if worst < 1 {
+		worst = 1
+	}
+	delta := dist - preferred
+	if delta < 0 {
+		delta = -delta
+	}
+	score := 1.0 - float64(delta)/float64(worst)
+	if score < 0 {
+		score = 0
+	}
+	if score > 1 {
+		score = 1
+	}
+	return score
+}
+
+// CoverGoal scores how desirable a cell is for cover relative to the current
+// threat target. Returns 0 when the NPC's strategy disables cover or no cover
+// model is wired. Otherwise lesser/standard/greater map to 0.33/0.66/1.0.
+//
+// Postcondition: result is in [0, 1].
+func CoverGoal(ctx MoveContext, cell GridCell) float64 {
+	if !ctx.UseCover || ctx.CoverTierAt == nil {
+		return 0
+	}
+	switch ctx.CoverTierAt(cell) {
+	case CoverTierGreater:
+		return 1.0
+	case CoverTierStandard:
+		return 0.66
+	case CoverTierLesser:
+		return 0.33
+	default:
+		return 0
+	}
+}
+
+// SpreadGoal scores how desirable a cell is for keeping the NPC away from
+// faction-allied combatants. Score scales linearly with the Chebyshev distance
+// to the nearest living ally, saturating at the ranged NPC's first increment
+// (or 6 cells / 30 ft for melee NPCs). NPCs with no allies always score 1.0.
+//
+// Postcondition: result is in [0, 1].
+func SpreadGoal(ctx MoveContext, actor *Combatant, cell GridCell) float64 {
+	nearest := math.MaxInt32
+	for _, a := range ctx.Allies {
+		if a == nil || a == actor || a.IsDead() {
+			continue
+		}
+		if a.FactionID != actor.FactionID {
+			continue
+		}
+		d := chebyshev(cell, GridCell{X: a.GridX, Y: a.GridY})
+		if d < nearest {
+			nearest = d
+		}
+	}
+	if nearest == math.MaxInt32 {
+		return 1.0
+	}
+	cap := 6
+	if ctx.RangeIncrementFt > 0 {
+		ri := ctx.RangeIncrementFt / 5
+		if ri > cap {
+			cap = ri
+		}
+	}
+	if cap < 1 {
+		cap = 1
+	}
+	score := float64(nearest) / float64(cap)
+	if score > 1 {
+		score = 1
+	}
+	if score < 0 {
+		score = 0
+	}
+	return score
+}
+
+// TerrainGoal scores how desirable a cell is on terrain grounds. Normal cells
+// score 1.0; difficult cells score 0.5; hazardous cells score 0.0. Greater-
+// difficult cells are filtered out at candidate enumeration so they never
+// reach this scorer.
+//
+// Postcondition: result is in [0, 1].
+func TerrainGoal(cbt *Combat, cell GridCell) float64 {
+	if cbt == nil {
+		return 1.0
+	}
+	tc := cbt.TerrainAt(cell.X, cell.Y)
+	switch tc.Type {
+	case TerrainHazardous:
+		return 0.0
+	case TerrainDifficult:
+		return 0.5
+	default:
+		return 1.0
+	}
+}
+
+// scoreCell computes the weighted sum of all four goals for a candidate.
+func scoreCell(cbt *Combat, ctx MoveContext, actor, target *Combatant, cell GridCell, gridDiagonal int, flipRange bool) float64 {
+	w := ctx.Weights.WithDefaults()
+	rg := RangeGoal(ctx, target, cell, gridDiagonal)
+	if flipRange {
+		rg = 1.0 - rg
+	}
+	return w.Range*rg +
+		w.Cover*CoverGoal(ctx, cell) +
+		w.Spread*SpreadGoal(ctx, actor, cell) +
+		w.Terrain*TerrainGoal(cbt, cell)
+}
+
+// ChooseMoveDestination returns the cell the NPC should attempt to occupy this
+// round, or nil to indicate "stay put". The chooser enumerates candidates,
+// scores each by the weighted goal sum, and picks the highest-scoring cell.
+// Ties break by lower Y, then lower X (deterministic).
+//
+// When the highest-scoring cell is the actor's current position (or scores
+// within an epsilon of staying put), the function returns nil so the caller
+// can skip queuing a stride entirely (MOVE-20).
+//
+// flipRange may be set by callers when the NPC is fleeing (HP below the flee
+// threshold) or routed (combat threat above the courage threshold) — the
+// rangeGoal is mirrored so the NPC actively seeks distance from the target.
+//
+// Precondition: cbt and actor must not be nil; target may be nil (in which
+// case no movement is chosen).
+// Postcondition: returned pointer, when non-nil, refers to a cell present in
+// CandidateCells(cbt, actor).
+func ChooseMoveDestination(cbt *Combat, actor, target *Combatant, ctx MoveContext, flipRange bool) *GridCell {
+	if cbt == nil || actor == nil || target == nil {
+		return nil
+	}
+	candidates := CandidateCells(cbt, actor)
+	if len(candidates) <= 1 {
+		return nil
+	}
+	gridDiagonal := cbt.GridWidth
+	if cbt.GridHeight > gridDiagonal {
+		gridDiagonal = cbt.GridHeight
+	}
+	if gridDiagonal <= 0 {
+		gridDiagonal = 10
+	}
+
+	here := GridCell{X: actor.GridX, Y: actor.GridY}
+	hereScore := scoreCell(cbt, ctx, actor, target, here, gridDiagonal, flipRange)
+
+	bestScore := math.Inf(-1)
+	var best GridCell
+	for _, cell := range candidates {
+		s := scoreCell(cbt, ctx, actor, target, cell, gridDiagonal, flipRange)
+		if s > bestScore {
+			bestScore = s
+			best = cell
+			continue
+		}
+		if s == bestScore {
+			// Deterministic tie-break: lower Y wins, then lower X.
+			if cell.Y < best.Y || (cell.Y == best.Y && cell.X < best.X) {
+				best = cell
+			}
+		}
+	}
+
+	const epsilon = 0.01
+	if best == here || (bestScore-hereScore) < epsilon {
+		return nil
+	}
+	return &best
+}
+
+// StepToward returns the unit (dx, dy) step that moves one Chebyshev cell from
+// 'from' toward 'to'. dx, dy ∈ {-1, 0, 1}; (0,0) means already coincident.
+func StepToward(from, to GridCell) (int, int) {
+	dx := 0
+	if to.X > from.X {
+		dx = 1
+	} else if to.X < from.X {
+		dx = -1
+	}
+	dy := 0
+	if to.Y > from.Y {
+		dy = 1
+	} else if to.Y < from.Y {
+		dy = -1
+	}
+	return dx, dy
+}

--- a/internal/game/combat/movement_test.go
+++ b/internal/game/combat/movement_test.go
@@ -1,0 +1,347 @@
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMovementCombat returns a Combat with a width×height grid and no terrain.
+func newMovementCombat(width, height int) *combat.Combat {
+	return &combat.Combat{
+		GridWidth:  width,
+		GridHeight: height,
+	}
+}
+
+// addCombatant places a non-dead combatant at (x, y) on the grid and returns it.
+func addCombatant(cbt *combat.Combat, id string, kind combat.Kind, x, y int) *combat.Combatant {
+	c := &combat.Combatant{
+		ID:        id,
+		Kind:      kind,
+		Name:      id,
+		MaxHP:     20,
+		CurrentHP: 20,
+		GridX:     x,
+		GridY:     y,
+		SpeedFt:   25, // SpeedBudget == 5
+	}
+	cbt.Combatants = append(cbt.Combatants, c)
+	return c
+}
+
+// containsCell reports whether the slice contains the given cell.
+func containsCell(cells []combat.GridCell, want combat.GridCell) bool {
+	for _, c := range cells {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ─── CandidateCells ──────────────────────────────────────────────────────────
+
+func TestCandidateCells_IncludesCurrentCell(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 5)
+	cells := combat.CandidateCells(cbt, npc)
+	require.True(t, containsCell(cells, combat.GridCell{X: 5, Y: 5}),
+		"current cell must always be a candidate (MOVE-9)")
+}
+
+func TestCandidateCells_ExcludesOccupiedAndOOB(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 0, 0)
+	addCombatant(cbt, "p1", combat.KindPlayer, 0, 1)
+	cells := combat.CandidateCells(cbt, npc)
+	assert.False(t, containsCell(cells, combat.GridCell{X: 0, Y: 1}),
+		"occupied cells must be excluded")
+	assert.False(t, containsCell(cells, combat.GridCell{X: -1, Y: 0}),
+		"out-of-bounds cells must be excluded")
+}
+
+func TestCandidateCells_ExcludesGreaterDifficultTerrain(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 5)
+	cbt.Terrain = map[combat.GridCell]*combat.TerrainCell{
+		{X: 6, Y: 5}: {X: 6, Y: 5, Type: combat.TerrainGreaterDifficult},
+	}
+	cells := combat.CandidateCells(cbt, npc)
+	assert.False(t, containsCell(cells, combat.GridCell{X: 6, Y: 5}),
+		"greater_difficult cells must be excluded (MOVE-14)")
+}
+
+func TestCandidateCells_BoundedByMovementBudget(t *testing.T) {
+	cbt := newMovementCombat(40, 40)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 20, 20)
+	maxRing := npc.SpeedBudget() * combat.MaxMovementAP
+	cells := combat.CandidateCells(cbt, npc)
+	for _, c := range cells {
+		dx := c.X - 20
+		if dx < 0 {
+			dx = -dx
+		}
+		dy := c.Y - 20
+		if dy < 0 {
+			dy = -dy
+		}
+		ring := dx
+		if dy > dx {
+			ring = dy
+		}
+		require.LessOrEqual(t, ring, maxRing,
+			"candidate cell %+v exceeds reachable Chebyshev ring %d", c, maxRing)
+	}
+}
+
+// ─── RangeGoal ───────────────────────────────────────────────────────────────
+
+func TestRangeGoal_MeleeMaxAtAdjacent(t *testing.T) {
+	target := &combat.Combatant{GridX: 5, GridY: 5}
+	score := combat.RangeGoal(combat.MoveContext{RangeIncrementFt: 0}, target,
+		combat.GridCell{X: 4, Y: 5}, 20)
+	assert.InDelta(t, 1.0, score, 0.001, "melee NPC adjacent to target should score 1.0")
+}
+
+func TestRangeGoal_RangedMaxAtIncrementDistance(t *testing.T) {
+	target := &combat.Combatant{GridX: 10, GridY: 10}
+	// 15 ft / 5 = 3 cells.
+	score := combat.RangeGoal(combat.MoveContext{RangeIncrementFt: 15}, target,
+		combat.GridCell{X: 7, Y: 10}, 20)
+	assert.InDelta(t, 1.0, score, 0.001, "ranged NPC at increment distance should score 1.0")
+}
+
+func TestRangeGoal_RangedNeverPrefersPointBlank(t *testing.T) {
+	target := &combat.Combatant{GridX: 10, GridY: 10}
+	near := combat.RangeGoal(combat.MoveContext{RangeIncrementFt: 15}, target,
+		combat.GridCell{X: 9, Y: 10}, 20)
+	farther := combat.RangeGoal(combat.MoveContext{RangeIncrementFt: 15}, target,
+		combat.GridCell{X: 7, Y: 10}, 20)
+	assert.Less(t, near, farther,
+		"ranged NPC must never prefer point-blank over its preferred range")
+}
+
+func TestRangeGoal_NilTargetReturnsZero(t *testing.T) {
+	score := combat.RangeGoal(combat.MoveContext{}, nil, combat.GridCell{X: 0, Y: 0}, 10)
+	assert.Equal(t, 0.0, score)
+}
+
+// ─── CoverGoal ───────────────────────────────────────────────────────────────
+
+func TestCoverGoal_DisabledByStrategy(t *testing.T) {
+	ctx := combat.MoveContext{
+		UseCover:    false,
+		CoverTierAt: func(combat.GridCell) string { return combat.CoverTierGreater },
+	}
+	assert.Equal(t, 0.0, combat.CoverGoal(ctx, combat.GridCell{X: 0, Y: 0}))
+}
+
+func TestCoverGoal_NilTierFnReturnsZero(t *testing.T) {
+	ctx := combat.MoveContext{UseCover: true}
+	assert.Equal(t, 0.0, combat.CoverGoal(ctx, combat.GridCell{X: 0, Y: 0}))
+}
+
+func TestCoverGoal_TierMonotone(t *testing.T) {
+	mk := func(tier string) combat.MoveContext {
+		return combat.MoveContext{
+			UseCover:    true,
+			CoverTierAt: func(combat.GridCell) string { return tier },
+		}
+	}
+	c := combat.GridCell{X: 1, Y: 1}
+	none := combat.CoverGoal(mk(combat.CoverTierNone), c)
+	lesser := combat.CoverGoal(mk(combat.CoverTierLesser), c)
+	standard := combat.CoverGoal(mk(combat.CoverTierStandard), c)
+	greater := combat.CoverGoal(mk(combat.CoverTierGreater), c)
+	assert.Less(t, none, lesser)
+	assert.Less(t, lesser, standard)
+	assert.Less(t, standard, greater)
+	assert.InDelta(t, 1.0, greater, 0.001)
+}
+
+// ─── SpreadGoal ──────────────────────────────────────────────────────────────
+
+func TestSpreadGoal_NoAlliesFullScore(t *testing.T) {
+	actor := &combat.Combatant{ID: "n1", GridX: 5, GridY: 5}
+	score := combat.SpreadGoal(combat.MoveContext{}, actor, combat.GridCell{X: 5, Y: 5})
+	assert.InDelta(t, 1.0, score, 0.001)
+}
+
+func TestSpreadGoal_AdjacentAllyLowScore(t *testing.T) {
+	actor := &combat.Combatant{ID: "n1", GridX: 5, GridY: 5, FactionID: "thugs", MaxHP: 10, CurrentHP: 10, Kind: combat.KindNPC}
+	ally := &combat.Combatant{ID: "n2", GridX: 5, GridY: 6, FactionID: "thugs", MaxHP: 10, CurrentHP: 10, Kind: combat.KindNPC}
+	ctx := combat.MoveContext{Allies: []*combat.Combatant{ally}}
+	atActor := combat.SpreadGoal(ctx, actor, combat.GridCell{X: 5, Y: 5})
+	farAway := combat.SpreadGoal(ctx, actor, combat.GridCell{X: 5, Y: 11})
+	assert.Less(t, atActor, farAway,
+		"a cell adjacent to an ally must score lower than a cell 6 cells away")
+}
+
+func TestSpreadGoal_DifferentFactionIgnored(t *testing.T) {
+	actor := &combat.Combatant{ID: "n1", GridX: 5, GridY: 5, FactionID: "thugs", MaxHP: 10, CurrentHP: 10, Kind: combat.KindNPC}
+	other := &combat.Combatant{ID: "n2", GridX: 5, GridY: 6, FactionID: "guards", MaxHP: 10, CurrentHP: 10, Kind: combat.KindNPC}
+	ctx := combat.MoveContext{Allies: []*combat.Combatant{other}}
+	score := combat.SpreadGoal(ctx, actor, combat.GridCell{X: 5, Y: 5})
+	assert.InDelta(t, 1.0, score, 0.001, "non-faction combatants must not affect spread")
+}
+
+// ─── TerrainGoal ─────────────────────────────────────────────────────────────
+
+func TestTerrainGoal_NormalUntilTerrainPopulated(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	assert.InDelta(t, 1.0, combat.TerrainGoal(cbt, combat.GridCell{X: 3, Y: 3}), 0.001)
+}
+
+func TestTerrainGoal_DifficultHalfScore(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	cbt.Terrain = map[combat.GridCell]*combat.TerrainCell{
+		{X: 3, Y: 3}: {X: 3, Y: 3, Type: combat.TerrainDifficult},
+	}
+	assert.InDelta(t, 0.5, combat.TerrainGoal(cbt, combat.GridCell{X: 3, Y: 3}), 0.001)
+}
+
+func TestTerrainGoal_HazardousZeroScore(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	cbt.Terrain = map[combat.GridCell]*combat.TerrainCell{
+		{X: 3, Y: 3}: {X: 3, Y: 3, Type: combat.TerrainHazardous},
+	}
+	assert.InDelta(t, 0.0, combat.TerrainGoal(cbt, combat.GridCell{X: 3, Y: 3}), 0.001)
+}
+
+// ─── ChooseMoveDestination ───────────────────────────────────────────────────
+
+func TestChooseMoveDestination_MeleeClosesDistance(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 0, 10)
+	pl := addCombatant(cbt, "p1", combat.KindPlayer, 19, 10)
+	dest := combat.ChooseMoveDestination(cbt, npc, pl, combat.MoveContext{RangeIncrementFt: 0}, false)
+	require.NotNil(t, dest, "melee NPC far from target should choose to move")
+	// New cell should reduce Chebyshev distance to player.
+	oldDist := chebyshev(combat.GridCell{X: npc.GridX, Y: npc.GridY},
+		combat.GridCell{X: pl.GridX, Y: pl.GridY})
+	newDist := chebyshev(*dest, combat.GridCell{X: pl.GridX, Y: pl.GridY})
+	assert.Less(t, newDist, oldDist, "melee NPC should close distance to target")
+}
+
+func TestChooseMoveDestination_RangedSeeksIncrementDistance(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 8, 10) // 1 cell from player
+	pl := addCombatant(cbt, "p1", combat.KindPlayer, 9, 10)
+	dest := combat.ChooseMoveDestination(cbt, npc, pl,
+		combat.MoveContext{RangeIncrementFt: 30}, false)
+	require.NotNil(t, dest, "ranged NPC at point-blank should move")
+	// Should move farther from the player, not closer.
+	oldDist := chebyshev(combat.GridCell{X: npc.GridX, Y: npc.GridY},
+		combat.GridCell{X: pl.GridX, Y: pl.GridY})
+	newDist := chebyshev(*dest, combat.GridCell{X: pl.GridX, Y: pl.GridY})
+	assert.Greater(t, newDist, oldDist, "ranged NPC should retreat from point-blank")
+}
+
+func TestChooseMoveDestination_NilTargetReturnsNil(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 5)
+	dest := combat.ChooseMoveDestination(cbt, npc, nil, combat.MoveContext{}, false)
+	assert.Nil(t, dest)
+}
+
+func TestChooseMoveDestination_HazardousNeverChosen(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 5)
+	pl := addCombatant(cbt, "p1", combat.KindPlayer, 19, 5)
+	// Surround the optimal "+x" route with hazardous terrain so the chooser
+	// must avoid it. Place hazardous cells at all (x, 5) for x in [6..15].
+	cbt.Terrain = map[combat.GridCell]*combat.TerrainCell{}
+	for x := 6; x <= 15; x++ {
+		cbt.Terrain[combat.GridCell{X: x, Y: 5}] = &combat.TerrainCell{X: x, Y: 5, Type: combat.TerrainHazardous}
+	}
+	dest := combat.ChooseMoveDestination(cbt, npc, pl, combat.MoveContext{}, false)
+	require.NotNil(t, dest)
+	tc := cbt.TerrainAt(dest.X, dest.Y)
+	assert.NotEqual(t, combat.TerrainHazardous, tc.Type,
+		"hazardous terrain must never be chosen as a destination")
+}
+
+func TestChooseMoveDestination_FleeReversesRangeGoal(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 10)
+	pl := addCombatant(cbt, "p1", combat.KindPlayer, 6, 10) // adjacent
+	// Without fleeing, melee NPC stays adjacent (no improvement available).
+	// With flipRange=true, the NPC seeks distance.
+	dest := combat.ChooseMoveDestination(cbt, npc, pl,
+		combat.MoveContext{RangeIncrementFt: 0}, true)
+	require.NotNil(t, dest, "fleeing NPC adjacent to enemy should move")
+	oldDist := chebyshev(combat.GridCell{X: npc.GridX, Y: npc.GridY},
+		combat.GridCell{X: pl.GridX, Y: pl.GridY})
+	newDist := chebyshev(*dest, combat.GridCell{X: pl.GridX, Y: pl.GridY})
+	assert.Greater(t, newDist, oldDist, "fleeing NPC should increase distance to enemy")
+}
+
+func TestChooseMoveDestination_EpsilonStayPut(t *testing.T) {
+	// When the actor is already at an optimal position (melee adjacent to
+	// target on open terrain with no allies), chooseMoveDestination should
+	// return nil rather than picking a tied cell.
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 10)
+	addCombatant(cbt, "p1", combat.KindPlayer, 6, 10)
+	dest := combat.ChooseMoveDestination(cbt, npc, cbt.Combatants[1],
+		combat.MoveContext{RangeIncrementFt: 0}, false)
+	assert.Nil(t, dest, "melee NPC already adjacent should stay put (MOVE-20)")
+}
+
+// chebyshev mirrors the package-private helper for use in tests.
+func chebyshev(a, b combat.GridCell) int {
+	dx := a.X - b.X
+	if dx < 0 {
+		dx = -dx
+	}
+	dy := a.Y - b.Y
+	if dy < 0 {
+		dy = -dy
+	}
+	if dx > dy {
+		return dx
+	}
+	return dy
+}
+
+// ─── Property tests ──────────────────────────────────────────────────────────
+
+func TestProperty_ChooseMoveDestination_Determinism(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 5)
+	pl := addCombatant(cbt, "p1", combat.KindPlayer, 12, 12)
+	ctx := combat.MoveContext{RangeIncrementFt: 30}
+	a := combat.ChooseMoveDestination(cbt, npc, pl, ctx, false)
+	b := combat.ChooseMoveDestination(cbt, npc, pl, ctx, false)
+	require.Equal(t, a, b, "same state must produce same destination")
+}
+
+func TestProperty_ChooseMoveDestination_BoundedByCandidates(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 5)
+	pl := addCombatant(cbt, "p1", combat.KindPlayer, 12, 12)
+	candidates := combat.CandidateCells(cbt, npc)
+	d := combat.ChooseMoveDestination(cbt, npc, pl, combat.MoveContext{}, false)
+	if d == nil {
+		return
+	}
+	assert.True(t, containsCell(candidates, *d),
+		"chosen destination must be in the candidate set")
+}
+
+func TestProperty_ChooseMoveDestination_StrideBudgetRespected(t *testing.T) {
+	cbt := newMovementCombat(20, 20)
+	npc := addCombatant(cbt, "n1", combat.KindNPC, 5, 5)
+	pl := addCombatant(cbt, "p1", combat.KindPlayer, 19, 19)
+	d := combat.ChooseMoveDestination(cbt, npc, pl, combat.MoveContext{}, false)
+	if d == nil {
+		return
+	}
+	dist := chebyshev(combat.GridCell{X: npc.GridX, Y: npc.GridY}, *d)
+	maxReach := npc.SpeedBudget() * combat.MaxMovementAP
+	assert.LessOrEqual(t, dist, maxReach,
+		"destination Chebyshev distance must fit inside total stride budget")
+}

--- a/internal/gameserver/combat_handler.go
+++ b/internal/gameserver/combat_handler.go
@@ -4381,35 +4381,92 @@ func (h *CombatHandler) maybeBroadcastTauntLocked(cbt *combat.Combat, c *combat.
 	}})
 }
 
-// npcMovementStrideLocked returns the stride direction needed for the NPC combatant
-// based on its current weapon type and distance to the nearest living player.
+// npcMovementStrideLocked returns the stride direction needed for the NPC
+// combatant based on the smarter goal-based chooser (combat.ChooseMoveDestination).
+// The chooser scores all reachable cells against four weighted goals — range,
+// cover, spread, and terrain — and the wrapper translates the chosen cell back
+// into the legacy "toward" / "away" string consumed by the existing stride
+// loop in round.go. Returns "" when the chooser opts to stay put.
 //
-// Rules:
-//   - Melee weapon (RangeIncrement == 0): stride "toward" when distance > 5 feet.
-//   - Ranged weapon (RangeIncrement > 0): stride "away" when distance <= 5 feet.
-//   - Returns "" when no stride is needed.
+// The chooser falls back to the previous melee-closes / ranged-retreats heuristic
+// in degenerate cases (no target, single-cell candidate set), preserving the
+// existing behavioural envelope while letting the goal-weighted picker handle
+// terrain, cover, and faction-spread decisions.
 //
-// Precondition: h.combatMu is held; c must not be nil.
+// Precondition: h.combatMu is held; cbt and c must not be nil.
 // Postcondition: Returns "toward", "away", or "".
 func (h *CombatHandler) npcMovementStrideLocked(cbt *combat.Combat, c *combat.Combatant) string {
-	isRanged := false
-	if inst, ok := h.npcMgr.Get(c.ID); ok && inst.WeaponID != "" && h.invRegistry != nil {
-		if wDef := h.invRegistry.Weapon(inst.WeaponID); wDef != nil && wDef.RangeIncrement > 0 {
-			isRanged = true
+	if cbt == nil || c == nil {
+		return ""
+	}
+	rangeIncrementFt := 0
+	useCover := false
+	if inst, ok := h.npcMgr.Get(c.ID); ok {
+		useCover = inst.UseCover
+		if inst.WeaponID != "" && h.invRegistry != nil {
+			if wDef := h.invRegistry.Weapon(inst.WeaponID); wDef != nil {
+				rangeIncrementFt = wDef.RangeIncrement
+			}
 		}
 	}
-	playerDist := 25 // fallback if no living player found
+
+	var target *combat.Combatant
 	for _, comb := range cbt.Combatants {
 		if comb.Kind == combat.KindPlayer && !comb.IsDead() {
-			playerDist = combat.CombatRange(*c, *comb)
+			target = comb
 			break
 		}
 	}
-	if !isRanged && playerDist > 5 {
+	if target == nil {
+		return ""
+	}
+
+	allies := make([]*combat.Combatant, 0, len(cbt.Combatants))
+	for _, comb := range cbt.Combatants {
+		if comb == c || comb.IsDead() || comb.Kind != c.Kind {
+			continue
+		}
+		allies = append(allies, comb)
+	}
+
+	ctx := combat.MoveContext{
+		RangeIncrementFt: rangeIncrementFt,
+		UseCover:         useCover,
+		Allies:           allies,
+		// CoverTierAt left nil until #247 ships its positional cover model;
+		// CoverGoal returns 0 in that case.
+		// Weights left zero — DefaultMoveWeights apply.
+	}
+
+	dest := combat.ChooseMoveDestination(cbt, c, target, ctx, false)
+	if dest == nil {
+		return ""
+	}
+
+	// Translate the chosen destination into the legacy "toward"/"away" string.
+	// The existing stride loop steps one cell at a time using CompassDelta
+	// against the current target, so we just need to know whether the chosen
+	// destination is closer to or farther from the target than the actor's
+	// current position.
+	curDist := combat.CombatRange(*c, *target)
+	destC := *c
+	destC.GridX = dest.X
+	destC.GridY = dest.Y
+	newDist := combat.CombatRange(destC, *target)
+	if newDist < curDist {
 		return "toward"
 	}
-	if isRanged && playerDist <= 5 && playerDist < combat.MaxCombatRange {
+	if newDist > curDist {
 		return "away"
+	}
+	// Lateral move (newDist == curDist). The stride loop only knows
+	// "toward"/"away"; pick the direction that the legacy heuristic would
+	// have chosen so we don't regress melee-closes / ranged-retreats.
+	if rangeIncrementFt > 0 && curDist <= 5 && curDist < combat.MaxCombatRange {
+		return "away"
+	}
+	if rangeIncrementFt == 0 && curDist > 5 {
+		return "toward"
 	}
 	return ""
 }

--- a/internal/gameserver/grpc_service_stride_test.go
+++ b/internal/gameserver/grpc_service_stride_test.go
@@ -380,13 +380,19 @@ func TestNPCAutoStride_MeleeNPC_ClosesDistance(t *testing.T) {
 	assert.Equal(t, combat.ActionAttack, actions[1].Type, "second action must be ActionAttack")
 }
 
-// TestNPCAutoStride_RangedNPC_DoesNotStride verifies that an NPC equipped with a
-// ranged weapon does NOT queue ActionStride even when distance > 5ft.
+// TestNPCAutoStride_RangedNPC_StridesAwayWhenInsideOptimalRange verifies that an NPC
+// equipped with a ranged weapon strides "away" when its current distance to the target
+// is well inside its preferred range increment (#251 smarter NPC movement). Previously
+// this test asserted the NPC would NOT stride at distance > 5ft, but the goal-based
+// chooser correctly backs the NPC off toward its first range increment. The legacy
+// "only retreat when within 5ft" behaviour is preserved at the wrapper boundary only
+// when the chooser produces no preferred destination.
 //
-// Precondition: NPC WeaponID references a WeaponDef with RangeIncrement > 0; player at (0,0), NPC at (2,0)
-// (Chebyshev dist=10ft > 5ft).
-// Postcondition: NPC action queue starts directly with ActionAttack (no ActionStride).
-func TestNPCAutoStride_RangedNPC_DoesNotStride(t *testing.T) {
+// Precondition: NPC WeaponID references a WeaponDef with RangeIncrement = 60ft; player at (0,0),
+// NPC at (2,0) (Chebyshev dist=10ft, well inside the 60ft / 12-cell preferred range).
+// Postcondition: NPC action queue prepends an ActionStride{Direction: "away"} so the NPC
+// retreats toward its preferred firing distance.
+func TestNPCAutoStride_RangedNPC_StridesAwayWhenInsideOptimalRange(t *testing.T) {
 	reg := inventory.NewRegistry()
 	bowDef := &inventory.WeaponDef{
 		ID:             "shortbow",
@@ -436,7 +442,11 @@ func TestNPCAutoStride_RangedNPC_DoesNotStride(t *testing.T) {
 	require.NotNil(t, q, "expected an action queue for the NPC")
 	actions := q.QueuedActions()
 	require.NotEmpty(t, actions, "expected at least one action in queue")
-	assert.Equal(t, combat.ActionAttack, actions[0].Type, "first action must be ActionAttack (no stride for ranged NPC)")
+	require.GreaterOrEqual(t, len(actions), 2,
+		"expected at least Stride+Attack (the chooser should retreat toward optimal range)")
+	assert.Equal(t, combat.ActionStride, actions[0].Type, "first action must be ActionStride (chooser retreats toward optimal range)")
+	assert.Equal(t, "away", actions[0].Direction, "stride must be away from the target")
+	assert.Equal(t, combat.ActionAttack, actions[1].Type, "second action must be ActionAttack")
 }
 
 // TestHandleStride_ReactiveStrike verifies that when a player strides away from an


### PR DESCRIPTION
Closes #251. candidateCells + 4 goal functions (range/cover/spread/terrain) + ChooseMoveDestination. NPC stride wired through chooser. HTN MoveScores + per-template YAML move_weights deferred to follow-up.