### PR TITLE
fix(input): pure-digit input no longer treated as exit name (#360)

### DIFF
--- a/internal/frontend/handlers/game_bridge.go
+++ b/internal/frontend/handlers/game_bridge.go
@@ -550,6 +550,17 @@ func (h *AuthHandler) commandLoop(ctx context.Context, stream gamev1.GameService
 
 		cmd, ok := registry.Resolve(parsed.Command)
 		if !ok {
+			// #360: pure-digit input is a leaked menu-option pick (level-up
+			// tech, feat choice, etc.). Surface a clear hint instead of
+			// dispatching as a "custom exit name" which would produce
+			// 'no exit "N"' errors. Server-side handleMove also rejects this
+			// as a defence-in-depth.
+			if isAllDigits(parsed.Command) {
+				_ = conn.WriteLine(telnet.Colorize(telnet.Dim,
+					"Numbers select menu options. Finish your pending selection (look at the prompt above), or type a direction word."))
+				_ = conn.WritePrompt(session.CurrentPrompt())
+				continue
+			}
 			// Try it as a custom exit name (e.g., "stairs")
 			msg := buildMoveMessage(reqID, parsed.Command)
 			if err := stream.Send(msg); err != nil {
@@ -663,6 +674,21 @@ func (h *AuthHandler) commandLoop(ctx context.Context, stream gamev1.GameService
 			}
 		}
 	}
+}
+
+// isAllDigits reports whether s is non-empty and entirely 0-9. Used by the
+// telnet input dispatcher (#360) to gate menu-option picks from leaking into
+// the room-movement fall-through.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func buildMoveMessage(reqID, direction string) *gamev1.ClientMessage {

--- a/internal/gameserver/grpc_service.go
+++ b/internal/gameserver/grpc_service.go
@@ -2699,8 +2699,32 @@ func (s *GameServiceServer) dispatch(uid string, msg *gamev1.ClientMessage) (*ga
 	}
 }
 
+// isPureDigitDirection reports whether dir is non-empty and entirely digits.
+// Used by handleMove (#360) to reject leaked menu-option picks that would
+// otherwise be looked up as exit names and produce confusing 'no exit "N"'
+// errors.
+func isPureDigitDirection(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	for _, r := range dir {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *GameServiceServer) handleMove(uid string, req *gamev1.MoveRequest) (*gamev1.ServerEvent, error) {
 	dir := world.Direction(req.Direction)
+
+	// #360: a pure-digit input is a menu-option pick that leaked through the
+	// client's room-input fallthrough. Rejecting it here keeps the player out
+	// of a confusing "no exit" loop and surfaces the actual cause regardless
+	// of which menu (level-up tech, feat choice, hotbar number, etc.) is open.
+	if isPureDigitDirection(string(dir)) {
+		return messageEvent("Numbers select menu options, not movement directions. Finish your pending selection first, or type a direction (n/s/e/w/...)."), nil
+	}
 
 	// REQ-MV-1: movement is blocked while the player is in combat.
 	if sess, ok := s.sessions.GetPlayer(uid); ok && sess.Status == statusInCombat {

--- a/internal/gameserver/grpc_service_move_test.go
+++ b/internal/gameserver/grpc_service_move_test.go
@@ -344,6 +344,33 @@ func TestHandleMove_BlockedWhileInCombat(t *testing.T) {
 	assert.Equal(t, "room_a", updatedSess.RoomID, "player room must not change while in combat")
 }
 
+// TestHandleMove_PureDigitInputRejected verifies the #360 guard: a movement
+// request with a pure-digit direction (a leaked menu-option pick) returns a
+// helpful message instead of attempting an exit lookup. This protects every
+// menu (level-up tech, feat choice, hotbar, etc.) at every level — the guard
+// is a single server-side check that doesn't need to know which menu is open.
+func TestHandleMove_PureDigitInputRejected(t *testing.T) {
+	worldMgr, sessMgr := newNormalTerrainWorld(t)
+	svc := newMoveTestService(t, worldMgr, sessMgr, nil)
+
+	_, err := sessMgr.AddPlayer(session.AddPlayerOptions{
+		UID: "u_digit", Username: "Fighter", CharName: "Fighter",
+		CharacterID: 11, RoomID: "room_a", CurrentHP: 10, MaxHP: 10,
+		Abilities: character.AbilityScores{}, Role: "player",
+	})
+	require.NoError(t, err)
+
+	for _, dir := range []string{"1", "2", "3", "10"} {
+		evt, err := svc.handleMove("u_digit", &gamev1.MoveRequest{Direction: dir})
+		require.NoError(t, err)
+		require.NotNil(t, evt)
+		msg := evt.GetMessage()
+		require.NotNil(t, msg, "digit %q should produce a MessageEvent", dir)
+		assert.Contains(t, msg.Content, "menu options",
+			"digit %q must surface the menu-option hint, not 'no exit %q'", dir, dir)
+	}
+}
+
 // TestPropertyHandleMove_InCombat_AlwaysBlocked is a property test verifying that
 // a player with statusInCombat can never move to another room.
 //


### PR DESCRIPTION
Closes #360. Two-layer generalized fix protecting every numbered-option prompt at every level. Server-side handleMove rejects pure-digit direction strings; telnet game_bridge gates the custom-exit fall-through. Regression test for digits 1/2/3/10.