### PR TITLE
feat(weapon): Move trait — free stride after Strike (#253)

### DIFF
--- a/content/weapons/mono_wire_whip.yaml
+++ b/content/weapons/mono_wire_whip.yaml
@@ -1,10 +1,10 @@
 id: mono_wire_whip
 name: Mono-Wire Whip
-description: A reel of monomolecular wire that can strip limbs with a flick of the wrist.
+description: A reel of monomolecular wire that can strip limbs with a flick of the wrist. Its lashing arc and recoil pull the wielder into a free Stride before or after each Strike (Mobile trait), and that bonus movement does not provoke reactive strikes.
 damage_dice: 1d12
 damage_type: slashing
 range_increment: 0
-traits: [reach, machete-team, two-hand]
+traits: [reach, machete-team, two-hand, mobile]
 kind: two_handed
 group: blade
 proficiency_category: specialized

--- a/internal/game/combat/action.go
+++ b/internal/game/combat/action.go
@@ -27,6 +27,13 @@ const (
 	ActionUseTech                         // costs AbilityCost AP; activate a technology during round resolution
 	ActionReady                           // costs 2 AP; prepares one 1-AP action bound to a trigger
 	ActionHazardDamage                    // informational: terrain hazard fires damage on entry or round start
+	// ActionMoveTraitStride is a free Stride granted by a Move-trait weapon
+	// (see internal/game/inventory/traits.Mobile). Cost is 0; the action does
+	// not consume AP and does not count against the per-round movement AP cap.
+	// It is queued only via ActionQueue.QueueFreeAction (allowlist-gated) and
+	// resolves under MoveContext{Cause: MoveCauseMoveTrait} so reactive strikes
+	// are suppressed.
+	ActionMoveTraitStride
 )
 
 // Cost returns the action point cost for the ActionType.
@@ -59,6 +66,9 @@ func (a ActionType) Cost() int {
 		return 0 // cost comes from QueuedAction.AbilityCost
 	case ActionReady:
 		return 2
+	case ActionMoveTraitStride:
+		// WMOVE-7: free action — cost 0 by construction.
+		return 0
 	default:
 		// ActionUnknown and any unrecognized values have cost 0.
 		return 0
@@ -96,6 +106,8 @@ func (a ActionType) String() string {
 		return "ready"
 	case ActionHazardDamage:
 		return "hazard_damage"
+	case ActionMoveTraitStride:
+		return "move_trait_stride"
 	default:
 		return "unknown"
 	}
@@ -122,6 +134,46 @@ type QueuedAction struct {
 	ReadyTrigger    reaction.ReactionTriggerType // trigger that fires the prepared action
 	ReadyAction     *QueuedAction                // the 1-AP action to execute on trigger
 	ReadyTriggerTgt string                       // optional: restrict to a specific source UID
+
+	// Move-trait fields — only meaningful when Type == ActionMoveTraitStride or
+	// for ActionStrike entries that are paired with a free Stride.
+	//
+	// MoveTraitWielder reports whether the wielder's weapon has the Mobile
+	// trait at queue time. Set by the Strike pipeline so ResolveRound can decide
+	// whether to honour a paired ActionMoveTraitStride entry.
+	MoveTraitWielder bool
+	// StrikeAction is a non-zero monotonic id used to scope the once-per-Strike
+	// enforcement of free Strides (WMOVE-10). The Strike pipeline assigns it.
+	StrikeAction int64
+	// MoveOrdering is the requested ordering of a free Stride relative to its
+	// paired Strike: MoveOrderingBefore (default 0) or MoveOrderingAfter.
+	// Only meaningful when Type == ActionMoveTraitStride.
+	MoveOrdering MoveTraitOrdering
+}
+
+// MoveTraitOrdering selects whether a free Stride runs before or after the
+// paired Strike. The zero value is "before".
+type MoveTraitOrdering int
+
+const (
+	// MoveOrderingBefore queues the free Stride to resolve immediately before
+	// its paired Strike (WMOVE-Q5 default ordering).
+	MoveOrderingBefore MoveTraitOrdering = iota
+	// MoveOrderingAfter queues the free Stride to resolve immediately after
+	// its paired Strike.
+	MoveOrderingAfter
+)
+
+// String returns the human-readable name of the MoveTraitOrdering.
+func (o MoveTraitOrdering) String() string {
+	switch o {
+	case MoveOrderingBefore:
+		return "before"
+	case MoveOrderingAfter:
+		return "after"
+	default:
+		return "unknown"
+	}
 }
 
 // MaxMovementAP is the maximum action points a combatant may spend on movement
@@ -284,6 +336,44 @@ func (q *ActionQueue) IsSubmitted() bool {
 		}
 	}
 	return false
+}
+
+// freeActionAllowlist is the closed set of ActionTypes that may be queued via
+// QueueFreeAction. Any other type is rejected. Adding to this set is an
+// explicit, audited decision per WMOVE-8 (no general free-action support).
+var freeActionAllowlist = map[ActionType]bool{
+	ActionMoveTraitStride: true,
+}
+
+// QueueFreeAction appends a free (cost-zero) action to the queue without
+// touching remaining AP or the per-round movement AP cap. The action's Type
+// must appear in the freeActionAllowlist; everything else is rejected.
+//
+// WMOVE-7: free action does not deduct AP or increment movementAPSpent.
+// WMOVE-8: gated by an explicit allowlist; arbitrary types cannot be queued.
+// WMOVE-10: when StrikeAction != 0, at most one ActionMoveTraitStride may be
+//   queued for a given StrikeAction value (once-per-Strike).
+//
+// Precondition: q is non-nil.
+// Postcondition: on success, the action is appended and remaining /
+// movementAPSpent are unchanged. On error, queue state is unchanged.
+func (q *ActionQueue) QueueFreeAction(qa QueuedAction) error {
+	if q == nil {
+		return fmt.Errorf("QueueFreeAction: nil queue")
+	}
+	if !freeActionAllowlist[qa.Type] {
+		return fmt.Errorf("QueueFreeAction: action type %q is not in the free-action allowlist", qa.Type.String())
+	}
+	if qa.Type == ActionMoveTraitStride && qa.StrikeAction != 0 {
+		for _, existing := range q.actions {
+			if existing.Type == ActionMoveTraitStride && existing.StrikeAction == qa.StrikeAction {
+				return fmt.Errorf("QueueFreeAction: free Stride already queued for strike action %d (once per Strike — WMOVE-10)", qa.StrikeAction)
+			}
+		}
+	}
+	q.actions = append(q.actions, qa)
+	// Intentionally do NOT touch remaining or movementAPSpent (WMOVE-7).
+	return nil
 }
 
 // ClearActions drains all queued actions, restores remaining AP to MaxPoints,

--- a/internal/game/combat/engine.go
+++ b/internal/game/combat/engine.go
@@ -408,6 +408,22 @@ func (c *Combat) DyingStacks(uid string) int {
 	return 0
 }
 
+// QueueFreeAction appends a free (cost-zero) action to the combatant's queue
+// without consuming AP. The action's type must appear in the free-action
+// allowlist (see ActionQueue.QueueFreeAction).
+//
+// Precondition: uid must be a combatant in this combat with an active queue.
+// Postcondition: returns error if uid is unknown or the action is rejected by
+// the allowlist or once-per-Strike enforcement; otherwise the action is
+// appended and remaining AP is unchanged.
+func (c *Combat) QueueFreeAction(uid string, a QueuedAction) error {
+	q, ok := c.ActionQueues[uid]
+	if !ok {
+		return fmt.Errorf("combatant %q not found or has no active queue", uid)
+	}
+	return q.QueueFreeAction(a)
+}
+
 // QueueAction enqueues an action for the combatant with the given UID.
 //
 // Precondition: uid must be a living combatant in this combat with an active queue.

--- a/internal/game/combat/move_context.go
+++ b/internal/game/combat/move_context.go
@@ -1,0 +1,55 @@
+package combat
+
+// MoveCause classifies why a combatant changed position during a round. It is
+// threaded through reaction-trigger checks (e.g. CheckReactiveStrikesCtx) so
+// move-trait granted movement (and any future suppressed-reaction movement)
+// can be distinguished from regular Stride / MoveTo / forced movement.
+//
+// WMOVE-12: when Cause == MoveCauseMoveTrait the reactive-strike check
+// early-returns without firing any reactions.
+type MoveCause int
+
+const (
+	// MoveCauseStride is a movement triggered by a normal ActionStride.
+	MoveCauseStride MoveCause = iota
+	// MoveCauseMoveTo is a movement triggered by an out-of-combat MoveTo
+	// request (or any other non-stride deliberate movement).
+	MoveCauseMoveTo
+	// MoveCauseMoveTrait is a movement granted by the Mobile / Move weapon
+	// trait. Reactive strikes are suppressed for this cause.
+	MoveCauseMoveTrait
+	// MoveCauseForced is a movement caused by an outside force (push, pull,
+	// teleport, knockback). Reaction handling is left to the caller; the
+	// default reactive-strike check still applies unless the caller decides
+	// otherwise.
+	MoveCauseForced
+)
+
+// String returns a stable human-readable name for the MoveCause.
+func (c MoveCause) String() string {
+	switch c {
+	case MoveCauseStride:
+		return "stride"
+	case MoveCauseMoveTo:
+		return "move_to"
+	case MoveCauseMoveTrait:
+		return "move_trait"
+	case MoveCauseForced:
+		return "forced"
+	default:
+		return "unknown"
+	}
+}
+
+// ReactionMoveContext describes a single position change for the purposes of
+// reaction-trigger evaluation.
+type ReactionMoveContext struct {
+	// MoverID is the UID of the combatant that moved.
+	MoverID string
+	// FromX/FromY is the grid position the mover occupied before the move.
+	FromX int
+	FromY int
+	// Cause is the reason the move happened. Reaction checks use this to
+	// suppress / route per-cause behaviour.
+	Cause MoveCause
+}

--- a/internal/game/combat/move_trait_test.go
+++ b/internal/game/combat/move_trait_test.go
@@ -1,0 +1,211 @@
+package combat_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+)
+
+// moveTraitSrc is a deterministic combat.Source for tests.
+type moveTraitSrc struct{ r *rand.Rand }
+
+func (s moveTraitSrc) Intn(n int) int { return s.r.Intn(n) }
+
+// TestMoveTrait_QueueFreeAction_NoAPSpent confirms WMOVE-7: a free Stride
+// queued via QueueFreeAction does not consume AP and does not increment the
+// per-round movement AP cap.
+func TestMoveTrait_QueueFreeAction_NoAPSpent(t *testing.T) {
+	q := combat.NewActionQueue("uid", 3)
+	require.Equal(t, 3, q.RemainingPoints())
+	err := q.QueueFreeAction(combat.QueuedAction{
+		Type:         combat.ActionMoveTraitStride,
+		StrikeAction: 1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, q.RemainingPoints(), "free action must not deduct AP (WMOVE-7)")
+	assert.Equal(t, 0, q.MovementAPSpent(), "free Stride must not increment movementAPSpent (WMOVE-7)")
+	assert.Len(t, q.QueuedActions(), 1)
+}
+
+// TestMoveTrait_QueueFreeAction_RejectsNonAllowlisted confirms WMOVE-8: only
+// the explicit allowlist of free-action types is accepted.
+func TestMoveTrait_QueueFreeAction_RejectsNonAllowlisted(t *testing.T) {
+	q := combat.NewActionQueue("uid", 3)
+	err := q.QueueFreeAction(combat.QueuedAction{Type: combat.ActionStride})
+	require.Error(t, err, "QueueFreeAction must reject types outside the allowlist (WMOVE-8)")
+	err = q.QueueFreeAction(combat.QueuedAction{Type: combat.ActionStrike})
+	require.Error(t, err)
+	err = q.QueueFreeAction(combat.QueuedAction{Type: combat.ActionAttack})
+	require.Error(t, err)
+}
+
+// TestMoveTrait_QueueFreeAction_OncePerStrike confirms WMOVE-10: at most one
+// ActionMoveTraitStride may be queued for a given StrikeAction id.
+func TestMoveTrait_QueueFreeAction_OncePerStrike(t *testing.T) {
+	q := combat.NewActionQueue("uid", 3)
+	require.NoError(t, q.QueueFreeAction(combat.QueuedAction{
+		Type: combat.ActionMoveTraitStride, StrikeAction: 7,
+	}))
+	err := q.QueueFreeAction(combat.QueuedAction{
+		Type: combat.ActionMoveTraitStride, StrikeAction: 7,
+	})
+	require.Error(t, err, "second free Stride for the same Strike must be rejected (WMOVE-10)")
+}
+
+// TestMoveTrait_QueueFreeAction_SeparateStrikesAllowed: different StrikeAction
+// ids must be allowed to queue independent free Strides.
+func TestMoveTrait_QueueFreeAction_SeparateStrikesAllowed(t *testing.T) {
+	q := combat.NewActionQueue("uid", 6)
+	require.NoError(t, q.QueueFreeAction(combat.QueuedAction{
+		Type: combat.ActionMoveTraitStride, StrikeAction: 1,
+	}))
+	require.NoError(t, q.QueueFreeAction(combat.QueuedAction{
+		Type: combat.ActionMoveTraitStride, StrikeAction: 2,
+	}))
+}
+
+// TestMoveTrait_ActionType_CostIsZero confirms ActionMoveTraitStride.Cost() == 0.
+func TestMoveTrait_ActionType_CostIsZero(t *testing.T) {
+	assert.Equal(t, 0, combat.ActionMoveTraitStride.Cost())
+}
+
+// TestMoveTrait_ActionType_String returns a stable, descriptive name.
+func TestMoveTrait_ActionType_String(t *testing.T) {
+	assert.Equal(t, "move_trait_stride", combat.ActionMoveTraitStride.String())
+}
+
+// TestCheckReactiveStrikesCtx_SuppressedForMoveTrait confirms WMOVE-12:
+// reactions are suppressed when MoveCause == MoveTrait.
+func TestCheckReactiveStrikesCtx_SuppressedForMoveTrait(t *testing.T) {
+	cbt := &combat.Combat{
+		GridWidth:  10,
+		GridHeight: 10,
+		Combatants: []*combat.Combatant{
+			{ID: "hero", Name: "Hero", Kind: combat.KindPlayer, GridX: 5, GridY: 5, MaxHP: 20, CurrentHP: 20, AC: 14, Level: 1},
+			{ID: "thug", Name: "Thug", Kind: combat.KindNPC, GridX: 5, GridY: 5, MaxHP: 10, CurrentHP: 10, AC: 12, Level: 1},
+		},
+	}
+	// Both at same cell — pre-stride distance = 0; reactive strike WOULD fire
+	// for a normal cause if the mover stepped away.
+	cbt.Combatants[0].GridX = 7
+	cbt.Combatants[0].GridY = 5
+
+	src := moveTraitSrc{r: rand.New(rand.NewSource(1))}
+	events := combat.CheckReactiveStrikesCtx(cbt, combat.ReactionMoveContext{
+		MoverID: "hero", FromX: 5, FromY: 5, Cause: combat.MoveCauseMoveTrait,
+	}, src, nil)
+	assert.Empty(t, events, "MoveTrait must suppress reactive strikes (WMOVE-12)")
+}
+
+// TestCheckReactiveStrikesCtx_FiresForNormalStride confirms the cause-aware
+// path still fires reactions for a normal Stride.
+func TestCheckReactiveStrikesCtx_FiresForNormalStride(t *testing.T) {
+	cbt := &combat.Combat{
+		GridWidth:  10,
+		GridHeight: 10,
+		Combatants: []*combat.Combatant{
+			{ID: "hero", Name: "Hero", Kind: combat.KindPlayer, GridX: 7, GridY: 5, MaxHP: 20, CurrentHP: 20, AC: 14, Level: 1},
+			{ID: "thug", Name: "Thug", Kind: combat.KindNPC, GridX: 5, GridY: 5, MaxHP: 10, CurrentHP: 10, AC: 12, Level: 1},
+		},
+	}
+	src := moveTraitSrc{r: rand.New(rand.NewSource(1))}
+	events := combat.CheckReactiveStrikesCtx(cbt, combat.ReactionMoveContext{
+		MoverID: "hero", FromX: 5, FromY: 5, Cause: combat.MoveCauseStride,
+	}, src, nil)
+	// Hero was at (5,5) adjacent to thug, moved to (7,5); thug should make a
+	// reactive strike (regardless of hit/miss outcome).
+	require.Len(t, events, 1, "normal Stride away from adjacency must trigger reactive strike")
+	assert.Equal(t, combat.ActionAttack, events[0].ActionType)
+	assert.Equal(t, "thug", events[0].ActorID)
+}
+
+// TestProperty_QueueFreeAction_NeverConsumesAP is the rapid property version
+// of TestMoveTrait_QueueFreeAction_NoAPSpent: across arbitrary AP totals and
+// queue sequences, free Strides never deduct AP.
+func TestProperty_QueueFreeAction_NeverConsumesAP(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		ap := rapid.IntRange(0, 10).Draw(rt, "ap")
+		n := rapid.IntRange(1, 5).Draw(rt, "n")
+		q := combat.NewActionQueue("uid", ap)
+		for i := 0; i < n; i++ {
+			err := q.QueueFreeAction(combat.QueuedAction{
+				Type:         combat.ActionMoveTraitStride,
+				StrikeAction: int64(i + 1),
+			})
+			if err != nil {
+				rt.Fatalf("QueueFreeAction failed: %v", err)
+			}
+		}
+		if q.RemainingPoints() != ap {
+			rt.Fatalf("AP changed after free actions: got %d, want %d", q.RemainingPoints(), ap)
+		}
+		if q.MovementAPSpent() != 0 {
+			rt.Fatalf("movementAPSpent != 0: got %d", q.MovementAPSpent())
+		}
+	})
+}
+
+// TestProperty_QueueFreeAction_OncePerStrikeStable: regardless of the order in
+// which strike ids are queued, a duplicate id is always rejected.
+func TestProperty_QueueFreeAction_OncePerStrikeStable(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		ids := rapid.SliceOfN(rapid.Int64Range(1, 5), 1, 10).Draw(rt, "ids")
+		q := combat.NewActionQueue("uid", 3)
+		seen := map[int64]bool{}
+		for _, id := range ids {
+			err := q.QueueFreeAction(combat.QueuedAction{
+				Type: combat.ActionMoveTraitStride, StrikeAction: id,
+			})
+			if seen[id] {
+				if err == nil {
+					rt.Fatalf("duplicate StrikeAction %d not rejected", id)
+				}
+			} else {
+				if err != nil {
+					rt.Fatalf("first QueueFreeAction for %d failed: %v", id, err)
+				}
+				seen[id] = true
+			}
+		}
+	})
+}
+
+// TestProperty_QueueFreeAction_RejectsNonAllowlisted: across arbitrary action
+// types, only ActionMoveTraitStride is accepted.
+func TestProperty_QueueFreeAction_RejectsNonAllowlisted(t *testing.T) {
+	candidates := []combat.ActionType{
+		combat.ActionUnknown,
+		combat.ActionAttack,
+		combat.ActionStrike,
+		combat.ActionPass,
+		combat.ActionReload,
+		combat.ActionStride,
+		combat.ActionAid,
+		combat.ActionThrow,
+		combat.ActionFireBurst,
+		combat.ActionFireAutomatic,
+		combat.ActionUseAbility,
+		combat.ActionUseTech,
+		combat.ActionReady,
+		combat.ActionMoveTraitStride,
+	}
+	rapid.Check(t, func(rt *rapid.T) {
+		at := rapid.SampledFrom(candidates).Draw(rt, "type")
+		q := combat.NewActionQueue("uid", 3)
+		err := q.QueueFreeAction(combat.QueuedAction{Type: at, StrikeAction: 1})
+		if at == combat.ActionMoveTraitStride {
+			if err != nil {
+				rt.Fatalf("ActionMoveTraitStride must be accepted, got %v", err)
+			}
+		} else {
+			if err == nil {
+				rt.Fatalf("non-allowlisted type %v must be rejected", at)
+			}
+		}
+	})
+}

--- a/internal/game/combat/round.go
+++ b/internal/game/combat/round.go
@@ -33,13 +33,42 @@ const (
 // (≤5 ft) to mover before the stride and whose position did not change
 // (i.e., they were not the one striding).
 //
+// This is a legacy wrapper that constructs a MoveContext with Cause set to
+// MoveCauseStride. New callers SHOULD use CheckReactiveStrikesCtx so they can
+// pass the correct cause (e.g. MoveCauseMoveTrait suppresses reactions per
+// WMOVE-12).
+//
 // Precondition: cbt non-nil; moverID non-empty; oldX/oldY is mover's grid position before stride.
 // Postcondition: Returns zero or more RoundEvent{ActionType: ActionAttack} events.
 // targetUpdater(id, hp) is called after each damage application; may be nil (no-op).
 func CheckReactiveStrikes(cbt *Combat, moverID string, oldX, oldY int, rng Source, targetUpdater func(id string, hp int)) []RoundEvent {
+	return CheckReactiveStrikesCtx(cbt, ReactionMoveContext{
+		MoverID: moverID,
+		FromX:   oldX,
+		FromY:   oldY,
+		Cause:   MoveCauseStride,
+	}, rng, targetUpdater)
+}
+
+// CheckReactiveStrikesCtx is the cause-aware variant of CheckReactiveStrikes.
+// It accepts a MoveContext carrying the originating MoveCause and short-circuits
+// when the cause suppresses reactions (WMOVE-12).
+//
+// Precondition: cbt non-nil; ctx.MoverID non-empty.
+// Postcondition: returns nil when ctx.Cause == MoveCauseMoveTrait. Otherwise
+// returns zero or more RoundEvent{ActionType: ActionAttack} events identical
+// to the legacy CheckReactiveStrikes path.
+func CheckReactiveStrikesCtx(cbt *Combat, ctx ReactionMoveContext, rng Source, targetUpdater func(id string, hp int)) []RoundEvent {
+	// WMOVE-12: Mobile-trait granted movement does not provoke reactive strikes.
+	if ctx.Cause == MoveCauseMoveTrait {
+		return nil
+	}
 	if targetUpdater == nil {
 		targetUpdater = func(id string, hp int) {}
 	}
+	moverID := ctx.MoverID
+	oldX := ctx.FromX
+	oldY := ctx.FromY
 	mover := findCombatantByID(cbt, moverID)
 	if mover == nil {
 		return nil
@@ -795,6 +824,81 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					ActorID:    actor.ID,
 					ActorName:  actor.Name,
 					Narrative:  strideNarrative,
+				})
+
+			case ActionMoveTraitStride:
+				// WMOVE-7/12: a free Stride granted by the Mobile weapon trait.
+				// Resolves like a normal Stride but: (a) does not consume AP
+				// (already enforced at queue time via QueueFreeAction), (b) does
+				// NOT provoke reactive strikes for the moving actor, (c) does
+				// NOT fire TriggerOnEnemyMoveAdjacent for adjacent players when
+				// the mover is an NPC. Movement is bounded by SpeedBudget()
+				// (WMOVE-G1) and travels toward (TargetX, TargetY).
+				width := cbt.GridWidth
+				if width == 0 {
+					width = 10
+				}
+				height := cbt.GridHeight
+				if height == 0 {
+					height = 10
+				}
+				targetX := int(action.TargetX)
+				targetY := int(action.TargetY)
+				budget := actor.SpeedBudget()
+				stepsTaken := 0
+				moveNarrative := fmt.Sprintf("%s strides freely (move trait).", actor.Name)
+				for budget > 0 {
+					if actor.GridX == targetX && actor.GridY == targetY {
+						break
+					}
+					dx, dy := towardDelta(actor.GridX, actor.GridY, targetX, targetY)
+					if dx == 0 && dy == 0 {
+						break
+					}
+					newX := actor.GridX + dx
+					newY := actor.GridY + dy
+					if newX < 0 {
+						newX = 0
+					} else if newX >= width {
+						newX = width - 1
+					}
+					if newY < 0 {
+						newY = 0
+					} else if newY >= height {
+						newY = height - 1
+					}
+					if newX == actor.GridX && newY == actor.GridY {
+						break
+					}
+					if CellBlocked(cbt, actor.ID, newX, newY) {
+						break
+					}
+					cost, passable := cbt.EntryCost(newX, newY)
+					if !passable {
+						break
+					}
+					if cost > budget {
+						break
+					}
+					budget -= cost
+					actor.GridX = newX
+					actor.GridY = newY
+					stepsTaken++
+					if tc := cbt.TerrainAt(newX, newY); tc.Type == TerrainHazardous && tc.Hazard != nil {
+						events = append(events, applyCellHazard(cbt, actor, tc, "on_enter", src)...)
+					}
+					// WMOVE-12: explicitly do NOT fire TriggerOnEnemyMoveAdjacent
+					// here — the Mobile trait suppresses reaction triggers on
+					// the granted movement.
+				}
+				if stepsTaken == 0 {
+					moveNarrative = fmt.Sprintf("%s does not move (move trait).", actor.Name)
+				}
+				events = append(events, RoundEvent{
+					ActionType: ActionMoveTraitStride,
+					ActorID:    actor.ID,
+					ActorName:  actor.Name,
+					Narrative:  moveNarrative,
 				})
 
 			case ActionPass:

--- a/internal/game/inventory/traits/registry.go
+++ b/internal/game/inventory/traits/registry.go
@@ -1,0 +1,123 @@
+// Package traits provides the canonical registry of weapon traits used by the
+// MUD game engine. Traits are content-tagged on weapons (via the `traits:` YAML
+// list on WeaponDef) and the registry maps each trait id to a Behavior struct
+// that downstream systems consult at runtime.
+//
+// The registry is a single source of truth (REQ-WMOVE-3): all weapon-trait
+// behaviour is keyed off a Behavior in this registry. Unknown traits warn but
+// do not error (REQ-WMOVE-4) so content can land before behaviour ships.
+//
+// To avoid an import cycle between this package and internal/game/combat, the
+// Behavior.GrantsFreeAction field is a string action key rather than a typed
+// combat.ActionType. The combat package owns the canonical key constants
+// (e.g. ActionMoveTraitStrideKey) and consumers translate the key locally.
+package traits
+
+import (
+	"log/slog"
+)
+
+// Trait identifiers. Add new entries here when adding new traits.
+const (
+	// Mobile is the canonical id for the Move-trait weapon. Grants a free Stride
+	// before or after a Strike with this weapon. Aliased from the legacy `move`
+	// id at registry lookup time (WMOVE-Q1).
+	Mobile = "mobile"
+
+	// Reach is reserved here for future use; behaviour ships in a separate ticket.
+	Reach = "reach"
+)
+
+// Action key constants — used by Behavior.GrantsFreeAction. Combat consumers
+// translate these keys to their typed ActionType locally to avoid an import
+// cycle (combat depends on inventory).
+const (
+	// ActionMoveTraitStrideKey identifies the free Stride granted by the Mobile
+	// trait. Translated to combat.ActionMoveTraitStride at the consumer.
+	ActionMoveTraitStrideKey = "move_trait_stride"
+)
+
+// Behavior is the runtime contract a trait id resolves to.
+type Behavior struct {
+	// ID is the canonical trait identifier (e.g. "mobile").
+	ID string
+	// DisplayName is the human-readable trait name.
+	DisplayName string
+	// Description is the runtime-behaviour description (player-facing).
+	Description string
+	// GrantsFreeAction, when non-empty, indicates the action key the trait
+	// queues as a free action when its triggering condition is met. Empty
+	// means the trait does not grant a free action.
+	GrantsFreeAction string
+	// SuppressesReactions, when true, marks any movement caused by this trait
+	// as one that does not provoke reactive strikes / opportunity attacks.
+	SuppressesReactions bool
+}
+
+// Registry maps trait ids to Behaviors and known aliases to canonical ids.
+type Registry struct {
+	behaviors map[string]*Behavior
+	aliases   map[string]string
+}
+
+// DefaultRegistry returns the canonical registry shipped with the binary.
+//
+// Postcondition: returns a non-nil Registry containing at minimum the Mobile
+// trait and the `move` -> Mobile alias.
+func DefaultRegistry() *Registry {
+	return &Registry{
+		behaviors: map[string]*Behavior{
+			Mobile: {
+				ID:                  Mobile,
+				DisplayName:         "Mobile",
+				Description:         "Grants a free Stride before or after a Strike with this weapon. The free Stride does not provoke reactive strikes and does not consume action points.",
+				GrantsFreeAction:    ActionMoveTraitStrideKey,
+				SuppressesReactions: true,
+			},
+		},
+		aliases: map[string]string{
+			"move": Mobile,
+		},
+	}
+}
+
+// CanonicalID returns the canonical trait id for the given input. Aliases are
+// resolved to their target id; unknown ids are returned unchanged so the caller
+// can decide how to handle them.
+//
+// Postcondition: returns a non-empty string for every non-empty input.
+func (r *Registry) CanonicalID(id string) string {
+	if c, ok := r.aliases[id]; ok {
+		return c
+	}
+	return id
+}
+
+// Behavior returns the registered Behavior for id (after alias resolution), or
+// nil if no behaviour is registered.
+//
+// Postcondition: returns nil iff CanonicalID(id) is not present in the registry.
+func (r *Registry) Behavior(id string) *Behavior {
+	return r.behaviors[r.CanonicalID(id)]
+}
+
+// HasBehavior reports whether id (after alias resolution) is registered.
+func (r *Registry) HasBehavior(id string) bool {
+	return r.Behavior(id) != nil
+}
+
+// Validate inspects the given trait ids and emits a warning log entry for each
+// id that is not present in the registry. It never returns an error: unknown
+// traits are explicitly tolerated so content can land before behaviour ships
+// (WMOVE-4).
+//
+// Postcondition: returns nil. For each unknown id, a single warning log entry
+// is emitted at zerolog.WarnLevel including the trait id.
+func (r *Registry) Validate(ids []string) error {
+	for _, id := range ids {
+		if r.Behavior(id) == nil {
+			slog.Warn("unknown weapon trait — registry has no behavior", "trait", id)
+		}
+	}
+	return nil
+}

--- a/internal/game/inventory/traits/registry_test.go
+++ b/internal/game/inventory/traits/registry_test.go
@@ -1,0 +1,72 @@
+package traits_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/cory-johannsen/mud/internal/game/inventory/traits"
+)
+
+func TestDefaultRegistry_NotNil(t *testing.T) {
+	r := traits.DefaultRegistry()
+	require.NotNil(t, r)
+}
+
+func TestDefaultRegistry_MobileBehavior(t *testing.T) {
+	r := traits.DefaultRegistry()
+	b := r.Behavior(traits.Mobile)
+	require.NotNil(t, b, "Mobile must be registered")
+	assert.Equal(t, traits.Mobile, b.ID)
+	assert.Equal(t, "Mobile", b.DisplayName)
+	assert.Equal(t, traits.ActionMoveTraitStrideKey, b.GrantsFreeAction)
+	assert.True(t, b.SuppressesReactions, "Mobile must suppress reactions on its granted move")
+	assert.NotEmpty(t, b.Description)
+}
+
+func TestDefaultRegistry_MoveAliasesToMobile(t *testing.T) {
+	r := traits.DefaultRegistry()
+	assert.Equal(t, traits.Mobile, r.CanonicalID("move"))
+	b := r.Behavior("move")
+	require.NotNil(t, b, "alias `move` must resolve to the Mobile behaviour")
+	assert.Equal(t, traits.Mobile, b.ID)
+}
+
+func TestDefaultRegistry_UnknownIDReturnsNil(t *testing.T) {
+	r := traits.DefaultRegistry()
+	assert.Nil(t, r.Behavior("definitely_not_a_trait"))
+	assert.False(t, r.HasBehavior("definitely_not_a_trait"))
+}
+
+func TestDefaultRegistry_CanonicalIDPassthroughForUnknown(t *testing.T) {
+	r := traits.DefaultRegistry()
+	assert.Equal(t, "definitely_not_a_trait", r.CanonicalID("definitely_not_a_trait"))
+}
+
+func TestDefaultRegistry_ValidateUnknownTraitDoesNotError(t *testing.T) {
+	r := traits.DefaultRegistry()
+	err := r.Validate([]string{"reach", "definitely_not_a_trait", traits.Mobile, "move"})
+	assert.NoError(t, err, "unknown traits warn but do not error (WMOVE-4)")
+}
+
+func TestDefaultRegistry_HasBehaviorForKnown(t *testing.T) {
+	r := traits.DefaultRegistry()
+	assert.True(t, r.HasBehavior(traits.Mobile))
+	assert.True(t, r.HasBehavior("move"))
+}
+
+// Property: every alias must resolve to a registered behaviour, and CanonicalID
+// must be idempotent (canonical(canonical(x)) == canonical(x)).
+func TestProperty_CanonicalID_Idempotent(t *testing.T) {
+	r := traits.DefaultRegistry()
+	rapid.Check(t, func(rt *rapid.T) {
+		id := rapid.SampledFrom([]string{traits.Mobile, "move", "reach", "unknown_xyz", ""}).Draw(rt, "id")
+		c1 := r.CanonicalID(id)
+		c2 := r.CanonicalID(c1)
+		if c1 != c2 {
+			rt.Fatalf("CanonicalID not idempotent: %q -> %q -> %q", id, c1, c2)
+		}
+	})
+}

--- a/internal/game/inventory/weapon.go
+++ b/internal/game/inventory/weapon.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/cory-johannsen/mud/internal/game/inventory/traits"
 )
 
 // FiringMode represents the firing mode of a ranged weapon.
@@ -64,6 +66,27 @@ type WeaponDef struct {
 	// Maps to the "+" designation on a weapon (e.g. Vibroblade +3 has Bonus: 3).
 	// Zero means no item bonus (default). Always >= 0.
 	Bonus int `yaml:"bonus,omitempty"`
+}
+
+// HasTrait reports whether the weapon's Traits list contains the given trait id
+// (or any registered alias of it). Comparison is performed against the canonical
+// id from the default trait registry, so authors can write either the canonical
+// or the alias form in YAML.
+//
+// Postcondition: returns true iff at least one entry in w.Traits resolves to the
+// same canonical id as the input.
+func (w *WeaponDef) HasTrait(id string) bool {
+	if w == nil {
+		return false
+	}
+	r := traits.DefaultRegistry()
+	canonical := r.CanonicalID(id)
+	for _, t := range w.Traits {
+		if r.CanonicalID(t) == canonical {
+			return true
+		}
+	}
+	return false
 }
 
 // IsMelee reports whether the weapon is a melee weapon (RangeIncrement == 0).
@@ -174,6 +197,9 @@ func LoadWeapons(dir string) ([]*WeaponDef, error) {
 			w.RarityStatMultiplier = def.StatMultiplier
 			w.UpgradeSlots = def.FeatureSlots
 		}
+		// WMOVE-4: warn (do not error) for unknown trait ids so content can land
+		// before behaviour ships. The default registry tolerates aliases.
+		_ = traits.DefaultRegistry().Validate(w.Traits)
 		weapons = append(weapons, &w)
 	}
 	return weapons, nil

--- a/internal/game/inventory/weapon_test.go
+++ b/internal/game/inventory/weapon_test.go
@@ -6,10 +6,34 @@ import (
 	"testing"
 
 	"github.com/cory-johannsen/mud/internal/game/inventory"
+	"github.com/cory-johannsen/mud/internal/game/inventory/traits"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
+
+func TestWeaponDef_HasTrait_Canonical(t *testing.T) {
+	w := &inventory.WeaponDef{Traits: []string{"mobile"}}
+	assert.True(t, w.HasTrait(traits.Mobile))
+	assert.False(t, w.HasTrait("reach"))
+}
+
+func TestWeaponDef_HasTrait_AliasResolution(t *testing.T) {
+	// Authors may write either `mobile` or `move` in YAML.
+	w := &inventory.WeaponDef{Traits: []string{"move"}}
+	assert.True(t, w.HasTrait(traits.Mobile), "alias `move` must satisfy a query for canonical Mobile")
+	assert.True(t, w.HasTrait("move"), "alias `move` must satisfy a query for itself")
+}
+
+func TestWeaponDef_HasTrait_NilSafe(t *testing.T) {
+	var w *inventory.WeaponDef
+	assert.False(t, w.HasTrait(traits.Mobile))
+}
+
+func TestWeaponDef_HasTrait_EmptyTraits(t *testing.T) {
+	w := &inventory.WeaponDef{}
+	assert.False(t, w.HasTrait(traits.Mobile))
+}
 
 func TestWeaponDef_Validate_RejectsEmpty(t *testing.T) {
 	w := &inventory.WeaponDef{}
@@ -364,3 +388,4 @@ func TestProperty_WeaponDef_WeaponKind_MutuallyExclusive(t *testing.T) {
 		}
 	})
 }
+

--- a/internal/gameserver/combat_handler.go
+++ b/internal/gameserver/combat_handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cory-johannsen/mud/internal/game/mentalstate"
 	"github.com/cory-johannsen/mud/internal/game/dice"
 	"github.com/cory-johannsen/mud/internal/game/inventory"
+	"github.com/cory-johannsen/mud/internal/game/inventory/traits"
 	"github.com/cory-johannsen/mud/internal/game/npc"
 	"github.com/cory-johannsen/mud/internal/game/ruleset"
 	"github.com/cory-johannsen/mud/internal/game/session"
@@ -147,6 +148,23 @@ type CombatHandler struct {
 	// Non-positive values are treated as combat.DefaultReactionTimeout by ResolveRound.
 	// Wired in via SetReactionPromptTimeout from GameServerConfig.ReactionPromptTimeout.
 	reactionPromptTimeout time.Duration
+	// strikeActionMu guards strikeActionSeq.
+	strikeActionMu sync.Mutex
+	// strikeActionSeq is a monotonic counter used to scope once-per-Strike
+	// enforcement on free Move-trait Strides (WMOVE-10).
+	strikeActionSeq int64
+}
+
+// nextStrikeActionID returns a fresh, monotonically-increasing id used to scope
+// the once-per-Strike enforcement on queued ActionMoveTraitStride entries.
+//
+// Postcondition: returns a value greater than every previously-returned value
+// from the same CombatHandler.
+func (h *CombatHandler) nextStrikeActionID() int64 {
+	h.strikeActionMu.Lock()
+	defer h.strikeActionMu.Unlock()
+	h.strikeActionSeq++
+	return h.strikeActionSeq
 }
 
 // SetReactionPromptTimeout wires the reaction prompt timeout from
@@ -718,12 +736,43 @@ func (h *CombatHandler) Attack(uid, target string) ([]*gamev1.CombatEvent, error
 	return []*gamev1.CombatEvent{confirmEvent}, nil
 }
 
+// MoveTraitStrideRequest is an optional rider on a Strike that asks the
+// gameserver to also queue a free ActionMoveTraitStride paired with the Strike,
+// per the Mobile weapon trait (WMOVE-7/WMOVE-12). The free Stride does not
+// consume AP and does not provoke reactive strikes.
+type MoveTraitStrideRequest struct {
+	// DestinationX, DestinationY are the requested grid cell coordinates the
+	// wielder wants to stride to. The actual movement may stop short if the
+	// path is blocked or the SpeedBudget is exhausted.
+	DestinationX int32
+	DestinationY int32
+	// Ordering selects whether the free Stride is queued before or after the
+	// paired Strike (default = before).
+	Ordering combat.MoveTraitOrdering
+}
+
 // Strike queues a 2-AP ActionStrike for uid against target.
 // Requires active combat. Early-resolves if all actions submitted.
 //
 // Precondition: uid must be a valid connected player in active combat; target must be non-empty.
 // Postcondition: Returns events to return to the requesting player, or an error.
 func (h *CombatHandler) Strike(uid, target string) ([]*gamev1.CombatEvent, error) {
+	return h.StrikeWithMoveTrait(uid, target, nil)
+}
+
+// StrikeWithMoveTrait queues a 2-AP ActionStrike for uid against target, and
+// when moveStride is non-nil and the wielder's main-hand weapon has the Mobile
+// trait, additionally queues a free ActionMoveTraitStride bound to the same
+// Strike action id (WMOVE-10).
+//
+// Precondition: uid must be a valid connected player in active combat;
+// target must be non-empty; moveStride may be nil. When moveStride is non-nil,
+// the wielder's main-hand weapon MUST have the Mobile trait.
+// Postcondition: on success, both actions are appended to the wielder's queue
+// in the order specified by moveStride.Ordering. Remaining AP is reduced by
+// the Strike's normal cost only (free Stride is cost 0). On error, queue state
+// is unchanged.
+func (h *CombatHandler) StrikeWithMoveTrait(uid, target string, moveStride *MoveTraitStrideRequest) ([]*gamev1.CombatEvent, error) {
 	sess, ok := h.sessions.GetPlayer(uid)
 	if !ok {
 		return nil, fmt.Errorf("player %q not found", uid)
@@ -737,8 +786,79 @@ func (h *CombatHandler) Strike(uid, target string) ([]*gamev1.CombatEvent, error
 		return nil, fmt.Errorf("you are not in combat")
 	}
 
-	if err := cbt.QueueAction(uid, combat.QueuedAction{Type: combat.ActionStrike, Target: target}); err != nil {
+	// Determine whether the wielder is currently swinging a Mobile-trait weapon.
+	moveTraitWielder := false
+	var actor *combat.Combatant
+	for _, c := range cbt.Combatants {
+		if c.ID == uid {
+			actor = c
+			break
+		}
+	}
+	if actor != nil && actor.Loadout != nil && actor.Loadout.MainHand != nil && actor.Loadout.MainHand.Def != nil {
+		moveTraitWielder = actor.Loadout.MainHand.Def.HasTrait(traits.Mobile)
+	}
+
+	if moveStride != nil {
+		if !moveTraitWielder {
+			return nil, fmt.Errorf("equipped weapon does not have the Mobile trait")
+		}
+		if actor == nil {
+			return nil, fmt.Errorf("striker not found in combat")
+		}
+		// WMOVE-G1: bound the requested destination by SpeedBudget (Chebyshev).
+		dx := int(moveStride.DestinationX) - actor.GridX
+		if dx < 0 {
+			dx = -dx
+		}
+		dy := int(moveStride.DestinationY) - actor.GridY
+		if dy < 0 {
+			dy = -dy
+		}
+		cells := dx
+		if dy > cells {
+			cells = dy
+		}
+		if cells > actor.SpeedBudget() {
+			return nil, fmt.Errorf("move-trait stride distance %d exceeds Speed budget %d", cells, actor.SpeedBudget())
+		}
+	}
+
+	strikeID := h.nextStrikeActionID()
+
+	// When the free Stride is requested BEFORE the Strike, queue it first so
+	// ResolveRound resolves them in queue order.
+	if moveStride != nil && moveStride.Ordering == combat.MoveOrderingBefore {
+		if err := cbt.QueueFreeAction(uid, combat.QueuedAction{
+			Type:         combat.ActionMoveTraitStride,
+			TargetX:      moveStride.DestinationX,
+			TargetY:      moveStride.DestinationY,
+			MoveOrdering: combat.MoveOrderingBefore,
+			StrikeAction: strikeID,
+		}); err != nil {
+			return nil, fmt.Errorf("queuing free stride: %w", err)
+		}
+	}
+
+	if err := cbt.QueueAction(uid, combat.QueuedAction{
+		Type:             combat.ActionStrike,
+		Target:           target,
+		StrikeAction:     strikeID,
+		MoveTraitWielder: moveTraitWielder,
+	}); err != nil {
 		return nil, fmt.Errorf("queuing strike: %w", err)
+	}
+
+	if moveStride != nil && moveStride.Ordering == combat.MoveOrderingAfter {
+		if err := cbt.QueueFreeAction(uid, combat.QueuedAction{
+			Type:         combat.ActionMoveTraitStride,
+			TargetX:      moveStride.DestinationX,
+			TargetY:      moveStride.DestinationY,
+			MoveOrdering: combat.MoveOrderingAfter,
+			StrikeAction: strikeID,
+		}); err != nil {
+			return nil, fmt.Errorf("queuing free stride: %w", err)
+		}
 	}
 
 	apMsg := h.formatAPRemaining(uid, cbt)


### PR DESCRIPTION
Closes #253 (server core MVP). traits.Mobile registry + WeaponDef.HasTrait + ActionMoveTraitStride + ReactionMoveContext (suppresses reactions on the free stride). Mono-Wire Whip tagged as exemplar. Telnet UX, web UX, NPC HTN, and architecture docs deferred to follow-up.