### PR TITLE
fix(deploy): rejector binds 0.0.0.0 + probe on 4000 (#325 hotfix)

### DIFF
--- a/deployments/k8s/mud/templates/frontend/deployment.yaml
+++ b/deployments/k8s/mud/templates/frontend/deployment.yaml
@@ -59,12 +59,17 @@ spec:
               value: {{ .Values.logging.level | quote }}
             - name: MUD_LOGGING_FORMAT
               value: {{ .Values.logging.format | quote }}
+            # The rejector port (4000) needs to bind to all interfaces so the
+            # K8s readiness probe on the pod IP can reach it. Service is
+            # ClusterIP so external access is still blocked at the cluster
+            # edge. The headless port (4002) is always loopback-only.
+            - name: MUD_TELNET_HOST
+              value: "0.0.0.0"
           readinessProbe:
-            # Probe the headless debug port; the rejector on 4000 also
-            # responds, but readiness probes against the debug surface are
-            # less coupled to the deprecated player flow.
+            # Probe the rejector port — it's reachable on the pod IP and
+            # accepts TCP even when refusing player auth.
             tcpSocket:
-              port: 4002
+              port: 4000
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,13 +286,12 @@ func validateTelnet(t TelnetConfig) error {
 		errs = append(errs, "telnet.write_timeout must not be negative")
 	}
 	// REQ-TD-1c: with the player flow retired by default, the public telnet
-	// port MUST bind to loopback unless the operator has opted into the
-	// graceful-sunset flow with allow_game_commands=true.
-	if t.Host != "" && t.Host != "127.0.0.1" && !t.AllowGameCommands {
-		errs = append(errs, fmt.Sprintf(
-			"telnet.host must be 127.0.0.1 unless telnet.allow_game_commands is true (got %q)",
-			t.Host))
-	}
+	// port runs the rejector that refuses player auth and disconnects with a
+	// pointer to the web client. The bind address may be 0.0.0.0 in
+	// containerised deployments so the K8s readiness probe (and any in-cluster
+	// caller) can reach the rejector. The Service is ClusterIP so external
+	// access is still blocked at the K8s edge. The headless port (Telnet.HeadlessPort)
+	// is always bound to 127.0.0.1 regardless of Host.
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,13 +87,16 @@ func TestTelnetConfig_HeadlessPortDistinctFromMain(t *testing.T) {
 		"telnet.headless_port must default to a non-zero value")
 }
 
-func TestTelnetConfig_RejectsExternalHostWhenSunsetFlagOff(t *testing.T) {
+func TestTelnetConfig_AllowsExternalRejectorHost(t *testing.T) {
+	// The rejector port may bind to 0.0.0.0 in containerised deployments so
+	// the K8s readiness probe on the pod IP can reach it. The Service is
+	// ClusterIP so external access is still blocked at the cluster edge.
+	// The headless port is always loopback-only regardless of Host.
 	cfg := validConfig()
 	cfg.Telnet.Host = "0.0.0.0"
 	cfg.Telnet.AllowGameCommands = false
-	err := cfg.Validate()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "telnet.host must be 127.0.0.1")
+	assert.NoError(t, cfg.Validate(),
+		"rejector host must accept 0.0.0.0 — K8s probe needs pod-IP reachability")
 }
 
 func TestTelnetConfig_AllowsExternalHostWhenSunsetFlagSet(t *testing.T) {


### PR DESCRIPTION
Hotfix for #325 deploy. Rejector port needs pod-IP reachability for K8s readiness probe; Service stays ClusterIP so external access is still blocked. Headless port stays loopback-only.