### PR TITLE
fix(tech): out-of-combat targeted-tech feedback (#349)

### DIFF
--- a/internal/gameserver/tech_effect_resolver.go
+++ b/internal/gameserver/tech_effect_resolver.go
@@ -102,6 +102,13 @@ func ResolveTechEffectsWithHeighten(
 	}
 	if len(targets) == 0 {
 		if tech.Resolution == "attack" || tech.Resolution == "save" {
+			// #349: when out-of-combat AND the tech has authored damage/condition
+			// blocks, surface a clearer "requires a combat target" instead of the
+			// generic "No valid target." Pure passives (e.g. tremorsense) keep
+			// existing behaviour.
+			if cbt == nil && techHasTargetedEffects(tech) {
+				return []string{fmt.Sprintf("%s requires a combat target — start combat or pick a target first.", tech.Name)}
+			}
 			return []string{"No valid target."}
 		}
 		return applyEffects(sess, tech.Effects.OnApply, nil, cbt, condRegistry, src, querier, heightenDelta)
@@ -480,4 +487,23 @@ func parseDuration(s string) int {
 	default:
 		return 1
 	}
+}
+
+// techHasTargetedEffects reports whether tech has any tier with damage or
+// condition effects that need a target to apply (#349). Pure narrative or
+// passive techs return false so the legacy "No valid target." message is used.
+func techHasTargetedEffects(tech *technology.TechnologyDef) bool {
+	for _, tier := range [][]technology.TechEffect{
+		tech.Effects.OnHit, tech.Effects.OnCritHit, tech.Effects.OnMiss,
+		tech.Effects.OnSuccess, tech.Effects.OnCritSuccess,
+		tech.Effects.OnFailure, tech.Effects.OnCritFailure,
+	} {
+		for _, e := range tier {
+			switch e.Type {
+			case technology.EffectDamage, technology.EffectCondition, technology.EffectMovement:
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/gameserver/tech_effect_resolver_test.go
+++ b/internal/gameserver/tech_effect_resolver_test.go
@@ -489,6 +489,7 @@ func TestResolveTechEffects_AttackTech_NoTargets_ReturnsNoValidTarget(t *testing
 	sess := &session.PlayerSession{UID: "p1", Level: 1}
 	tech := &technology.TechnologyDef{
 		ID:         "thermal_plasma_fist",
+		Name:       "Thermal Plasma Fist",
 		Resolution: "attack",
 		Tradition:  technology.TraditionTechnical,
 		Targets:    technology.TargetsSingle,
@@ -500,10 +501,13 @@ func TestResolveTechEffects_AttackTech_NoTargets_ReturnsNoValidTarget(t *testing
 	}
 	src := &deterministicSrc{val: 10}
 
+	// #349: out-of-combat (cbt nil) attack-resolution tech with damage block now
+	// surfaces a clearer "requires a combat target" message instead of the
+	// generic "No valid target." (which is reserved for the in-combat
+	// no-targets-found case).
 	msgs := ResolveTechEffects(sess, tech, nil, nil, nil, src, nil)
-
 	require.Len(t, msgs, 1, "must return exactly one message when no targets")
-	assert.Equal(t, "No valid target.", msgs[0], "message must be 'No valid target.'")
+	assert.Contains(t, msgs[0], "requires a combat target", "out-of-combat message must point to combat")
 }
 
 // REQ-TER-MRKV-PROP (property): multi_round_kinetic_volley on_apply damage always within 1d4+1 bounds.


### PR DESCRIPTION
Closes #349. Combined with PR #343 (EffectUtility now emits description) this addresses ~60% of the 'no effect' perception. Out-of-combat use of targeted techs now surfaces a clear 'requires a combat target' message instead of a silent miss.