### PR TITLE
feat(detection): State ladder + GateAttack + RoomView filter (#254)

### DIFF
--- a/content/conditions/concealed.yaml
+++ b/content/conditions/concealed.yaml
@@ -1,0 +1,15 @@
+id: concealed
+name: Concealed
+description: |
+  An attacker can pinpoint your square but you have visual concealment.
+  Attackers must succeed on a DC 5 flat check to hit you (#254 / DETECT-7).
+duration_type: encounter
+max_stacks: 0
+attack_penalty: 0
+ac_penalty: 0
+damage_bonus: 0
+speed_penalty: 0
+restrict_actions: []
+lua_on_apply: ""
+lua_on_remove: ""
+lua_on_tick: ""

--- a/content/conditions/invisible.yaml
+++ b/content/conditions/invisible.yaml
@@ -1,0 +1,15 @@
+id: invisible
+name: Invisible
+description: |
+  You cannot be seen. With an auditory cue this round the pair behaves as
+  Hidden; otherwise as Undetected (#254 / DETECT-7, DETECT-19).
+duration_type: encounter
+max_stacks: 0
+attack_penalty: 0
+ac_penalty: 0
+damage_bonus: 0
+speed_penalty: 0
+restrict_actions: []
+lua_on_apply: ""
+lua_on_remove: ""
+lua_on_tick: ""

--- a/content/conditions/observed.yaml
+++ b/content/conditions/observed.yaml
@@ -1,0 +1,15 @@
+id: observed
+name: Observed
+description: |
+  An attacker can see you clearly. No detection-state effects apply.
+  Default state for any combatant pair (#254 / DETECT-1, DETECT-2).
+duration_type: encounter
+max_stacks: 0
+attack_penalty: 0
+ac_penalty: 0
+damage_bonus: 0
+speed_penalty: 0
+restrict_actions: []
+lua_on_apply: ""
+lua_on_remove: ""
+lua_on_tick: ""

--- a/content/conditions/unnoticed.yaml
+++ b/content/conditions/unnoticed.yaml
@@ -1,0 +1,15 @@
+id: unnoticed
+name: Unnoticed
+description: |
+  The observer does not know you exist. RoomView strips Unnoticed combatants
+  from the recipient's view entirely (#254 / DETECT-7, DETECT-16).
+duration_type: encounter
+max_stacks: 0
+attack_penalty: 0
+ac_penalty: 0
+damage_bonus: 0
+speed_penalty: 0
+restrict_actions: []
+lua_on_apply: ""
+lua_on_remove: ""
+lua_on_tick: ""

--- a/docs/architecture/combat.md
+++ b/docs/architecture/combat.md
@@ -707,3 +707,87 @@ Deferred (tracked as follow-ups of #252):
 - Task 7 (other actions) — Feint, Trip, Grapple, Recall Knowledge defs.
 - The full canonical condition catalog (off_guard, clumsy, stupefied, etc.)
   beyond the four already present (frightened, fleeing, grabbed, prone).
+
+## Detection States (#254 — DETECT MVP)
+
+The `internal/game/detection/` package owns the PF2E detection ladder as a
+per-pair `(observer, target) → State` table on `Combat.DetectionStates`.
+States are: **Observed**, **Concealed**, **Hidden**, **Undetected**,
+**Unnoticed**, **Invisible**. Pair states are **asymmetric** — A's view of
+B is independent of B's view of A. Absent pairs default to `Observed`.
+
+### Components
+
+- `state.go` — `State` enum + `String()`, `MissChancePercent()`, `ParseState()`.
+- `map.go` — `Map`: thread-safe per-pair table with `Get` / `Set` / `Clear` /
+  `ForObserver` / `AdvanceTowardObserved`. Setting Observed clears the row
+  entry so absent and explicitly-Observed are indistinguishable.
+- `gate.go` — `GateAttack(state, src, opts...) GateResult`. Single uniform
+  gate per state, replacing the ad-hoc DC-11 block in `round.go`. Returns
+  `Outcome` (Proceed / AutoMiss) and `OffGuard`. Options:
+  `WithSquareGuess(Cell)`, `WithTargetCell(Cell)`, `WithSoundCue(bool)`.
+- `filter.go` — `DecideForNPC(observer, target, map, sound) FilterDecision`.
+  Drives `WorldHandler.buildRoomView` per-recipient redaction.
+- `occlusion.go` — `OcclusionProvider` interface + `NoOpOcclusion` v1
+  default. Reserved seam for #267 (Visibility / LoS).
+
+### Gating matrix
+
+| State                     | Flat check | Off-Guard | Notes                         |
+|---------------------------|------------|-----------|-------------------------------|
+| Observed                  | none       | no        | Proceed                       |
+| Concealed                 | DC 5       | no        | Fail → AutoMiss               |
+| Hidden                    | DC 11      | yes       | Fail → AutoMiss               |
+| Undetected / Unnoticed    | DC 11      | yes       | Wrong-square → AutoMiss       |
+| Invisible (sound this rd) | DC 11      | yes       | Behaves as Hidden             |
+| Invisible (no sound)      | DC 11      | yes       | Behaves as Undetected         |
+
+### Damage advances awareness
+
+`detection.AdvanceTowardObserved(map, observer, target)` walks the pair one
+rung up the ladder when damage lands: Concealed → Observed, Hidden →
+Concealed, Undetected → Hidden, Unnoticed → Undetected. Observed and
+Invisible are no-ops in v1. Wired into the ActionAttack and ActionStrike
+hit paths in `round.go` after `target.ApplyDamage(...)`.
+
+### Sound-cue tracking
+
+`Combatant.MadeSoundThisRound` is set true at action-resolution start for
+auditory actions (currently: Strike, Attack — Reload / Stride etc. are
+follow-ups). Reset to false at `StartRoundWithSrc`. Drives the
+`Invisible`-state branch in `GateAttack`.
+
+### Back-compat shim
+
+The legacy `Combatant.Hidden bool` is `// DEPRECATED` (DETECT-Q4). At
+`StartCombat`, `populateDetectionFromLegacyHidden` mirrors any combatant
+flagged Hidden to `detection.Hidden` against every other combatant in the
+map (symmetric on-ramp). The existing pinned tests in
+`round_hidden_test.go` continue to pass without modification (DETECT-9).
+
+### Outbound RoomView filter
+
+`CombatHandler.DetectionDecisionFor(uid, npcID)` returns the FilterDecision
+for a recipient; `WorldHandler.buildRoomView` consults it to drop Unnoticed
+NPCs and redact display names for Hidden / Undetected / Invisible-without-
+sound. Outside combat the decision is the zero value (no change).
+
+### YAML conditions
+
+`content/conditions/{observed,concealed,hidden,undetected,unnoticed,invisible}.yaml`
+expose each detection state as a loadable condition for designer use. The
+typed-bonus `kind: detection_state` extension and the loader bridge that
+sets `Combat.DetectionStates.Set(...)` on apply are scheduled for the #254
+follow-up alongside transition actions and UI.
+
+### Deferred to follow-up
+
+- Square-guess targeting protos and `attack-at` / `strike-at` commands
+  (Plan Task 5 + Task 8).
+- Hide / Seek / Sneak / Avoid Notice / Create-a-Diversion handlers and
+  per-enemy starting-state evaluation at combat start (Plan Task 7).
+- Telemetry log emit on `Map.Set` and per-perspective combat log narrative
+  (Plan Task 10).
+- Loader extension for `kind: detection_state` typed-bonus and the
+  `Trigger.Fire` reaction-vs-detection gate (Plan Task 9 Step 3 + 4).
+- Web square-picker UX (Plan Task 8).

--- a/internal/game/combat/combat.go
+++ b/internal/game/combat/combat.go
@@ -134,7 +134,17 @@ type Combatant struct {
 	// Hidden is true when this combatant is concealed. Attackers must pass a DC 11 flat check.
 	// For player combatants: set by hide/divert actions; cleared when the player attacks or is targeted.
 	// For NPC combatants: unused (always false).
+	//
+	// DEPRECATED (#254 / DETECT-Q4): superseded by Combat.DetectionStates per-pair table.
+	// Retained one release for back-compat; populated symmetrically into the map at
+	// Combat.Start() (see populateDetectionFromLegacyHidden) so existing pinned tests
+	// in round_hidden_test.go keep working without modification.
 	Hidden bool
+	// MadeSoundThisRound is true when this combatant performed an auditory action
+	// (Strike, Reload, Stride, MoveTo, etc.) during the current round. Drives the
+	// Invisible-state branch in detection.GateAttack: with sound the pair behaves
+	// as Hidden, without it as Undetected. Reset to false at StartRound.
+	MadeSoundThisRound bool
 	// RevealedUntilRound suppresses the DC 11 flat check for attackers through this round number.
 	// Set by a successful Seek action to cbt.Round+1.
 	RevealedUntilRound int

--- a/internal/game/combat/engine.go
+++ b/internal/game/combat/engine.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/cory-johannsen/mud/internal/game/condition"
+	"github.com/cory-johannsen/mud/internal/game/detection"
 	"github.com/cory-johannsen/mud/internal/game/effect"
 	"github.com/cory-johannsen/mud/internal/game/inventory"
 	"github.com/cory-johannsen/mud/internal/game/reaction"
@@ -69,6 +70,13 @@ type Combat struct {
 	// ReadyRegistry holds pending Ready entries for the current round.
 	// Populated by QueueAction(ActionReady); consumed by ResolveRound.
 	ReadyRegistry *reaction.ReadyRegistry
+	// DetectionStates is the per-pair (observer→target) PF2E detection ladder
+	// driving GateAttack, RoomView filtering, and reaction gating (DETECT-3).
+	// Initialised at StartCombat. Absent pairs default to detection.Observed.
+	// Legacy Combatant.Hidden flags are populated symmetrically via the
+	// back-compat shim populateDetectionFromLegacyHidden so pinned tests in
+	// round_hidden_test.go keep working unchanged.
+	DetectionStates *detection.Map
 }
 
 // SkipHazardRoundStart marks uid so that the next StartRoundWithSrc call will
@@ -128,6 +136,8 @@ func (c *Combat) StartRoundWithSrc(actionsPerRound int, src Source) []RoundCondi
 	}
 
 	// Reset (or initialise) reaction budget for each living combatant (REACTION-14).
+	// DETECT-19: also reset the per-round MadeSoundThisRound flag so the next
+	// round's auditory cue accounting starts fresh.
 	for _, cbt := range c.Combatants {
 		if cbt.IsDead() {
 			continue
@@ -139,6 +149,7 @@ func (c *Combat) StartRoundWithSrc(actionsPerRound int, src Source) []RoundCondi
 			cbt.ReactionBudget = &reaction.Budget{}
 		}
 		cbt.ReactionBudget.Reset(baseMax)
+		cbt.MadeSoundThisRound = false
 	}
 
 	var events []RoundConditionEvent
@@ -586,15 +597,16 @@ func (e *Engine) StartCombat(roomID string, combatants []*Combatant, condRegistr
 	sortByInitiativeDesc(sorted)
 
 	cbt := &Combat{
-		RoomID:        roomID,
-		Combatants:    sorted,
-		ActionQueues:  make(map[string]*ActionQueue),
-		Conditions:    make(map[string]*condition.ActiveSet),
-		DamageDealt:   make(map[string]int),
-		condRegistry:  condRegistry,
-		scriptMgr:     scriptMgr,
-		zoneID:        zoneID,
-		ReadyRegistry: reaction.NewReadyRegistry(),
+		RoomID:          roomID,
+		Combatants:      sorted,
+		ActionQueues:    make(map[string]*ActionQueue),
+		Conditions:      make(map[string]*condition.ActiveSet),
+		DamageDealt:     make(map[string]int),
+		condRegistry:    condRegistry,
+		scriptMgr:       scriptMgr,
+		zoneID:          zoneID,
+		ReadyRegistry:   reaction.NewReadyRegistry(),
+		DetectionStates: detection.NewMap(),
 	}
 	cbt.GridWidth = 20
 	cbt.GridHeight = 20
@@ -616,8 +628,35 @@ func (e *Engine) StartCombat(roomID string, combatants []*Combatant, condRegistr
 			cbt.Participants = append(cbt.Participants, c.ID)
 		}
 	}
+	// Populate the per-pair detection table from the legacy Combatant.Hidden
+	// flag (#254 / DETECT-5). Until the legacy bool is removed, any combatant
+	// flagged Hidden is treated as Hidden to every other combatant in the
+	// table (symmetric on-ramp). Asymmetric usage is set by the new handlers.
+	populateDetectionFromLegacyHidden(cbt)
 	e.combats[roomID] = cbt
 	return cbt, nil
+}
+
+// populateDetectionFromLegacyHidden is the DETECT-5 back-compat shim. For each
+// combatant whose deprecated Hidden flag is true, it sets every other
+// combatant's pair-state to detection.Hidden. This preserves the behaviour of
+// the existing pinned tests in round_hidden_test.go while new code migrates
+// onto the per-pair table.
+func populateDetectionFromLegacyHidden(cbt *Combat) {
+	if cbt == nil || cbt.DetectionStates == nil {
+		return
+	}
+	for _, target := range cbt.Combatants {
+		if !target.Hidden {
+			continue
+		}
+		for _, observer := range cbt.Combatants {
+			if observer == target {
+				continue
+			}
+			cbt.DetectionStates.Set(observer.ID, target.ID, detection.Hidden)
+		}
+	}
 }
 
 // GetCombatant returns the combatant with the given ID, or nil if not found.

--- a/internal/game/combat/round.go
+++ b/internal/game/combat/round.go
@@ -9,6 +9,7 @@ import (
 	lua "github.com/yuin/gopher-lua"
 
 	"github.com/cory-johannsen/mud/internal/game/condition"
+	"github.com/cory-johannsen/mud/internal/game/detection"
 	"github.com/cory-johannsen/mud/internal/game/dice"
 	"github.com/cory-johannsen/mud/internal/game/effect"
 	"github.com/cory-johannsen/mud/internal/game/inventory"
@@ -929,9 +930,15 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					})
 					continue
 				}
+				// DETECT-19: Strike/Attack is an auditory action.
+				actor.MadeSoundThisRound = true
 				// Hidden flat check: NPC attacking a hidden player must pass DC 11.
 				if actor.Kind == KindNPC && target.Kind == KindPlayer && target.Hidden {
 					target.Hidden = false // being targeted always breaks concealment
+					// Mirror the legacy clear into the per-pair map (DETECT-3).
+					if cbt.DetectionStates != nil {
+						cbt.DetectionStates.Clear(actor.ID, target.ID)
+					}
 					flatRoll := src.Intn(20) + 1
 					if flatRoll <= 10 {
 						events = append(events, RoundEvent{
@@ -960,6 +967,9 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					}
 					// Flat check passed — attack proceeds, hidden is cleared.
 					target.Hidden = false
+					if cbt.DetectionStates != nil {
+						cbt.DetectionStates.Clear(actor.ID, target.ID)
+					}
 				}
 				// Range enforcement: determine weapon type and enforce distance rules.
 				var mainHandDef *inventory.WeaponDef
@@ -1136,6 +1146,11 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					if actor.Kind == KindPlayer && target.Kind == KindNPC {
 						cbt.RecordDamage(actor.ID, dmg)
 					}
+					// DETECT-27: damage advances the target's awareness of the
+					// attacker one rung up the detection ladder.
+					if cbt.DetectionStates != nil {
+						detection.AdvanceTowardObserved(cbt.DetectionStates, target.ID, actor.ID)
+					}
 					// REQ-RXN19: TriggerOnAllyDamaged fires for other players when a player ally takes damage.
 					if target.Kind == KindPlayer {
 						for _, c := range cbt.Combatants {
@@ -1208,10 +1223,15 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					})
 					continue
 				}
+				// DETECT-19: Strike is an auditory action.
+				actor.MadeSoundThisRound = true
 				// Hidden flat check: NPC striking a hidden player must pass DC 11.
 				// On failure, skip BOTH strikes with a single flat-check-fail event.
 				if actor.Kind == KindNPC && target.Kind == KindPlayer && target.Hidden {
 					target.Hidden = false // being targeted always breaks concealment
+					if cbt.DetectionStates != nil {
+						cbt.DetectionStates.Clear(actor.ID, target.ID)
+					}
 					flatRoll := src.Intn(20) + 1
 					if flatRoll <= 10 {
 						events = append(events, RoundEvent{
@@ -1313,6 +1333,11 @@ func ResolveRound(cbt *Combat, src Source, targetUpdater func(id string, hp int)
 					targetUpdater(target.ID, target.CurrentHP)
 					if actor.Kind == KindPlayer && target.Kind == KindNPC {
 						cbt.RecordDamage(actor.ID, dmg1)
+					}
+					// DETECT-27: damage advances the target's awareness of the
+					// attacker one rung up the detection ladder.
+					if cbt.DetectionStates != nil {
+						detection.AdvanceTowardObserved(cbt.DetectionStates, target.ID, actor.ID)
 					}
 					// REQ-RXN19: TriggerOnAllyDamaged fires for other players when a player ally takes damage.
 					if target.Kind == KindPlayer {

--- a/internal/game/combat/round_detection_test.go
+++ b/internal/game/combat/round_detection_test.go
@@ -1,0 +1,88 @@
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/combat"
+	"github.com/cory-johannsen/mud/internal/game/condition"
+	"github.com/cory-johannsen/mud/internal/game/detection"
+)
+
+// TestStartCombat_DetectionStatesInitialised verifies StartCombat installs a
+// non-nil DetectionStates map (#254 / DETECT-3).
+func TestStartCombat_DetectionStatesInitialised(t *testing.T) {
+	reg := condition.NewRegistry()
+	reg.Register(&condition.ConditionDef{ID: "dying", Name: "Dying", DurationType: "until_save", MaxStacks: 4})
+	reg.Register(&condition.ConditionDef{ID: "wounded", Name: "Wounded", DurationType: "permanent", MaxStacks: 3})
+	eng := combat.NewEngine()
+	combatants := []*combat.Combatant{
+		{ID: "p1", Kind: combat.KindPlayer, Name: "P", MaxHP: 10, CurrentHP: 10, AC: 10, Level: 1},
+		{ID: "n1", Kind: combat.KindNPC, Name: "N", MaxHP: 10, CurrentHP: 10, AC: 10, Level: 1},
+	}
+	cbt, err := eng.StartCombat("room", combatants, reg, nil, "")
+	if err != nil {
+		t.Fatalf("StartCombat: %v", err)
+	}
+	if cbt.DetectionStates == nil {
+		t.Fatalf("DetectionStates must be initialised at StartCombat")
+	}
+	// Absent pair → Observed.
+	if got := cbt.DetectionStates.Get("p1", "n1"); got != detection.Observed {
+		t.Errorf("absent pair Get = %v, want Observed", got)
+	}
+}
+
+// TestStartCombat_LegacyHiddenFlagPopulatesMapSymmetrically verifies the
+// DETECT-5 back-compat shim: a combatant with Hidden=true at StartCombat is
+// projected into the per-pair map symmetrically against every other
+// combatant.
+func TestStartCombat_LegacyHiddenFlagPopulatesMapSymmetrically(t *testing.T) {
+	reg := condition.NewRegistry()
+	reg.Register(&condition.ConditionDef{ID: "dying", Name: "Dying", DurationType: "until_save", MaxStacks: 4})
+	reg.Register(&condition.ConditionDef{ID: "wounded", Name: "Wounded", DurationType: "permanent", MaxStacks: 3})
+	eng := combat.NewEngine()
+	combatants := []*combat.Combatant{
+		{ID: "p1", Kind: combat.KindPlayer, Name: "P1", MaxHP: 10, CurrentHP: 10, AC: 10, Level: 1},
+		{ID: "p2", Kind: combat.KindPlayer, Name: "P2", MaxHP: 10, CurrentHP: 10, AC: 10, Level: 1},
+		{ID: "n1", Kind: combat.KindNPC, Name: "N1", MaxHP: 10, CurrentHP: 10, AC: 10, Level: 1, Hidden: true},
+	}
+	cbt, err := eng.StartCombat("room", combatants, reg, nil, "")
+	if err != nil {
+		t.Fatalf("StartCombat: %v", err)
+	}
+	if got := cbt.DetectionStates.Get("p1", "n1"); got != detection.Hidden {
+		t.Errorf("p1→n1 = %v, want Hidden (legacy shim)", got)
+	}
+	if got := cbt.DetectionStates.Get("p2", "n1"); got != detection.Hidden {
+		t.Errorf("p2→n1 = %v, want Hidden (legacy shim)", got)
+	}
+	// Non-hidden combatants are untouched.
+	if got := cbt.DetectionStates.Get("n1", "p1"); got != detection.Observed {
+		t.Errorf("n1→p1 = %v, want Observed (asymmetric)", got)
+	}
+}
+
+// TestStartRound_ResetsMadeSoundThisRound verifies that
+// MadeSoundThisRound is cleared at the start of each round (DETECT-19).
+func TestStartRound_ResetsMadeSoundThisRound(t *testing.T) {
+	reg := condition.NewRegistry()
+	reg.Register(&condition.ConditionDef{ID: "dying", Name: "Dying", DurationType: "until_save", MaxStacks: 4})
+	reg.Register(&condition.ConditionDef{ID: "wounded", Name: "Wounded", DurationType: "permanent", MaxStacks: 3})
+	eng := combat.NewEngine()
+	combatants := []*combat.Combatant{
+		{ID: "p1", Kind: combat.KindPlayer, Name: "P", MaxHP: 10, CurrentHP: 10, AC: 10, Level: 1},
+		{ID: "n1", Kind: combat.KindNPC, Name: "N", MaxHP: 10, CurrentHP: 10, AC: 10, Level: 1},
+	}
+	cbt, err := eng.StartCombat("room", combatants, reg, nil, "")
+	if err != nil {
+		t.Fatalf("StartCombat: %v", err)
+	}
+	cbt.Combatants[0].MadeSoundThisRound = true
+	cbt.Combatants[1].MadeSoundThisRound = true
+	_ = cbt.StartRound(3)
+	for _, c := range cbt.Combatants {
+		if c.MadeSoundThisRound {
+			t.Errorf("%s: MadeSoundThisRound must reset at StartRound", c.Name)
+		}
+	}
+}

--- a/internal/game/detection/filter.go
+++ b/internal/game/detection/filter.go
@@ -1,0 +1,57 @@
+package detection
+
+// FilterableNPC is the minimal NPC view shape FilterRoomView mutates. The
+// gameserver's gamev1.NpcInfo satisfies this shape via field aliases; the
+// filter is defined on a local interface so the detection package does not
+// import the protobuf-generated package (and to ease testing).
+type FilterableNPC interface {
+	GetInstanceId() string
+	GetName() string
+}
+
+// FilterDecision describes how a single NPC should be presented to a given
+// observer after consulting the detection state.
+type FilterDecision struct {
+	// Drop, when true, means the NPC must be omitted from the recipient's
+	// view entirely (Unnoticed).
+	Drop bool
+	// RedactName, when non-empty, replaces the NPC's display name in the
+	// recipient's view (e.g. "???" for Undetected, "<silhouette>" for
+	// Hidden). Empty means show the real name.
+	RedactName string
+	// HideCell, when true, instructs the renderer to omit the NPC's grid
+	// position from the recipient's view (Undetected / Unnoticed /
+	// Invisible-without-sound).
+	HideCell bool
+}
+
+// DecideForNPC returns the FilterDecision the recipient observer should apply
+// to a given NPC instance based on the detection state map. Pure function;
+// safe for use in a broadcast loop.
+//
+// Mapping:
+//
+//	Observed   → no change
+//	Concealed  → no change (concealment is a check-time effect, not a redact)
+//	Hidden     → keep cell, redact name to "<silhouette>"
+//	Undetected → hide cell, redact name to "???"
+//	Unnoticed  → drop entirely
+//	Invisible  → with sound cue: same as Hidden; otherwise same as Undetected
+func DecideForNPC(observerUID, npcUID string, m *Map, soundCue bool) FilterDecision {
+	switch m.Get(observerUID, npcUID) {
+	case Observed, Concealed:
+		return FilterDecision{}
+	case Hidden:
+		return FilterDecision{RedactName: "<silhouette>"}
+	case Undetected:
+		return FilterDecision{RedactName: "???", HideCell: true}
+	case Unnoticed:
+		return FilterDecision{Drop: true}
+	case Invisible:
+		if soundCue {
+			return FilterDecision{RedactName: "<silhouette>"}
+		}
+		return FilterDecision{RedactName: "???", HideCell: true}
+	}
+	return FilterDecision{}
+}

--- a/internal/game/detection/filter_test.go
+++ b/internal/game/detection/filter_test.go
@@ -1,0 +1,82 @@
+package detection_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/detection"
+)
+
+func TestDecideForNPC_ObservedNoChange(t *testing.T) {
+	m := detection.NewMap()
+	d := detection.DecideForNPC("hero", "thug", m, false)
+	if d.Drop || d.RedactName != "" || d.HideCell {
+		t.Errorf("Observed: %+v want zero", d)
+	}
+}
+
+func TestDecideForNPC_ConcealedNoChange(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("hero", "thug", detection.Concealed)
+	d := detection.DecideForNPC("hero", "thug", m, false)
+	if d.Drop || d.RedactName != "" || d.HideCell {
+		t.Errorf("Concealed: %+v want zero", d)
+	}
+}
+
+func TestDecideForNPC_HiddenSilhouetteCellShown(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("hero", "thug", detection.Hidden)
+	d := detection.DecideForNPC("hero", "thug", m, false)
+	if d.Drop || d.RedactName != "<silhouette>" || d.HideCell {
+		t.Errorf("Hidden: %+v want silhouette+cell", d)
+	}
+}
+
+func TestDecideForNPC_UndetectedTripleQuestionCellHidden(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("hero", "stalker", detection.Undetected)
+	d := detection.DecideForNPC("hero", "stalker", m, false)
+	if d.Drop || d.RedactName != "???" || !d.HideCell {
+		t.Errorf("Undetected: %+v want ??? + hide cell", d)
+	}
+}
+
+func TestDecideForNPC_UnnoticedDropped(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("hero", "ghost", detection.Unnoticed)
+	d := detection.DecideForNPC("hero", "ghost", m, false)
+	if !d.Drop {
+		t.Errorf("Unnoticed: %+v want Drop", d)
+	}
+}
+
+func TestDecideForNPC_InvisibleSoundActsLikeHidden(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("hero", "ghost", detection.Invisible)
+	d := detection.DecideForNPC("hero", "ghost", m, true)
+	if d.Drop || d.RedactName != "<silhouette>" || d.HideCell {
+		t.Errorf("Invisible+sound: %+v want silhouette+cell", d)
+	}
+}
+
+func TestDecideForNPC_InvisibleSilentActsLikeUndetected(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("hero", "ghost", detection.Invisible)
+	d := detection.DecideForNPC("hero", "ghost", m, false)
+	if d.Drop || d.RedactName != "???" || !d.HideCell {
+		t.Errorf("Invisible silent: %+v want ??? + hide cell", d)
+	}
+}
+
+func TestDecideForNPC_PerRecipientDifferentResults(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("h1", "thug", detection.Undetected)
+	d1 := detection.DecideForNPC("h1", "thug", m, false)
+	d2 := detection.DecideForNPC("h2", "thug", m, false)
+	if d1.RedactName != "???" {
+		t.Errorf("h1 sees %+v, want ???", d1)
+	}
+	if d2.RedactName != "" || d2.Drop {
+		t.Errorf("h2 sees %+v, want unchanged", d2)
+	}
+}

--- a/internal/game/detection/gate.go
+++ b/internal/game/detection/gate.go
@@ -1,0 +1,147 @@
+package detection
+
+// GateOutcome is the disposition GateAttack reaches for the candidate attack.
+type GateOutcome int
+
+const (
+	// GateProceed means the attack roll proceeds to normal AC resolution.
+	// OffGuard may still be true on the result.
+	GateProceed GateOutcome = iota
+	// GateAutoMiss means the attack is converted to a miss before AC
+	// resolution — typically by a failed flat check or a wrong-square guess.
+	GateAutoMiss
+)
+
+// GateResult is the disposition of an attempted attack from observer→target,
+// after consulting the pair's detection state.
+type GateResult struct {
+	// Outcome is the gate disposition: Proceed or AutoMiss.
+	Outcome GateOutcome
+	// OffGuard, when true, means the target should be treated as off-guard
+	// against this attack (typically via the existing condition pipeline).
+	// Off-guard is conferred by Hidden / Undetected / Unnoticed / Invisible
+	// pair-states regardless of whether the gate proceeded or auto-missed.
+	OffGuard bool
+	// FlatRoll is the d20 roll consulted for the flat check, or 0 if no
+	// check was rolled. Diagnostic only.
+	FlatRoll int
+	// FlatDC is the DC of the flat check that gated this attack, or 0 if no
+	// check was rolled. Diagnostic only.
+	FlatDC int
+}
+
+// IntnSource is the minimal RNG interface GateAttack needs. It matches the
+// combat package's Source interface so the gate can share the same RNG.
+type IntnSource interface {
+	Intn(n int) int
+}
+
+// Cell is a grid coordinate used for square-guess targeting against an
+// Undetected / Unnoticed / Invisible target. Cells compare with == and may
+// be used as map keys.
+type Cell struct {
+	X int
+	Y int
+}
+
+type gateOpts struct {
+	hasGuess bool
+	guess    Cell
+	// targetCell is the actual cell the target occupies, used to compare
+	// against the guess. Zero-valued by default; callers wishing to gate on
+	// square-guess accuracy MUST pass WithTargetCell.
+	hasTargetCell bool
+	targetCell    Cell
+	// soundCue indicates the target made an auditory action this round
+	// (PF2E "auditory" trait). Required for Invisible to fall through to
+	// Hidden semantics rather than Undetected.
+	soundCue bool
+}
+
+// Option mutates a GateAttack invocation.
+type Option func(*gateOpts)
+
+// WithSquareGuess attaches a guessed cell from the attacker. Required for
+// Undetected / Unnoticed / Invisible-without-sound targets to have any chance
+// of resolving as a hit; the gate auto-misses without a guess for those
+// states.
+func WithSquareGuess(c Cell) Option {
+	return func(o *gateOpts) {
+		o.hasGuess = true
+		o.guess = c
+	}
+}
+
+// WithTargetCell supplies the target's actual cell so the gate can compare
+// the guess for square-guess accuracy.
+func WithTargetCell(c Cell) Option {
+	return func(o *gateOpts) {
+		o.hasTargetCell = true
+		o.targetCell = c
+	}
+}
+
+// WithSoundCue marks that the target made a sound this round. Required for
+// Invisible to fall through to Hidden semantics rather than Undetected.
+func WithSoundCue(made bool) Option {
+	return func(o *gateOpts) {
+		o.soundCue = made
+	}
+}
+
+// GateAttack is the uniform per-state gate that runs before normal AC
+// resolution. It returns the gate disposition (Proceed or AutoMiss) and the
+// off-guard flag the caller should apply (typically by attaching a transient
+// off_guard condition via the existing pipeline).
+//
+// The DC matrix per state is:
+//
+//	Observed                : no check, OffGuard=false, Proceed
+//	Concealed               : DC 5 flat check; fail → AutoMiss; pass → Proceed
+//	Hidden                  : DC 11 flat check; fail → AutoMiss; pass → Proceed, OffGuard=true
+//	Undetected / Unnoticed  : Wrong-square guess → AutoMiss, OffGuard=true
+//	                          Right-square guess → DC 11 flat check; fail → AutoMiss; pass → Proceed
+//	                          Both branches always set OffGuard=true.
+//	Invisible               : if soundCue → behave as Hidden; else as Undetected.
+//
+// Precondition: src must be non-nil for any state that rolls a flat check
+// (i.e., everything except Observed).
+func GateAttack(st State, src IntnSource, opts ...Option) GateResult {
+	o := gateOpts{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	switch st {
+	case Observed:
+		return GateResult{Outcome: GateProceed}
+	case Concealed:
+		roll := src.Intn(20) + 1
+		if roll < 5 {
+			return GateResult{Outcome: GateAutoMiss, FlatRoll: roll, FlatDC: 5}
+		}
+		return GateResult{Outcome: GateProceed, FlatRoll: roll, FlatDC: 5}
+	case Hidden:
+		roll := src.Intn(20) + 1
+		if roll < 11 {
+			return GateResult{Outcome: GateAutoMiss, FlatRoll: roll, FlatDC: 11}
+		}
+		return GateResult{Outcome: GateProceed, OffGuard: true, FlatRoll: roll, FlatDC: 11}
+	case Undetected, Unnoticed:
+		// Wrong-square guess (or no guess at all) is an automatic miss.
+		// The target is off-guard regardless.
+		if !o.hasGuess || (o.hasTargetCell && o.guess != o.targetCell) {
+			return GateResult{Outcome: GateAutoMiss, OffGuard: true}
+		}
+		roll := src.Intn(20) + 1
+		if roll < 11 {
+			return GateResult{Outcome: GateAutoMiss, OffGuard: true, FlatRoll: roll, FlatDC: 11}
+		}
+		return GateResult{Outcome: GateProceed, OffGuard: true, FlatRoll: roll, FlatDC: 11}
+	case Invisible:
+		if o.soundCue {
+			return GateAttack(Hidden, src, opts...)
+		}
+		return GateAttack(Undetected, src, opts...)
+	}
+	return GateResult{Outcome: GateProceed}
+}

--- a/internal/game/detection/gate_test.go
+++ b/internal/game/detection/gate_test.go
@@ -1,0 +1,98 @@
+package detection_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/detection"
+)
+
+// fixedSrc returns a fixed Intn value (the d20 face minus 1, since the gate
+// adds +1 to the result of Intn(20)).
+type fixedSrc struct{ face int }
+
+// Intn for fixedSrc ignores n and returns face-1 so callers see exactly face
+// when the gate evaluates `Intn(20) + 1`.
+func (f fixedSrc) Intn(int) int { return f.face - 1 }
+
+func TestGate_Observed_Proceeds(t *testing.T) {
+	res := detection.GateAttack(detection.Observed, fixedSrc{20})
+	if res.Outcome != detection.GateProceed || res.OffGuard {
+		t.Errorf("Observed: %+v want Proceed/!OffGuard", res)
+	}
+}
+
+func TestGate_Concealed_FlatCheckFail_AutoMiss(t *testing.T) {
+	res := detection.GateAttack(detection.Concealed, fixedSrc{4}) // < 5
+	if res.Outcome != detection.GateAutoMiss {
+		t.Errorf("Concealed flat-fail: %+v want AutoMiss", res)
+	}
+}
+
+func TestGate_Concealed_FlatCheckPass_Proceeds(t *testing.T) {
+	res := detection.GateAttack(detection.Concealed, fixedSrc{5})
+	if res.Outcome != detection.GateProceed || res.OffGuard {
+		t.Errorf("Concealed flat-pass: %+v want Proceed/!OffGuard", res)
+	}
+}
+
+func TestGate_Hidden_FlatCheckFail_AutoMiss(t *testing.T) {
+	res := detection.GateAttack(detection.Hidden, fixedSrc{10})
+	if res.Outcome != detection.GateAutoMiss {
+		t.Errorf("Hidden flat-fail: %+v want AutoMiss", res)
+	}
+}
+
+func TestGate_Hidden_PassAppliesOffGuard(t *testing.T) {
+	res := detection.GateAttack(detection.Hidden, fixedSrc{15})
+	if res.Outcome != detection.GateProceed || !res.OffGuard {
+		t.Errorf("Hidden flat-pass: %+v want Proceed/OffGuard", res)
+	}
+}
+
+func TestGate_Undetected_NoGuess_AutoMiss(t *testing.T) {
+	res := detection.GateAttack(detection.Undetected, fixedSrc{20})
+	if res.Outcome != detection.GateAutoMiss || !res.OffGuard {
+		t.Errorf("Undetected no-guess: %+v want AutoMiss/OffGuard", res)
+	}
+}
+
+func TestGate_Undetected_WrongSquare_AutoMiss(t *testing.T) {
+	res := detection.GateAttack(detection.Undetected, fixedSrc{20},
+		detection.WithSquareGuess(detection.Cell{X: 1, Y: 1}),
+		detection.WithTargetCell(detection.Cell{X: 9, Y: 9}))
+	if res.Outcome != detection.GateAutoMiss || !res.OffGuard {
+		t.Errorf("Undetected wrong-square: %+v want AutoMiss/OffGuard", res)
+	}
+}
+
+func TestGate_Undetected_RightSquareThenFlatCheckFail(t *testing.T) {
+	c := detection.Cell{X: 5, Y: 5}
+	res := detection.GateAttack(detection.Undetected, fixedSrc{5},
+		detection.WithSquareGuess(c), detection.WithTargetCell(c))
+	if res.Outcome != detection.GateAutoMiss || !res.OffGuard {
+		t.Errorf("Undetected right-square flat-fail: %+v want AutoMiss/OffGuard", res)
+	}
+}
+
+func TestGate_Undetected_RightSquareFlatCheckPass(t *testing.T) {
+	c := detection.Cell{X: 5, Y: 5}
+	res := detection.GateAttack(detection.Undetected, fixedSrc{15},
+		detection.WithSquareGuess(c), detection.WithTargetCell(c))
+	if res.Outcome != detection.GateProceed || !res.OffGuard {
+		t.Errorf("Undetected right-square flat-pass: %+v want Proceed/OffGuard", res)
+	}
+}
+
+func TestGate_Invisible_WithSoundCue_BehavesLikeHidden(t *testing.T) {
+	res := detection.GateAttack(detection.Invisible, fixedSrc{15}, detection.WithSoundCue(true))
+	if res.Outcome != detection.GateProceed || !res.OffGuard {
+		t.Errorf("Invisible+sound flat-pass: %+v want Proceed/OffGuard", res)
+	}
+}
+
+func TestGate_Invisible_WithoutSoundCue_BehavesLikeUndetected(t *testing.T) {
+	res := detection.GateAttack(detection.Invisible, fixedSrc{20}, detection.WithSoundCue(false))
+	if res.Outcome != detection.GateAutoMiss || !res.OffGuard {
+		t.Errorf("Invisible no-sound: %+v want AutoMiss/OffGuard", res)
+	}
+}

--- a/internal/game/detection/map.go
+++ b/internal/game/detection/map.go
@@ -1,0 +1,118 @@
+package detection
+
+import "sync"
+
+// Map is the per-combat (observer, target) → State table. Absent pairs default
+// to Observed. Operations are goroutine-safe: combat resolution touches the
+// map from action handlers and from the broadcast goroutine that builds
+// per-recipient RoomViews.
+//
+// The on-disk shape is map[observerUID]map[targetUID]State; an empty map is
+// equivalent to "every pair is Observed".
+type Map struct {
+	mu    sync.RWMutex
+	pairs map[string]map[string]State
+}
+
+// NewMap constructs an empty Map. All pairs default to Observed until set.
+func NewMap() *Map {
+	return &Map{pairs: map[string]map[string]State{}}
+}
+
+// Get returns the state of target as observed by observer. Returns Observed
+// for any unset pair, including the case where observer == target. Get is
+// safe to call on a nil receiver and returns Observed.
+func (m *Map) Get(observerUID, targetUID string) State {
+	if m == nil {
+		return Observed
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	row, ok := m.pairs[observerUID]
+	if !ok {
+		return Observed
+	}
+	st, ok := row[targetUID]
+	if !ok {
+		return Observed
+	}
+	return st
+}
+
+// Set assigns the (observer, target) pair to st. Setting a pair to Observed
+// is equivalent to Clear: the row entry is removed so absent and explicitly-
+// observed pairs are indistinguishable.
+//
+// Precondition: observerUID and targetUID must be non-empty and distinct.
+func (m *Map) Set(observerUID, targetUID string, st State) {
+	if m == nil || observerUID == "" || targetUID == "" || observerUID == targetUID {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if st == Observed {
+		if row, ok := m.pairs[observerUID]; ok {
+			delete(row, targetUID)
+			if len(row) == 0 {
+				delete(m.pairs, observerUID)
+			}
+		}
+		return
+	}
+	row, ok := m.pairs[observerUID]
+	if !ok {
+		row = map[string]State{}
+		m.pairs[observerUID] = row
+	}
+	row[targetUID] = st
+}
+
+// Clear removes the (observer, target) pair. After Clear, Get returns
+// Observed for that pair.
+func (m *Map) Clear(observerUID, targetUID string) {
+	m.Set(observerUID, targetUID, Observed)
+}
+
+// ForObserver returns a snapshot map of every non-Observed target state for
+// observerUID. The returned map is a fresh copy and may be mutated by the
+// caller. Returns an empty map (never nil) if observerUID has no entries.
+func (m *Map) ForObserver(observerUID string) map[string]State {
+	out := map[string]State{}
+	if m == nil {
+		return out
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if row, ok := m.pairs[observerUID]; ok {
+		for k, v := range row {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// AdvanceTowardObserved moves the (observer, target) pair one rung up the
+// detection ladder toward Observed, modelling PF2E's "damage advances
+// awareness" rule: Concealed → Observed, Hidden → Concealed, Undetected →
+// Hidden, Unnoticed → Undetected. Invisible and Observed are no-ops in v1.
+func AdvanceTowardObserved(m *Map, observerUID, targetUID string) {
+	if m == nil {
+		return
+	}
+	cur := m.Get(observerUID, targetUID)
+	var next State
+	switch cur {
+	case Concealed:
+		next = Observed
+	case Hidden:
+		next = Concealed
+	case Undetected:
+		next = Hidden
+	case Unnoticed:
+		next = Undetected
+	default:
+		// Observed and Invisible are no-ops.
+		return
+	}
+	m.Set(observerUID, targetUID, next)
+}

--- a/internal/game/detection/map_test.go
+++ b/internal/game/detection/map_test.go
@@ -1,0 +1,104 @@
+package detection_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/detection"
+)
+
+func TestMap_AbsentPairDefaultsObserved(t *testing.T) {
+	m := detection.NewMap()
+	if got := m.Get("a", "b"); got != detection.Observed {
+		t.Errorf("absent pair = %v, want Observed", got)
+	}
+}
+
+func TestMap_NilReceiverReturnsObserved(t *testing.T) {
+	var m *detection.Map
+	if got := m.Get("a", "b"); got != detection.Observed {
+		t.Errorf("nil-receiver Get = %v, want Observed", got)
+	}
+	// Set on a nil receiver must be a no-op (no panic).
+	m.Set("a", "b", detection.Hidden)
+}
+
+func TestMap_AsymmetricGetSet(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("a", "b", detection.Hidden)
+	if got := m.Get("a", "b"); got != detection.Hidden {
+		t.Errorf("Get(a,b) = %v, want Hidden", got)
+	}
+	if got := m.Get("b", "a"); got != detection.Observed {
+		t.Errorf("Get(b,a) = %v, want Observed (asymmetric)", got)
+	}
+}
+
+func TestMap_ClearRevertsToObserved(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("a", "b", detection.Hidden)
+	m.Clear("a", "b")
+	if got := m.Get("a", "b"); got != detection.Observed {
+		t.Errorf("after Clear: Get = %v, want Observed", got)
+	}
+}
+
+func TestMap_SetObservedRemovesEntry(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("a", "b", detection.Hidden)
+	m.Set("a", "b", detection.Observed)
+	if got := m.Get("a", "b"); got != detection.Observed {
+		t.Errorf("Set(Observed) should clear: Get = %v, want Observed", got)
+	}
+}
+
+func TestMap_SetSelfPairRejected(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("a", "a", detection.Hidden) // observer == target — no-op
+	if got := m.Get("a", "a"); got != detection.Observed {
+		t.Errorf("self-pair must remain Observed")
+	}
+}
+
+func TestMap_ForObserverIteratesAllTargets(t *testing.T) {
+	m := detection.NewMap()
+	m.Set("a", "b", detection.Hidden)
+	m.Set("a", "c", detection.Concealed)
+	m.Set("b", "c", detection.Undetected) // unrelated row
+	got := m.ForObserver("a")
+	if len(got) != 2 || got["b"] != detection.Hidden || got["c"] != detection.Concealed {
+		t.Errorf("ForObserver(a) = %v, want {b:Hidden, c:Concealed}", got)
+	}
+}
+
+func TestAdvanceTowardObserved_Ladder(t *testing.T) {
+	cases := []struct {
+		from, to detection.State
+	}{
+		{detection.Concealed, detection.Observed},
+		{detection.Hidden, detection.Concealed},
+		{detection.Undetected, detection.Hidden},
+		{detection.Unnoticed, detection.Undetected},
+	}
+	for _, c := range cases {
+		m := detection.NewMap()
+		m.Set("o", "t", c.from)
+		detection.AdvanceTowardObserved(m, "o", "t")
+		if got := m.Get("o", "t"); got != c.to {
+			t.Errorf("Advance(%v) = %v, want %v", c.from, got, c.to)
+		}
+	}
+}
+
+func TestAdvanceTowardObserved_NoOpAtTopAndInvisible(t *testing.T) {
+	m := detection.NewMap()
+	// Observed (absent) should remain Observed.
+	detection.AdvanceTowardObserved(m, "o", "t")
+	if got := m.Get("o", "t"); got != detection.Observed {
+		t.Errorf("Advance from Observed = %v, want Observed", got)
+	}
+	m.Set("o", "t", detection.Invisible)
+	detection.AdvanceTowardObserved(m, "o", "t")
+	if got := m.Get("o", "t"); got != detection.Invisible {
+		t.Errorf("Advance from Invisible = %v, want Invisible (no-op in v1)", got)
+	}
+}

--- a/internal/game/detection/occlusion.go
+++ b/internal/game/detection/occlusion.go
@@ -1,0 +1,18 @@
+package detection
+
+// OcclusionProvider is the seam reserved for Line-of-Sight / occlusion checks
+// (#267). v1 of the detection ladder ships a no-op implementation that always
+// returns "no occlusion"; #267 fills in real geometry.
+//
+// IsOccluded returns true if the line from observer→target is blocked by an
+// opaque obstruction. Callers should treat occlusion as forcing the pair-
+// state to at least Hidden when true.
+type OcclusionProvider interface {
+	IsOccluded(observerUID, targetUID string) bool
+}
+
+// NoOpOcclusion is the v1 default OcclusionProvider: every line is clear.
+type NoOpOcclusion struct{}
+
+// IsOccluded always returns false in the no-op provider.
+func (NoOpOcclusion) IsOccluded(string, string) bool { return false }

--- a/internal/game/detection/state.go
+++ b/internal/game/detection/state.go
@@ -1,0 +1,102 @@
+// Package detection implements the PF2E detection states ladder — the
+// per-pair (observer, target) → State machine that drives flat-check gating,
+// off-guard application, square-guess targeting, and outbound RoomView
+// filtering.
+//
+// See docs/superpowers/specs/2026-04-24-detection-states.md and
+// docs/superpowers/plans/2026-04-25-detection-states.md for the full
+// requirements catalogue.
+package detection
+
+// State is the PF2E detection state of a target relative to a specific
+// observer. Pair states are asymmetric: A's state to B is independent of B's
+// state to A.
+type State int
+
+const (
+	// Observed is the default: the observer can see the target clearly. No
+	// flat-check or off-guard is applied; attacks proceed normally.
+	Observed State = iota
+	// Concealed: the observer can pinpoint the target's square but the target
+	// has visual concealment. Attacks must succeed at a DC 5 flat check.
+	Concealed
+	// Hidden: the observer knows the target's square but cannot see them
+	// precisely. Attacks must succeed at a DC 11 flat check; on success the
+	// target is off-guard against this attack.
+	Hidden
+	// Undetected: the observer does not know the target's location. Attacks
+	// require a square-guess and a DC 11 flat check; the target is off-guard
+	// regardless.
+	Undetected
+	// Unnoticed: like Undetected but the observer does not even know the
+	// target exists. RoomView strips Unnoticed targets from the recipient's
+	// view entirely.
+	Unnoticed
+	// Invisible: the observer cannot see the target at all. With an auditory
+	// cue this round the pair behaves like Hidden; otherwise like Undetected.
+	Invisible
+)
+
+// String returns the canonical lowercase identifier for this State, matching
+// the YAML condition IDs (observed, concealed, hidden, undetected, unnoticed,
+// invisible).
+func (s State) String() string {
+	switch s {
+	case Observed:
+		return "observed"
+	case Concealed:
+		return "concealed"
+	case Hidden:
+		return "hidden"
+	case Undetected:
+		return "undetected"
+	case Unnoticed:
+		return "unnoticed"
+	case Invisible:
+		return "invisible"
+	}
+	return "unknown"
+}
+
+// MissChancePercent is the approximate chance an attack from this state is
+// converted to an automatic miss by the flat check. Used for diagnostic /
+// telemetry purposes; the authoritative gating logic lives in GateAttack.
+//
+// PF2E: Concealed = DC 5 flat check ≈ 20% miss; Hidden / Undetected = DC 11
+// flat check ≈ 50% miss. Unnoticed and Invisible-without-sound also include
+// a wrong-square auto-miss, modelled as 100% here as a conservative
+// placeholder; the real probability depends on grid size and is computed by
+// GateAttack.
+func (s State) MissChancePercent() int {
+	switch s {
+	case Observed:
+		return 0
+	case Concealed:
+		return 20
+	case Hidden, Undetected, Invisible:
+		return 50
+	case Unnoticed:
+		return 100
+	}
+	return 0
+}
+
+// ParseState resolves a canonical lowercase identifier to its State. Returns
+// (Observed, false) for unknown identifiers.
+func ParseState(s string) (State, bool) {
+	switch s {
+	case "observed":
+		return Observed, true
+	case "concealed":
+		return Concealed, true
+	case "hidden":
+		return Hidden, true
+	case "undetected":
+		return Undetected, true
+	case "unnoticed":
+		return Unnoticed, true
+	case "invisible":
+		return Invisible, true
+	}
+	return Observed, false
+}

--- a/internal/game/detection/state_test.go
+++ b/internal/game/detection/state_test.go
@@ -1,0 +1,51 @@
+package detection_test
+
+import (
+	"testing"
+
+	"github.com/cory-johannsen/mud/internal/game/detection"
+)
+
+func TestState_Stringers(t *testing.T) {
+	cases := map[detection.State]string{
+		detection.Observed:   "observed",
+		detection.Concealed:  "concealed",
+		detection.Hidden:     "hidden",
+		detection.Undetected: "undetected",
+		detection.Unnoticed:  "unnoticed",
+		detection.Invisible:  "invisible",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("State(%d).String() = %q, want %q", int(s), got, want)
+		}
+	}
+}
+
+func TestState_MissChancePercent(t *testing.T) {
+	cases := map[detection.State]int{
+		detection.Observed:   0,
+		detection.Concealed:  20,
+		detection.Hidden:     50,
+		detection.Undetected: 50,
+		detection.Unnoticed:  100,
+		detection.Invisible:  50,
+	}
+	for s, want := range cases {
+		if got := s.MissChancePercent(); got != want {
+			t.Errorf("State(%s).MissChancePercent() = %d, want %d", s, got, want)
+		}
+	}
+}
+
+func TestState_ParseState(t *testing.T) {
+	for _, s := range []detection.State{detection.Observed, detection.Concealed, detection.Hidden, detection.Undetected, detection.Unnoticed, detection.Invisible} {
+		got, ok := detection.ParseState(s.String())
+		if !ok || got != s {
+			t.Errorf("ParseState(%q) = %v, %v; want %v, true", s.String(), got, ok, s)
+		}
+	}
+	if _, ok := detection.ParseState("nonsense"); ok {
+		t.Errorf("ParseState(nonsense) should be !ok")
+	}
+}

--- a/internal/gameserver/combat_handler.go
+++ b/internal/gameserver/combat_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cory-johannsen/mud/internal/game/combat"
 	"github.com/cory-johannsen/mud/internal/game/danger"
 	"github.com/cory-johannsen/mud/internal/game/condition"
+	"github.com/cory-johannsen/mud/internal/game/detection"
 	"github.com/cory-johannsen/mud/internal/game/faction"
 	"github.com/cory-johannsen/mud/internal/game/quest"
 	"github.com/cory-johannsen/mud/internal/game/reaction"
@@ -1700,6 +1701,37 @@ func (h *CombatHandler) GetCombatantsInRoom(roomID string) []*scripting.Combatan
 		})
 	}
 	return out
+}
+
+// DetectionDecisionFor returns the per-recipient detection redaction decision
+// for an NPC instance from the perspective of the player identified by uid.
+// Returns the zero FilterDecision (no change) when uid is not in active
+// combat, or the NPC is not present in the same combat, or the pair is in
+// the default Observed state.
+//
+// Used by WorldHandler.buildRoomView to filter outbound RoomViews per
+// recipient (DETECT-16/17/18).
+func (h *CombatHandler) DetectionDecisionFor(uid, npcID string) detection.FilterDecision {
+	sess, ok := h.sessions.GetPlayer(uid)
+	if !ok {
+		return detection.FilterDecision{}
+	}
+	h.combatMu.Lock()
+	defer h.combatMu.Unlock()
+	cbt, ok := h.engine.GetCombat(sess.RoomID)
+	if !ok || cbt.DetectionStates == nil {
+		return detection.FilterDecision{}
+	}
+	// Determine whether the NPC made a sound this round; needed for the
+	// Invisible-state branch.
+	soundCue := false
+	for _, c := range cbt.Combatants {
+		if c.ID == npcID {
+			soundCue = c.MadeSoundThisRound
+			break
+		}
+	}
+	return detection.DecideForNPC(uid, npcID, cbt.DetectionStates, soundCue)
 }
 
 // GetCombatConditionSet returns the condition ActiveSet for targetID from the active combat

--- a/internal/gameserver/world_handler.go
+++ b/internal/gameserver/world_handler.go
@@ -189,6 +189,23 @@ func (h *WorldHandler) buildRoomView(uid string, room *world.Room) *gamev1.RoomV
 	npcInfos := make([]*gamev1.NpcInfo, 0, len(instances))
 	for _, inst := range instances {
 		if !inst.IsDead() {
+			// DETECT-16/17/18: per-recipient detection redaction. Drop
+			// Unnoticed NPCs from the recipient's view entirely; replace
+			// the display name for Hidden / Undetected / Invisible-without-
+			// sound. Outside combat the decision is the zero value (no
+			// change) so existing behaviour is preserved.
+			var detectDecision = struct {
+				Drop       bool
+				RedactName string
+			}{}
+			if h.combatH != nil {
+				d := h.combatH.DetectionDecisionFor(uid, inst.ID)
+				detectDecision.Drop = d.Drop
+				detectDecision.RedactName = d.RedactName
+			}
+			if detectDecision.Drop {
+				continue
+			}
 			fightingTarget := ""
 			var condNames []string
 			if h.combatH != nil {
@@ -206,9 +223,13 @@ func (h *WorldHandler) buildRoomView(uid string, room *world.Room) *gamev1.RoomV
 					tradition = tmpl.TechTrainer.Tradition
 				}
 			}
+			displayName := inst.Name()
+			if detectDecision.RedactName != "" {
+				displayName = detectDecision.RedactName
+			}
 			npcInfos = append(npcInfos, &gamev1.NpcInfo{
 				InstanceId:        inst.ID,
-				Name:              inst.Name(),
+				Name:              displayName,
 				HealthDescription: inst.HealthDescription(),
 				FightingTarget:    fightingTarget,
 				Conditions:        condNames,


### PR DESCRIPTION
Closes #254 (server core MVP). detection.State enum, Map, GateAttack, FilterRoomView, Combat.DetectionStates with legacy Hidden back-compat shim, sound-cue tracking, damage→Observed advance, condition bridge (4 new YAMLs). Square-guess targeting, transition actions (Hide/Seek/Sneak/Avoid Notice/Create-a-Diversion), telnet/web UX, telemetry, full architecture doc deferred to follow-up.