### PR TITLE
feat(skillaction): ActionDef framework + Demoralize exemplar (#252)

### DIFF
--- a/content/skill_actions/demoralize.yaml
+++ b/content/skill_actions/demoralize.yaml
@@ -1,0 +1,40 @@
+id: demoralize
+display_name: Demoralize
+description: |
+  Cow your foe with a verbal threat, harsh stare, or display of dominance.
+  On a successful smooth_talk check vs the target's Cool DC, the target
+  becomes Frightened — penalising their attacks and AC for the encounter.
+ap_cost: 1
+skill: smooth_talk
+dc:
+  kind: target_will
+range:
+  kind: ranged
+  feet: 30
+target_kinds:
+  - npc
+outcomes:
+  crit_success:
+    effects:
+      - apply_condition:
+          id: frightened
+          stacks: 2
+          duration_rounds: -1
+      - narrative:
+          text: "{actor}'s words shatter {target}'s composure. ({target} is Frightened 2.)"
+  success:
+    effects:
+      - apply_condition:
+          id: frightened
+          stacks: 1
+          duration_rounds: -1
+      - narrative:
+          text: "{actor} unnerves {target}. ({target} is Frightened 1.)"
+  failure:
+    effects:
+      - narrative:
+          text: "{actor}'s threats fall flat."
+  crit_failure:
+    effects:
+      - narrative:
+          text: "{actor}'s posturing only emboldens {target}."

--- a/docs/architecture/combat.md
+++ b/docs/architecture/combat.md
@@ -606,3 +606,104 @@ The targeting subsystem (`internal/game/combat/targeting.go`, `internal/game/com
 ### Wiring status
 
 The handler wiring (telnet `attack` / `strike` / `use` and the corresponding gRPC handlers) is **deferred to a follow-up of #249**. The same follow-up brings telnet/web `target` commands, AoE-cell validation, and feat/tech YAML targeting blocks online. The seam shipped in this iteration is the type and helper surface only.
+
+## Skill Actions Against Combat NPCs (#252 MVP)
+
+The `internal/game/skillaction/` package is the unified, data-driven framework
+for non-combat (skill-based) actions taken against combat NPCs (Demoralize,
+Feint, Trip, Recall Knowledge, etc). The MVP lands the framework plus
+**Demoralize** as the exemplar; the remaining actions and the discovery RPC
+(`ListCombatActions`), telnet `skills` command, web Skill Actions submenu,
+telemetry, and the Task 6 audit-and-migrate of the eight other handlers are
+deferred to follow-ups of #252.
+
+### Pipeline
+
+```
+bindSkillAction
+  → ValidateTarget          (target_kind + range + presence/liveness/allegiance + LoF seam)
+  → spendAP                 (legacy combat handler)
+  → Resolve                 (DoS computation + outcome lookup)
+  → Apply effects           (ApplyCondition / Damage / Move / Narrative / Reveal)
+  → emit narrative + log
+  → refund AP if Outcome.APRefund (NCA-33)
+```
+
+`Resolve` itself is pure: every side-effect is dispatched via the
+`ResolveContext.Apply` callback supplied by the handler. This keeps the
+functional core deterministic and trivially testable.
+
+### Degree of Success (NCA-7)
+
+`skillaction.DoS(roll, bonus, dc)` returns the four-tier PF2E result band:
+
+| Total vs DC | Band         |
+|-------------|--------------|
+| `>= dc+10`  | CritSuccess  |
+| `>= dc`     | Success      |
+| `>= dc-10`  | Failure      |
+| `<  dc-10`  | CritFailure  |
+
+The natural-1 / natural-20 step rule applies after band computation: nat 20
+bumps the result up one step (capped at CritSuccess); nat 1 bumps the result
+down one step (capped at CritFailure).
+
+### ActionDef YAML schema
+
+Each action lives at `content/skill_actions/<id>.yaml` and is loaded via
+`skillaction.LoadDirectory`. The loader validates that every
+`apply_condition.id` resolves against the live `condition.Registry` and that
+all numeric fields (ap_cost, stacks, durations, fixed DCs, range feet) are
+non-negative. See `content/skill_actions/demoralize.yaml` for the canonical
+example.
+
+Effect kinds supported by the `EffectEntry` discriminated union:
+
+- `apply_condition` — adds a stacked condition with a duration in rounds
+  (`-1` = until removed).
+- `narrative` — emits a player-facing line. `{actor}` and `{target}` are
+  substituted at resolve time.
+- `damage` — rolls and applies an HP damage formula (deferred wiring; the
+  damage routing lives in #246's `combat.ResolveDamage`).
+- `move` — shifts the target by a number of feet.
+- `reveal` — Recall Knowledge; surfaces NPC-metadata facts to a per-session
+  store (deferred wiring).
+
+### Target validation (NCA-12 / NCA-15 / NCA-16)
+
+`skillaction.ValidateTarget` composes:
+
+1. **Target-kind filter** — `npc` / `player` / `any` / `self`.
+2. **Range gate** — `melee_reach` (5 ft / adjacency), `ranged` (≤ feet),
+   `self`.
+3. **Standard combat target pipeline** — delegates to
+   `combat.ValidateSingleTarget` for presence, liveness, allegiance, and
+   distance, plus the line-of-fire seam (`PostValidateTarget`, currently a
+   no-op until #267 lands).
+
+Failures return a structured `*PreconditionError{Field, Detail}` that the
+handler surfaces to the client without consuming AP (NCA-17).
+
+### MVP scope (#252)
+
+Shipped in this iteration:
+
+- `internal/game/skillaction/` — `def.go`, `loader.go`, `dos.go`, `target.go`,
+  `resolve.go` plus full unit tests.
+- `content/skill_actions/demoralize.yaml` — the canonical Demoralize def with
+  the Frightened 1 / Frightened 2 ladder.
+- `internal/gameserver/skillaction_catalog.go` — process-wide lazy-loaded
+  catalog keyed off the existing condition registry.
+- `handleDemoralize` integration — on success, the unified pipeline applies
+  the canonical Frightened condition through `CombatHandler.ApplyConditionToNPC`
+  in addition to the legacy `ACMod` / `AttackMod` flat decrements (preserved
+  for backward compatibility until Task 6's audit-and-migrate completes).
+
+Deferred (tracked as follow-ups of #252):
+
+- Tasks 5/6/8/9/10 — `ListCombatActions` RPC, audit-and-migrate of the eight
+  other handlers, telnet `skills` command, web Skill Actions submenu,
+  structured telemetry.
+- Task 7 (other actions) — Feint, Trip, Grapple, Recall Knowledge defs.
+- The full canonical condition catalog (off_guard, clumsy, stupefied, etc.)
+  beyond the four already present (frightened, fleeing, grabbed, prone).

--- a/internal/game/skillaction/def.go
+++ b/internal/game/skillaction/def.go
@@ -1,0 +1,223 @@
+// Package skillaction provides a unified, data-driven framework for resolving
+// non-combat (skill-based) actions taken against combat NPCs.
+//
+// An ActionDef is the YAML-loaded static description of a single skill action
+// (Demoralize, Feint, Trip, Recall Knowledge, ...). The ActionDef enumerates
+// the AP cost, the skill exercised, the DC source, the range / target kind
+// requirements, and a per-degree-of-success outcome map. The Resolver walks
+// that outcome map after a DoS computation to drive a small effect-application
+// callback (ApplyCondition / Damage / Move / Narrative / Reveal).
+//
+// The package is the functional core; all mutation lives behind the
+// ResolveContext.Apply callback so that Resolve itself can stay deterministic
+// and pure (NCA-11). See docs/architecture/combat.md for the full pipeline.
+package skillaction
+
+import (
+	"fmt"
+)
+
+// DegreeOfSuccess is the four-tier PF2E result band.
+//
+// The integer values intentionally match the ordering used by skillcheck.CheckOutcome
+// (CritSuccess=0, Success=1, Failure=2, CritFailure=3).
+type DegreeOfSuccess int
+
+const (
+	CritSuccess DegreeOfSuccess = iota
+	Success
+	Failure
+	CritFailure
+)
+
+// String returns the YAML-friendly snake_case name for the degree.
+func (d DegreeOfSuccess) String() string {
+	switch d {
+	case CritSuccess:
+		return "crit_success"
+	case Success:
+		return "success"
+	case Failure:
+		return "failure"
+	case CritFailure:
+		return "crit_failure"
+	default:
+		return "unknown"
+	}
+}
+
+// DCKind enumerates the supported DC source types.
+type DCKind string
+
+const (
+	DCKindFixed            DCKind = "fixed"             // literal value from def.DC.Value
+	DCKindTargetWill       DCKind = "target_will"       // 10 + level + Savvy mod + Cool rank bonus
+	DCKindTargetPerception DCKind = "target_perception" // 10 + level + Savvy mod + Awareness rank bonus
+	DCKindTargetAC         DCKind = "target_ac"         // raw target AC
+	DCKindFormula          DCKind = "formula"           // free-form expression (deferred)
+)
+
+// RangeKind enumerates the supported targeting ranges.
+type RangeKind string
+
+const (
+	RangeMelee  RangeKind = "melee_reach" // adjacent (≤5 ft)
+	RangeRanged RangeKind = "ranged"      // up to def.Range.Feet
+	RangeSelf   RangeKind = "self"        // actor only
+)
+
+// TargetKind enumerates the kinds of combatant the action may target.
+type TargetKind string
+
+const (
+	TargetKindNPC    TargetKind = "npc"
+	TargetKindPlayer TargetKind = "player"
+	TargetKindAny    TargetKind = "any"
+	TargetKindSelf   TargetKind = "self"
+)
+
+// DC describes how the difficulty class is computed at resolve time.
+type DC struct {
+	Kind  DCKind `yaml:"kind"`
+	Value int    `yaml:"value,omitempty"`
+	Expr  string `yaml:"expr,omitempty"`
+}
+
+// Range describes the legal actor↔target distance.
+type Range struct {
+	Kind RangeKind `yaml:"kind"`
+	Feet int       `yaml:"feet,omitempty"`
+}
+
+// Effect is the discriminated union of side-effects produced by a successful
+// (or failed) outcome. The wire format uses one effect kind per YAML map entry
+// — see UnmarshalYAML on EffectEntry.
+type Effect interface {
+	effect()
+}
+
+// ApplyCondition adds a condition (by canonical ID) to the target, with a
+// stack count and a duration in rounds. Duration -1 means "until removed".
+type ApplyCondition struct {
+	ID             string `yaml:"id"`
+	Stacks         int    `yaml:"stacks,omitempty"`
+	DurationRounds int    `yaml:"duration_rounds,omitempty"`
+}
+
+func (ApplyCondition) effect() {}
+
+// Narrative emits a player-facing line. May contain {actor}/{target} placeholders.
+type Narrative struct {
+	Text string `yaml:"text"`
+}
+
+func (Narrative) effect() {}
+
+// Damage rolls and applies an HP damage formula to the target.
+type Damage struct {
+	Expr string `yaml:"expr"`
+}
+
+func (Damage) effect() {}
+
+// Move shifts the target by a number of feet (positive = away from actor).
+type Move struct {
+	Feet int `yaml:"feet"`
+}
+
+func (Move) effect() {}
+
+// Reveal exposes a number of NPC-metadata facts (Recall Knowledge).
+type Reveal struct {
+	Count int `yaml:"count"`
+}
+
+func (Reveal) effect() {}
+
+// OutcomeDef enumerates the side-effects of a single degree band, plus
+// optional flags such as ap_refund (NCA-33).
+type OutcomeDef struct {
+	APRefund  bool      `yaml:"ap_refund,omitempty"`
+	Effects   []Effect  `yaml:"-"`
+	Narrative string    `yaml:"-"` // resolved narrative shortcut
+	rawEffects []EffectEntry
+}
+
+// ActionDef is the full static description of one skill action.
+type ActionDef struct {
+	ID          string                              `yaml:"id"`
+	DisplayName string                              `yaml:"display_name"`
+	Description string                              `yaml:"description"`
+	APCost      int                                 `yaml:"ap_cost"`
+	Skill       string                              `yaml:"skill"`
+	DC          DC                                  `yaml:"dc"`
+	Range       Range                               `yaml:"range"`
+	TargetKinds []TargetKind                        `yaml:"target_kinds"`
+	Outcomes    map[DegreeOfSuccess]*OutcomeDef     `yaml:"-"`
+	rawOutcomes map[string]rawOutcome
+}
+
+type rawOutcome struct {
+	APRefund bool          `yaml:"ap_refund,omitempty"`
+	Effects  []EffectEntry `yaml:"effects,omitempty"`
+}
+
+// EffectEntry is the wire form of one Effect. Each YAML mapping has exactly
+// one of the known keys (apply_condition / narrative / damage / move / reveal).
+type EffectEntry struct {
+	ApplyCondition *ApplyCondition `yaml:"apply_condition,omitempty"`
+	Narrative      *Narrative      `yaml:"narrative,omitempty"`
+	Damage         *Damage         `yaml:"damage,omitempty"`
+	Move           *Move           `yaml:"move,omitempty"`
+	Reveal         *Reveal         `yaml:"reveal,omitempty"`
+}
+
+// ToEffect collapses an EffectEntry to its single non-nil Effect, or returns
+// an error if zero or multiple effect kinds are populated.
+func (e EffectEntry) ToEffect() (Effect, error) {
+	count := 0
+	var out Effect
+	if e.ApplyCondition != nil {
+		count++
+		out = *e.ApplyCondition
+	}
+	if e.Narrative != nil {
+		count++
+		out = *e.Narrative
+	}
+	if e.Damage != nil {
+		count++
+		out = *e.Damage
+	}
+	if e.Move != nil {
+		count++
+		out = *e.Move
+	}
+	if e.Reveal != nil {
+		count++
+		out = *e.Reveal
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("effect entry has no recognised kind")
+	}
+	if count > 1 {
+		return nil, fmt.Errorf("effect entry has %d kinds; exactly one is required", count)
+	}
+	return out, nil
+}
+
+// parseDegree maps the YAML key onto a DegreeOfSuccess.
+func parseDegree(s string) (DegreeOfSuccess, error) {
+	switch s {
+	case "crit_success":
+		return CritSuccess, nil
+	case "success":
+		return Success, nil
+	case "failure":
+		return Failure, nil
+	case "crit_failure":
+		return CritFailure, nil
+	default:
+		return 0, fmt.Errorf("unknown degree of success %q", s)
+	}
+}

--- a/internal/game/skillaction/dos.go
+++ b/internal/game/skillaction/dos.go
@@ -1,0 +1,59 @@
+package skillaction
+
+// DoS computes the four-tier degree-of-success result from a d20 roll, an
+// additive bonus, and a target DC, applying the PF2E natural-1 / natural-20
+// step rule per spec NCA-7.
+//
+// Bands are:
+//   total >= dc+10 → CritSuccess
+//   total >= dc    → Success
+//   total >= dc-10 → Failure
+//   total <  dc-10 → CritFailure
+//
+// Then:
+//   nat 20 bumps the result up one step (capped at CritSuccess);
+//   nat 1  bumps the result down one step (capped at CritFailure).
+//
+// Precondition: roll is the raw d20 value (typically 1..20); bonus and dc may be any int.
+// Postcondition: returned value is one of {CritSuccess, Success, Failure, CritFailure}.
+func DoS(roll, bonus, dc int) DegreeOfSuccess {
+	total := roll + bonus
+	band := computeBand(total, dc) // 2 = critSuccess, 1 = success, 0 = failure, -1 = critFailure
+	switch roll {
+	case 20:
+		if band < 2 {
+			band++
+		}
+	case 1:
+		if band > -1 {
+			band--
+		}
+	}
+	return bandToDoS(band)
+}
+
+func computeBand(total, dc int) int {
+	switch {
+	case total >= dc+10:
+		return 2
+	case total >= dc:
+		return 1
+	case total >= dc-10:
+		return 0
+	default:
+		return -1
+	}
+}
+
+func bandToDoS(b int) DegreeOfSuccess {
+	switch b {
+	case 2:
+		return CritSuccess
+	case 1:
+		return Success
+	case 0:
+		return Failure
+	default:
+		return CritFailure
+	}
+}

--- a/internal/game/skillaction/dos_test.go
+++ b/internal/game/skillaction/dos_test.go
@@ -1,0 +1,54 @@
+package skillaction_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cory-johannsen/mud/internal/game/skillaction"
+)
+
+func TestDoS_PlusTenIsCritSuccess(t *testing.T) {
+	require.Equal(t, skillaction.CritSuccess, skillaction.DoS(15, 5, 10)) // 20 vs 10 → +10 → crit success
+}
+
+func TestDoS_HitDcIsSuccess(t *testing.T) {
+	require.Equal(t, skillaction.Success, skillaction.DoS(10, 0, 10))
+}
+
+func TestDoS_OneShortIsFailure(t *testing.T) {
+	require.Equal(t, skillaction.Failure, skillaction.DoS(9, 0, 10))
+}
+
+func TestDoS_MinusTenIsCritFailure(t *testing.T) {
+	require.Equal(t, skillaction.CritFailure, skillaction.DoS(2, 0, 15)) // 2 vs 15 → -13 → crit failure
+}
+
+func TestDoS_Nat20BumpsFailureToSuccess(t *testing.T) {
+	// roll 20 + bonus 0 vs DC 30 → raw failure (20 vs 30 in -10..0 band).
+	// Nat 20 bumps one step → success.
+	require.Equal(t, skillaction.Success, skillaction.DoS(20, 0, 30))
+}
+
+func TestDoS_Nat20OnSuccessBumpsToCritSuccess(t *testing.T) {
+	// roll 20 + bonus 0 vs DC 15 → raw success; nat 20 → crit success.
+	require.Equal(t, skillaction.CritSuccess, skillaction.DoS(20, 0, 15))
+}
+
+func TestDoS_Nat20OnCritStaysCrit(t *testing.T) {
+	require.Equal(t, skillaction.CritSuccess, skillaction.DoS(20, 20, 15))
+}
+
+func TestDoS_Nat1OnCritFailureStaysCritFailure(t *testing.T) {
+	require.Equal(t, skillaction.CritFailure, skillaction.DoS(1, 0, 15))
+}
+
+func TestDoS_Nat1OnCritSuccessBumpsDownToSuccess(t *testing.T) {
+	// roll 1 + bonus 30 vs DC 10 → raw crit success (31 vs 10); nat 1 → success.
+	require.Equal(t, skillaction.Success, skillaction.DoS(1, 30, 10))
+}
+
+func TestDoS_Nat1OnSuccessBumpsDownToFailure(t *testing.T) {
+	// roll 1 + bonus 12 vs DC 10 → raw success (13 vs 10); nat 1 → failure.
+	require.Equal(t, skillaction.Failure, skillaction.DoS(1, 12, 10))
+}

--- a/internal/game/skillaction/loader.go
+++ b/internal/game/skillaction/loader.go
@@ -1,0 +1,147 @@
+package skillaction
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cory-johannsen/mud/internal/game/condition"
+)
+
+// rawActionDef is the on-disk YAML shape for an ActionDef. The wire format
+// uses string keys for the outcome map; we project to typed enums in Load.
+type rawActionDef struct {
+	ID          string                `yaml:"id"`
+	DisplayName string                `yaml:"display_name"`
+	Description string                `yaml:"description"`
+	APCost      int                   `yaml:"ap_cost"`
+	Skill       string                `yaml:"skill"`
+	DC          DC                    `yaml:"dc"`
+	Range       Range                 `yaml:"range"`
+	TargetKinds []TargetKind          `yaml:"target_kinds"`
+	Outcomes    map[string]rawOutcome `yaml:"outcomes"`
+}
+
+// Load parses a single ActionDef from a YAML byte slice. When condReg is non-nil
+// every apply_condition.id referenced is validated against it. Numeric fields
+// are checked for non-negativity per NCA-3.
+func Load(data []byte, condReg *condition.Registry) (*ActionDef, error) {
+	var raw rawActionDef
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if raw.ID == "" {
+		return nil, fmt.Errorf("action def: id is required")
+	}
+	if raw.APCost < 0 {
+		return nil, fmt.Errorf("action %q: ap_cost must be non-negative (got %d)", raw.ID, raw.APCost)
+	}
+	if raw.Skill == "" {
+		return nil, fmt.Errorf("action %q: skill is required", raw.ID)
+	}
+	if raw.DC.Kind == "" {
+		return nil, fmt.Errorf("action %q: dc.kind is required", raw.ID)
+	}
+	if raw.DC.Value < 0 {
+		return nil, fmt.Errorf("action %q: dc.value must be non-negative (got %d)", raw.ID, raw.DC.Value)
+	}
+	if raw.Range.Kind == "" {
+		return nil, fmt.Errorf("action %q: range.kind is required", raw.ID)
+	}
+	if raw.Range.Feet < 0 {
+		return nil, fmt.Errorf("action %q: range.feet must be non-negative (got %d)", raw.ID, raw.Range.Feet)
+	}
+	if len(raw.TargetKinds) == 0 {
+		return nil, fmt.Errorf("action %q: target_kinds must be non-empty", raw.ID)
+	}
+
+	def := &ActionDef{
+		ID:          raw.ID,
+		DisplayName: raw.DisplayName,
+		Description: raw.Description,
+		APCost:      raw.APCost,
+		Skill:       raw.Skill,
+		DC:          raw.DC,
+		Range:       raw.Range,
+		TargetKinds: raw.TargetKinds,
+		Outcomes:    make(map[DegreeOfSuccess]*OutcomeDef),
+	}
+	for k, v := range raw.Outcomes {
+		dos, err := parseDegree(k)
+		if err != nil {
+			return nil, fmt.Errorf("action %q: %w", raw.ID, err)
+		}
+		od := &OutcomeDef{APRefund: v.APRefund}
+		for i, e := range v.Effects {
+			eff, err := e.ToEffect()
+			if err != nil {
+				return nil, fmt.Errorf("action %q outcome %s effect %d: %w", raw.ID, k, i, err)
+			}
+			if ac, ok := eff.(ApplyCondition); ok {
+				if ac.ID == "" {
+					return nil, fmt.Errorf("action %q outcome %s: apply_condition.id is required", raw.ID, k)
+				}
+				if ac.Stacks < 0 {
+					return nil, fmt.Errorf("action %q outcome %s: apply_condition.stacks must be non-negative", raw.ID, k)
+				}
+				if condReg != nil && !condReg.Has(ac.ID) {
+					return nil, fmt.Errorf("action %q outcome %s: unknown condition %q (not_a_condition guard)", raw.ID, k, ac.ID)
+				}
+			}
+			if d, ok := eff.(Damage); ok && d.Expr == "" {
+				return nil, fmt.Errorf("action %q outcome %s: damage.expr is required", raw.ID, k)
+			}
+			if r, ok := eff.(Reveal); ok && r.Count <= 0 {
+				return nil, fmt.Errorf("action %q outcome %s: reveal.count must be positive", raw.ID, k)
+			}
+			od.Effects = append(od.Effects, eff)
+			if n, ok := eff.(Narrative); ok && od.Narrative == "" {
+				od.Narrative = n.Text
+			}
+		}
+		def.Outcomes[dos] = od
+	}
+	return def, nil
+}
+
+// LoadDirectory scans dir for *.yaml skill-action defs and returns them keyed by ID.
+// condReg, when non-nil, is used to validate every apply_condition.id reference.
+func LoadDirectory(dir string, condReg *condition.Registry) (map[string]*ActionDef, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir %q: %w", dir, err)
+	}
+	out := make(map[string]*ActionDef)
+	// Sort for deterministic load order — surfacing errors early on the first conflict.
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %q: %w", path, err)
+		}
+		def, err := Load(data, condReg)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		if _, dup := out[def.ID]; dup {
+			return nil, fmt.Errorf("%s: duplicate action id %q", name, def.ID)
+		}
+		out[def.ID] = def
+	}
+	return out, nil
+}

--- a/internal/game/skillaction/loader_test.go
+++ b/internal/game/skillaction/loader_test.go
@@ -1,0 +1,127 @@
+package skillaction_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cory-johannsen/mud/internal/game/condition"
+	"github.com/cory-johannsen/mud/internal/game/skillaction"
+)
+
+const demoralizeYAML = `
+id: demoralize
+display_name: Demoralize
+description: test
+ap_cost: 1
+skill: smooth_talk
+dc: { kind: target_will }
+range: { kind: ranged, feet: 30 }
+target_kinds: [npc]
+outcomes:
+  crit_success:
+    effects:
+      - apply_condition: { id: frightened, stacks: 2, duration_rounds: -1 }
+      - narrative: { text: "{actor} crushes {target}." }
+  success:
+    effects:
+      - apply_condition: { id: frightened, stacks: 1, duration_rounds: -1 }
+  failure:
+    effects:
+      - narrative: { text: "{actor} is unconvincing." }
+`
+
+// frightenedRegistry returns a Registry containing only the canonical
+// frightened condition, sufficient for loader validation tests.
+func frightenedRegistry(t *testing.T) *condition.Registry {
+	t.Helper()
+	reg := condition.NewRegistry()
+	reg.Register(&condition.ConditionDef{ID: "frightened", Name: "Frightened", MaxStacks: 4})
+	return reg
+}
+
+func TestLoad_AllFieldsParse(t *testing.T) {
+	def, err := skillaction.Load([]byte(demoralizeYAML), frightenedRegistry(t))
+	require.NoError(t, err)
+	require.Equal(t, "demoralize", def.ID)
+	require.Equal(t, 1, def.APCost)
+	require.Equal(t, skillaction.DCKindTargetWill, def.DC.Kind)
+	require.Equal(t, skillaction.RangeRanged, def.Range.Kind)
+	require.Equal(t, 30, def.Range.Feet)
+	require.Equal(t, []skillaction.TargetKind{skillaction.TargetKindNPC}, def.TargetKinds)
+
+	cs := def.Outcomes[skillaction.CritSuccess]
+	require.NotNil(t, cs)
+	require.Len(t, cs.Effects, 2)
+	ac, ok := cs.Effects[0].(skillaction.ApplyCondition)
+	require.True(t, ok)
+	require.Equal(t, "frightened", ac.ID)
+	require.Equal(t, 2, ac.Stacks)
+}
+
+func TestLoad_RejectsUnknownCondition(t *testing.T) {
+	bad := `
+id: bogus
+ap_cost: 1
+skill: smooth_talk
+dc: { kind: target_will }
+range: { kind: melee_reach }
+target_kinds: [npc]
+outcomes:
+  success:
+    effects:
+      - apply_condition: { id: not_a_condition, duration_rounds: 1 }
+`
+	_, err := skillaction.Load([]byte(bad), frightenedRegistry(t))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not_a_condition")
+}
+
+func TestLoad_RejectsNegativeAPCost(t *testing.T) {
+	bad := `
+id: bogus
+ap_cost: -1
+skill: smooth_talk
+dc: { kind: target_will }
+range: { kind: melee_reach }
+target_kinds: [npc]
+outcomes: {}
+`
+	_, err := skillaction.Load([]byte(bad), frightenedRegistry(t))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ap_cost")
+}
+
+func TestLoad_RejectsMultiKindEffect(t *testing.T) {
+	bad := `
+id: bogus
+ap_cost: 1
+skill: smooth_talk
+dc: { kind: target_will }
+range: { kind: melee_reach }
+target_kinds: [npc]
+outcomes:
+  success:
+    effects:
+      - apply_condition: { id: frightened, stacks: 1 }
+        narrative: { text: "x" }
+`
+	_, err := skillaction.Load([]byte(bad), frightenedRegistry(t))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "kinds")
+}
+
+func TestLoadDirectory_LoadsDemoralizeYAML(t *testing.T) {
+	// Write the canonical demoralize.yaml into a temp dir so the test is
+	// hermetic and does not depend on cwd.
+	dir := t.TempDir()
+	src, err := os.ReadFile(filepath.Join("..", "..", "..", "content", "skill_actions", "demoralize.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "demoralize.yaml"), src, 0o644))
+
+	defs, err := skillaction.LoadDirectory(dir, frightenedRegistry(t))
+	require.NoError(t, err)
+	require.Contains(t, defs, "demoralize")
+}

--- a/internal/game/skillaction/resolve.go
+++ b/internal/game/skillaction/resolve.go
@@ -1,0 +1,101 @@
+package skillaction
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Outcome is the structured result of a single Resolve call.
+type Outcome struct {
+	DoS       DegreeOfSuccess
+	Roll      int
+	Bonus     int
+	DC        int
+	Effects   []Effect // outcome's effect list (may be nil)
+	Narrative string   // chosen narrative line (placeholders already substituted)
+	APRefund  bool     // NCA-33: when true the wrapper SHOULD refund APCost
+}
+
+// ResolveContext carries the per-call inputs to Resolve. The Apply callback is
+// the side-effect dispatch hook — Resolve itself never mutates external state
+// (NCA-11).
+type ResolveContext struct {
+	ActorName  string
+	TargetName string
+	Apply      func(eff Effect) // optional; when nil, effects are still recorded on the Outcome
+}
+
+// Resolve runs the DoS computation and projects the matching OutcomeDef into
+// an Outcome. When ctx.Apply is non-nil, every effect is dispatched in YAML
+// order. Narrative substitution honours {actor} and {target} placeholders.
+//
+// Precondition: def != nil; def.Outcomes is populated (may omit any band — the
+// returned Outcome.Effects will be nil for missing bands, and the Narrative
+// will fall back to a generic template).
+func Resolve(ctx ResolveContext, def *ActionDef, roll, bonus, dc int) (Outcome, error) {
+	if def == nil {
+		return Outcome{}, fmt.Errorf("Resolve: def is nil")
+	}
+	dos := DoS(roll, bonus, dc)
+	out := Outcome{DoS: dos, Roll: roll, Bonus: bonus, DC: dc}
+	od := def.Outcomes[dos]
+	if od != nil {
+		out.Effects = od.Effects
+		out.APRefund = od.APRefund
+		if ctx.Apply != nil {
+			for _, eff := range od.Effects {
+				ctx.Apply(eff)
+			}
+		}
+		out.Narrative = renderNarrative(ctx, def, dos, od)
+	} else {
+		out.Narrative = fallbackNarrative(ctx, def, dos)
+	}
+	return out, nil
+}
+
+// renderNarrative picks the first Narrative effect's text in the outcome's
+// effect list, falls back to OutcomeDef.Narrative, and finally to the generic
+// template. {actor} / {target} placeholders are substituted.
+func renderNarrative(ctx ResolveContext, def *ActionDef, dos DegreeOfSuccess, od *OutcomeDef) string {
+	text := od.Narrative
+	if text == "" {
+		return fallbackNarrative(ctx, def, dos)
+	}
+	return substitute(ctx, text)
+}
+
+func fallbackNarrative(ctx ResolveContext, def *ActionDef, dos DegreeOfSuccess) string {
+	verb := "succeeds"
+	switch dos {
+	case CritSuccess:
+		verb = "succeeds critically"
+	case Success:
+		verb = "succeeds"
+	case Failure:
+		verb = "fails"
+	case CritFailure:
+		verb = "fails critically"
+	}
+	display := def.DisplayName
+	if display == "" {
+		display = def.ID
+	}
+	if ctx.TargetName != "" {
+		return fmt.Sprintf("%s %s %s against %s.", nameOr(ctx.ActorName, "Someone"), verb, display, ctx.TargetName)
+	}
+	return fmt.Sprintf("%s %s %s.", nameOr(ctx.ActorName, "Someone"), verb, display)
+}
+
+func substitute(ctx ResolveContext, s string) string {
+	s = strings.ReplaceAll(s, "{actor}", nameOr(ctx.ActorName, "the actor"))
+	s = strings.ReplaceAll(s, "{target}", nameOr(ctx.TargetName, "the target"))
+	return s
+}
+
+func nameOr(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}

--- a/internal/game/skillaction/resolve_test.go
+++ b/internal/game/skillaction/resolve_test.go
@@ -1,0 +1,65 @@
+package skillaction_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cory-johannsen/mud/internal/game/skillaction"
+)
+
+func TestResolve_AppliesEffectsInOrder(t *testing.T) {
+	def, err := skillaction.Load([]byte(demoralizeYAML), frightenedRegistry(t))
+	require.NoError(t, err)
+
+	var seen []skillaction.Effect
+	ctx := skillaction.ResolveContext{
+		ActorName:  "Riker",
+		TargetName: "Thug",
+		Apply:      func(e skillaction.Effect) { seen = append(seen, e) },
+	}
+	// roll 18 + bonus 5 vs DC 10 → 23 vs 10 = +13 → crit success.
+	out, err := skillaction.Resolve(ctx, def, 18, 5, 10)
+	require.NoError(t, err)
+	require.Equal(t, skillaction.CritSuccess, out.DoS)
+	require.Len(t, seen, 2)
+
+	ac, ok := seen[0].(skillaction.ApplyCondition)
+	require.True(t, ok)
+	require.Equal(t, "frightened", ac.ID)
+	require.Equal(t, 2, ac.Stacks)
+
+	require.Contains(t, out.Narrative, "Riker")
+	require.Contains(t, out.Narrative, "Thug")
+}
+
+func TestResolve_NarrativeFallback_WhenOutcomeMissing(t *testing.T) {
+	// Define an action with only crit_success defined; resolve a roll that
+	// triggers Failure → no outcome → fallback narrative.
+	yaml := `
+id: stub
+ap_cost: 1
+skill: smooth_talk
+dc: { kind: target_will }
+range: { kind: melee_reach }
+target_kinds: [npc]
+outcomes:
+  crit_success:
+    effects:
+      - narrative: { text: "perfect" }
+`
+	def, err := skillaction.Load([]byte(yaml), frightenedRegistry(t))
+	require.NoError(t, err)
+	out, err := skillaction.Resolve(skillaction.ResolveContext{ActorName: "A", TargetName: "B"}, def, 12, 0, 15)
+	require.NoError(t, err)
+	require.Equal(t, skillaction.Failure, out.DoS)
+	require.Contains(t, out.Narrative, "fails")
+}
+
+func TestResolve_NoApplyCallback_StillSetsEffectsOnOutcome(t *testing.T) {
+	def, err := skillaction.Load([]byte(demoralizeYAML), frightenedRegistry(t))
+	require.NoError(t, err)
+	out, err := skillaction.Resolve(skillaction.ResolveContext{}, def, 18, 5, 10)
+	require.NoError(t, err)
+	require.Len(t, out.Effects, 2, "Resolve must record effects on the Outcome even without an Apply callback")
+}

--- a/internal/game/skillaction/target.go
+++ b/internal/game/skillaction/target.go
@@ -1,0 +1,138 @@
+package skillaction
+
+import (
+	"fmt"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+// PreconditionError is the structured error returned by ValidateTarget when a
+// pre-resolution gate fails. The handler MUST surface it to the client without
+// consuming AP (NCA-17). The Field/Detail pair is suitable for both telnet
+// echo and structured RPC responses.
+type PreconditionError struct {
+	Field  string
+	Detail string
+}
+
+func (e *PreconditionError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Detail)
+}
+
+// TargetCtx is the slim, side-effect-free view of the actor / target / combat
+// trio that ValidateTarget needs. Constructing this in the handler keeps the
+// skillaction package free of session/manager dependencies.
+type TargetCtx struct {
+	Combat *combat.Combat
+	Actor  *combat.Combatant
+	Target *combat.Combatant
+}
+
+// ValidateTarget runs the standard target gates for the given action. It
+// composes:
+//
+//  1. Target-kind filter (NCA-12) — npc / player / any / self.
+//  2. Range gate (NCA-16) — melee_reach / ranged_feet / self.
+//  3. The shared combat.ValidateSingleTarget pipeline — presence, liveness,
+//     allegiance, distance, and the line-of-fire seam (NCA-15, currently a
+//     no-op until #267 lands).
+//
+// Returns a *PreconditionError on any failure; nil on success.
+func ValidateTarget(tc TargetCtx, def *ActionDef) error {
+	if def == nil {
+		return &PreconditionError{Field: "def", Detail: "action def is nil"}
+	}
+	if tc.Actor == nil {
+		return &PreconditionError{Field: "actor", Detail: "actor is nil"}
+	}
+
+	// Self range short-circuit — target may legitimately be nil/self.
+	if def.Range.Kind == RangeSelf {
+		if tc.Target != nil && tc.Target.ID != tc.Actor.ID {
+			return &PreconditionError{Field: "range", Detail: "must target self"}
+		}
+		return nil
+	}
+
+	if tc.Target == nil {
+		return &PreconditionError{Field: "target", Detail: "no target selected"}
+	}
+
+	// Stage 1: target-kind filter.
+	if !targetKindAllowed(tc.Actor, tc.Target, def.TargetKinds) {
+		return &PreconditionError{Field: "target_kind", Detail: targetKindMessage(tc.Target, def.TargetKinds)}
+	}
+
+	// Stage 2 + standard combat target pipeline (presence, liveness, allegiance, range, LoF seam).
+	maxRangeFt := 0
+	switch def.Range.Kind {
+	case RangeMelee:
+		maxRangeFt = 5 // adjacency in PF2E
+	case RangeRanged:
+		maxRangeFt = def.Range.Feet
+	}
+	res := combat.ValidateSingleTarget(tc.Combat, tc.Actor, tc.Target.ID, combat.TargetSingleEnemy, maxRangeFt, false)
+	if !res.OK() {
+		return &PreconditionError{Field: rangeField(res.Err), Detail: res.Detail}
+	}
+	return PostValidateTarget(tc, def)
+}
+
+// PostValidateTarget is the line-of-fire seam reserved for #267 (NCA-15).
+// Currently a no-op; tests may stub via go-link tricks if needed.
+var PostValidateTarget = func(tc TargetCtx, def *ActionDef) error {
+	return nil
+}
+
+// targetKindAllowed reports whether the target's kind matches one of the
+// def's allowed TargetKind values.
+func targetKindAllowed(actor, target *combat.Combatant, allowed []TargetKind) bool {
+	for _, k := range allowed {
+		switch k {
+		case TargetKindAny:
+			return true
+		case TargetKindNPC:
+			if !target.IsPlayer() {
+				return true
+			}
+		case TargetKindPlayer:
+			if target.IsPlayer() {
+				return true
+			}
+		case TargetKindSelf:
+			if actor != nil && target != nil && actor.ID == target.ID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func targetKindMessage(target *combat.Combatant, allowed []TargetKind) string {
+	if len(allowed) == 1 {
+		switch allowed[0] {
+		case TargetKindNPC:
+			return fmt.Sprintf("%s is not an NPC", target.Name)
+		case TargetKindPlayer:
+			return fmt.Sprintf("%s is not a player", target.Name)
+		case TargetKindSelf:
+			return fmt.Sprintf("must target self, not %s", target.Name)
+		}
+	}
+	return fmt.Sprintf("target kind %q is not allowed", target.Name)
+}
+
+func rangeField(e combat.TargetingError) string {
+	switch e {
+	case combat.ErrOutOfRange:
+		return "range"
+	case combat.ErrTargetNotInCombat, combat.ErrTargetMissing:
+		return "target"
+	case combat.ErrTargetDead:
+		return "target_dead"
+	case combat.ErrWrongCategory:
+		return "target_kind"
+	default:
+		return "target"
+	}
+}

--- a/internal/game/skillaction/target_test.go
+++ b/internal/game/skillaction/target_test.go
@@ -1,0 +1,71 @@
+package skillaction_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	"github.com/cory-johannsen/mud/internal/game/skillaction"
+)
+
+func newCombatWith(t *testing.T, actor, target *combat.Combatant) *combat.Combat {
+	t.Helper()
+	cbt := &combat.Combat{Combatants: []*combat.Combatant{actor}}
+	if target != nil {
+		cbt.Combatants = append(cbt.Combatants, target)
+	}
+	return cbt
+}
+
+func mkPlayer(id, name string) *combat.Combatant {
+	return &combat.Combatant{ID: id, Kind: combat.KindPlayer, Name: name, MaxHP: 30, CurrentHP: 30, AC: 12}
+}
+
+func mkNPC(id, name, faction string) *combat.Combatant {
+	return &combat.Combatant{ID: id, Kind: combat.KindNPC, Name: name, FactionID: faction, MaxHP: 20, CurrentHP: 20, AC: 12}
+}
+
+func demoralizeDef(t *testing.T) *skillaction.ActionDef {
+	def, err := skillaction.Load([]byte(demoralizeYAML), frightenedRegistry(t))
+	require.NoError(t, err)
+	return def
+}
+
+func TestValidateTarget_NPCOnly_RejectsPlayerTarget(t *testing.T) {
+	actor := mkPlayer("p1", "Riker")
+	target := mkPlayer("p2", "Worf")
+	cbt := newCombatWith(t, actor, target)
+	err := skillaction.ValidateTarget(skillaction.TargetCtx{Combat: cbt, Actor: actor, Target: target}, demoralizeDef(t))
+	require.Error(t, err)
+	pe, ok := err.(*skillaction.PreconditionError)
+	require.True(t, ok)
+	require.Equal(t, "target_kind", pe.Field)
+}
+
+func TestValidateTarget_DeadTargetRejected(t *testing.T) {
+	actor := mkPlayer("p1", "Riker")
+	target := mkNPC("n1", "Thug", "raiders")
+	target.CurrentHP = 0
+	cbt := newCombatWith(t, actor, target)
+	err := skillaction.ValidateTarget(skillaction.TargetCtx{Combat: cbt, Actor: actor, Target: target}, demoralizeDef(t))
+	require.Error(t, err)
+}
+
+func TestValidateTarget_HappyPath(t *testing.T) {
+	actor := mkPlayer("p1", "Riker")
+	target := mkNPC("n1", "Thug", "raiders")
+	cbt := newCombatWith(t, actor, target)
+	err := skillaction.ValidateTarget(skillaction.TargetCtx{Combat: cbt, Actor: actor, Target: target}, demoralizeDef(t))
+	require.NoError(t, err)
+}
+
+func TestValidateTarget_NoTarget(t *testing.T) {
+	actor := mkPlayer("p1", "Riker")
+	cbt := newCombatWith(t, actor, nil)
+	err := skillaction.ValidateTarget(skillaction.TargetCtx{Combat: cbt, Actor: actor, Target: nil}, demoralizeDef(t))
+	require.Error(t, err)
+	pe, ok := err.(*skillaction.PreconditionError)
+	require.True(t, ok)
+	require.Equal(t, "target", pe.Field)
+}

--- a/internal/gameserver/grpc_service.go
+++ b/internal/gameserver/grpc_service.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cory-johannsen/mud/internal/game/quest"
 	"github.com/cory-johannsen/mud/internal/game/ruleset"
 	"github.com/cory-johannsen/mud/internal/game/session"
+	"github.com/cory-johannsen/mud/internal/game/skillaction"
 	"github.com/cory-johannsen/mud/internal/game/skillcheck"
 	"github.com/cory-johannsen/mud/internal/game/substance"
 	"github.com/cory-johannsen/mud/internal/game/technology"
@@ -10401,11 +10402,17 @@ func (s *GameServiceServer) handleFeint(uid string, req *gamev1.FeintRequest) (*
 }
 
 // handleDemoralize performs a smooth_talk skill check against the target NPC's Cool DC (10 + level + AbilityMod(Savvy) + CoolRank bonus).
-// On success, applies -1 AC and -1 attack to the target combatant for the encounter.
+// On success, applies -1 AC and -1 attack to the target combatant for the encounter,
+// and (per #252) also applies the canonical Frightened condition through the unified
+// skillaction pipeline (loaded from content/skill_actions/demoralize.yaml).
 // Combat only; costs 1 AP.
 //
 // Precondition: uid must be in active combat; req.Target must name an NPC in the room.
-// Postcondition: On success, target's ACMod and AttackMod are each decremented by 1.
+// Postcondition: On success, target's ACMod and AttackMod are each decremented by 1
+// AND the target gains 1 stack of Frightened (2 stacks on critical success when the
+// skillaction catalog loads successfully). Legacy ACMod/AttackMod application is
+// retained for backward compatibility with existing combat tests; future work
+// (Task 6) will retire the flat-mod path in favour of the condition-only model.
 func (s *GameServiceServer) handleDemoralize(uid string, req *gamev1.DemoralizeRequest) (*gamev1.ServerEvent, error) {
 	sess, ok := s.sessions.GetPlayer(uid)
 	if !ok {
@@ -10452,7 +10459,9 @@ func (s *GameServiceServer) handleDemoralize(uid string, req *gamev1.DemoralizeR
 		return messageEvent(detail + " — failure. Your words fall flat."), nil
 	}
 
-	// Success: apply -1 AC and -1 attack to NPC combatant.
+	// Legacy flat-mod application — retained for backward compatibility with
+	// the combat engine's pre-#252 demoralize handling. Task 6 of #252 will
+	// migrate this to a Frightened-only model gated by an audit checkpoint.
 	if err := s.combatH.ApplyCombatantACMod(uid, inst.ID, -1); err != nil {
 		s.logger.Warn("handleDemoralize: ApplyCombatantACMod failed",
 			zap.String("npc_id", inst.ID), zap.Error(err))
@@ -10462,7 +10471,57 @@ func (s *GameServiceServer) handleDemoralize(uid string, req *gamev1.DemoralizeR
 			zap.String("npc_id", inst.ID), zap.Error(err))
 	}
 
+	// #252 NCA-7/NCA-9: drive the canonical Frightened condition application
+	// through the unified skillaction pipeline so the catalog YAML is the
+	// source of truth for the demoralize ladder. Failures here are non-fatal
+	// — the legacy mods above already applied — and are logged.
+	s.applyDemoralizeFrightened(uid, sess.RoomID, inst.ID, roll, bonus, dc)
+
 	return messageEvent(detail + fmt.Sprintf(" — success! %s is demoralized (-1 AC, -1 attack).", inst.Name())), nil
+}
+
+// applyDemoralizeFrightened is the #252 skillaction-pipeline integration for
+// Demoralize. It computes the PF2E degree of success (with nat-1/nat-20
+// promotion/demotion), looks up the matching outcome in the loaded
+// demoralize.yaml ActionDef, and applies any apply_condition effects through
+// the existing CombatHandler.ApplyConditionToNPC plumbing.
+//
+// Failures are warning-logged and silently swallowed: the caller has already
+// applied the legacy flat mods, so the legacy behaviour is preserved even
+// when the skillaction catalog fails to load.
+func (s *GameServiceServer) applyDemoralizeFrightened(uid, roomID, npcID string, roll, bonus, dc int) {
+	defs, err := loadSkillActions(s.condRegistry)
+	if err != nil {
+		s.logger.Debug("skillaction: catalog load failed; legacy demoralize path only",
+			zap.Error(err))
+		return
+	}
+	def, ok := defs["demoralize"]
+	if !ok {
+		s.logger.Debug("skillaction: demoralize def not present in catalog")
+		return
+	}
+	out, err := skillaction.Resolve(skillaction.ResolveContext{}, def, roll, bonus, dc)
+	if err != nil {
+		s.logger.Warn("skillaction: Resolve failed", zap.Error(err))
+		return
+	}
+	for _, eff := range out.Effects {
+		ac, ok := eff.(skillaction.ApplyCondition)
+		if !ok {
+			continue
+		}
+		stacks := ac.Stacks
+		if stacks <= 0 {
+			stacks = 1
+		}
+		if applyErr := s.combatH.ApplyConditionToNPC(roomID, npcID, ac.ID, stacks, ac.DurationRounds); applyErr != nil {
+			s.logger.Warn("skillaction: ApplyConditionToNPC failed",
+				zap.String("npc_id", npcID),
+				zap.String("condition", ac.ID),
+				zap.Error(applyErr))
+		}
+	}
 }
 
 // handleGrapple performs a muscle skill check against the target NPC's Toughness DC (10 + level + AbilityMod(Brutality) + ToughnessRank bonus).

--- a/internal/gameserver/skillaction_catalog.go
+++ b/internal/gameserver/skillaction_catalog.go
@@ -1,0 +1,65 @@
+package gameserver
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/cory-johannsen/mud/internal/game/condition"
+	"github.com/cory-johannsen/mud/internal/game/skillaction"
+)
+
+// skillActionCatalog is a process-wide lazy-loaded catalog of ActionDefs read
+// from content/skill_actions/. Lazy-loading keeps the Service constructor
+// untouched while still letting handlers participate in the unified
+// skillaction pipeline. The condition registry is supplied at first-use time
+// so apply_condition.id references can be validated.
+//
+// Thread-safe: guards the load with a sync.Once.
+var (
+	skillActionOnce sync.Once
+	skillActionDefs map[string]*skillaction.ActionDef
+	skillActionErr  error
+)
+
+// loadSkillActions loads the catalog once and returns it. The first caller's
+// condReg seeds the validation set. Subsequent calls reuse the cached map and
+// ignore the supplied condReg.
+//
+// The directory is resolved by walking up from cwd until content/skill_actions
+// is found; this matches the discovery patterns used elsewhere for content
+// dirs and lets tests resolve the path regardless of cwd.
+func loadSkillActions(condReg *condition.Registry) (map[string]*skillaction.ActionDef, error) {
+	skillActionOnce.Do(func() {
+		dir, err := findSkillActionsDir()
+		if err != nil {
+			skillActionErr = err
+			return
+		}
+		skillActionDefs, skillActionErr = skillaction.LoadDirectory(dir, condReg)
+	})
+	return skillActionDefs, skillActionErr
+}
+
+// findSkillActionsDir walks up from the current working directory looking for
+// content/skill_actions. Returns the absolute path or an error if not found.
+func findSkillActionsDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	cur := cwd
+	for {
+		candidate := filepath.Join(cur, "content", "skill_actions")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate, nil
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Hit the filesystem root without finding the directory; fall
+			// back to the relative path for callers running with a known cwd.
+			return filepath.Join("content", "skill_actions"), nil
+		}
+		cur = parent
+	}
+}


### PR DESCRIPTION
Closes #252 (MVP). New internal/game/skillaction package: ActionDef + YAML loader, DoS computation with nat-1/nat-20 step rule, target validation reusing #249's ValidateSingleTarget, Resolve with Apply callback. handleDemoralize now applies Frightened via the canonical pipeline. ListCombatActions RPC, full handler audit, telnet skills command, web SkillActionsMenu, and other actions (Feint/Trip/Grapple/Recall) deferred to follow-up.