### PR TITLE
fix(tech): surface projectiles + AoE shape in effects summary (#363)

### DIFF
--- a/internal/game/technology/summary.go
+++ b/internal/game/technology/summary.go
@@ -65,6 +65,12 @@ func formatHeader(def *TechnologyDef) string {
 		parts = append(parts, rangeStr)
 	}
 
+	// #363: surface AoE shape parameters in the header so the per-tech UI
+	// row shows the area at a glance (e.g. "burst 10 ft", "cone 30 ft", "line 25x5 ft").
+	if aoe := formatAoeHeader(def); aoe != "" {
+		parts = append(parts, aoe)
+	}
+
 	switch def.Resolution {
 	case "save":
 		parts = append(parts, fmt.Sprintf("Save: %s DC %d", strings.Title(strings.ReplaceAll(def.SaveType, "_", " ")), def.SaveDC)) //nolint:staticcheck
@@ -172,10 +178,22 @@ func formatEffect(e TechEffect) string {
 	switch e.Type {
 	case EffectDamage:
 		dmg := formatDiceAmount(e.Dice, e.Amount)
+		var s string
 		if e.DamageType != "" {
-			return dmg + " " + e.DamageType + " damage"
+			s = dmg + " " + e.DamageType + " damage"
+		} else {
+			s = dmg + " damage"
 		}
-		return dmg + " damage"
+		// #363: surface multi-projectile + persistent flags so the count is
+		// visible in the Technologies panel and hotbar tooltip without the
+		// player having to drill into the YAML or read the description prose.
+		if e.Projectiles > 0 {
+			s += fmt.Sprintf(" × %d projectiles", e.Projectiles)
+		}
+		if e.Persistent {
+			s += " (persistent)"
+		}
+		return s
 	case EffectHeal:
 		return formatDiceAmount(e.Dice, e.Amount) + " healing"
 	case EffectDrain:
@@ -232,4 +250,33 @@ func formatDiceAmount(dice string, amount int) string {
 	default:
 		return "?"
 	}
+}
+
+// formatAoeHeader returns a compact AoE shape descriptor for the header line,
+// or "" when the tech has no AoE shape. Generic across burst / cone / line so
+// any tech declaring an AoE shape gets the same affordance (#363).
+func formatAoeHeader(def *TechnologyDef) string {
+	// Legacy back-compat: aoe_radius without an explicit shape implies burst.
+	if def.AoeRadius > 0 && def.AoeShape == "" {
+		return fmt.Sprintf("burst %d ft", def.AoeRadius)
+	}
+	switch string(def.AoeShape) {
+	case "burst":
+		if def.AoeRadius > 0 {
+			return fmt.Sprintf("burst %d ft", def.AoeRadius)
+		}
+	case "cone":
+		if def.AoeLength > 0 {
+			return fmt.Sprintf("cone %d ft", def.AoeLength)
+		}
+	case "line":
+		if def.AoeLength > 0 {
+			w := def.AoeWidth
+			if w == 0 {
+				w = 5
+			}
+			return fmt.Sprintf("line %dx%d ft", def.AoeLength, w)
+		}
+	}
+	return ""
 }

--- a/internal/game/technology/summary_test.go
+++ b/internal/game/technology/summary_test.go
@@ -1,0 +1,73 @@
+package technology
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatEffectsSummary_ProjectilesShown verifies that a damage effect with
+// projectiles > 0 surfaces the count in the summary (#363).
+func TestFormatEffectsSummary_ProjectilesShown(t *testing.T) {
+	def := &TechnologyDef{
+		ID: "multi_round_kinetic_volley", Name: "Multi-Round Kinetic Volley",
+		ActionCost: 2, Range: RangeRanged, Targets: TargetsSingle,
+		Resolution: "none",
+		Effects: TieredEffects{
+			OnApply: []TechEffect{
+				{Type: EffectDamage, Dice: "1d4+1", DamageType: "force", Projectiles: 3},
+			},
+		},
+	}
+	got := FormatEffectsSummary(def)
+	if !strings.Contains(got, "× 3 projectiles") {
+		t.Fatalf("summary must show projectile count, got:\n%s", got)
+	}
+}
+
+// TestFormatEffectsSummary_AoeBurstShown verifies that the burst radius
+// surfaces in the header line (#363, generic across all AoE techs).
+func TestFormatEffectsSummary_AoeBurstShown(t *testing.T) {
+	def := &TechnologyDef{
+		ID: "frag_grenade_tech", Name: "Frag Grenade",
+		ActionCost: 1, Range: RangeRanged, Targets: TargetsSingle,
+		Resolution: "none",
+		AoeRadius:  10,
+	}
+	got := FormatEffectsSummary(def)
+	if !strings.Contains(got, "burst 10 ft") {
+		t.Fatalf("summary must show burst radius, got:\n%s", got)
+	}
+}
+
+// TestFormatEffectsSummary_AoeConeShown verifies that an AoE cone shape +
+// length surfaces in the header (#363).
+func TestFormatEffectsSummary_AoeConeShown(t *testing.T) {
+	def := &TechnologyDef{
+		ID: "shock_cone_tech", Name: "Shock Cone",
+		ActionCost: 2, Range: RangeMelee, Targets: TargetsSingle,
+		Resolution: "save", SaveType: "quickness", SaveDC: 15,
+		AoeShape:  "cone",
+		AoeLength: 30,
+	}
+	got := FormatEffectsSummary(def)
+	if !strings.Contains(got, "cone 30 ft") {
+		t.Fatalf("summary must show cone length, got:\n%s", got)
+	}
+}
+
+// TestFormatEffectsSummary_AoeLineShown verifies that an AoE line + width
+// surfaces in the header (#363).
+func TestFormatEffectsSummary_AoeLineShown(t *testing.T) {
+	def := &TechnologyDef{
+		ID: "laser_sweep_tech", Name: "Laser Sweep",
+		ActionCost: 2, Range: RangeRanged, Targets: TargetsSingle,
+		Resolution: "save", SaveType: "quickness", SaveDC: 15,
+		AoeShape:  "line",
+		AoeLength: 25,
+		AoeWidth:  5,
+	}
+	got := FormatEffectsSummary(def)
+	if !strings.Contains(got, "line 25x5 ft") {
+		t.Fatalf("summary must show line length + width, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #363. FormatEffectsSummary now shows projectile count, burst/cone/line shape params, and persistent flag on every tech that declares them. PreparedSlotView/HardwiredSlotView/etc. consume this string so both Technologies panel and Hotbar tooltip benefit without per-UI work. Generic — applies to any tech, not just Multi-Round Kinetic Volley.