### PR TITLE
fix(hotbar): keep New button reachable when slots overflow (#365)

### DIFF
--- a/cmd/webclient/ui/src/game/panels/HotbarPanel.tsx
+++ b/cmd/webclient/ui/src/game/panels/HotbarPanel.tsx
@@ -421,6 +421,7 @@ export function HotbarPanel() {
           type="button"
         >▼</button>
         <span className="hotbar-indicator">{activeHotbarIndex}/{hotbarCount}</span>
+        <div className="hotbar-slots">
         {KEYS.map((key, i) => {
           const slot = hotbarSlots[i] ?? { kind: 'command', ref: '' }
           const label = slotDisplayLabel(slot)
@@ -467,6 +468,7 @@ export function HotbarPanel() {
             </button>
           )
         })}
+        </div>
         {hotbarCount < maxHotbars && (
           <button
             className="hotbar-new-btn"

--- a/cmd/webclient/ui/src/styles/game.css
+++ b/cmd/webclient/ui/src/styles/game.css
@@ -258,7 +258,28 @@ body:has(.game-layout) #root { height: 100%; overflow: hidden; }
   border-top: 1px solid #333;
   border-bottom: 1px solid #333;
   height: 38px;
-  overflow: hidden;
+  /* #365: do NOT clip the row — the slots scroll horizontally inside
+     .hotbar-slots, and the New button is anchored outside that scroll
+     region so it stays reachable regardless of how many slots are bound. */
+  overflow: visible;
+}
+
+/* #365: scrollable container for the 10 numbered slot buttons. flex:1 +
+   min-width:0 lets it shrink within the .hotbar row; overflow-x:auto produces
+   a horizontal scrollbar when slots overflow. */
+.hotbar-slots {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+.hotbar-slots::-webkit-scrollbar {
+  height: 4px;
+}
+.hotbar-slots::-webkit-scrollbar-thumb {
+  background: #333;
 }
 .hotbar-slot {
   flex: 1;


### PR DESCRIPTION
Closes #365. Wraps the 10 numbered slot buttons in .hotbar-slots (flex:1 + overflow-x:auto). The New Hotbar button is now a sibling outside that container so it stays anchored on the right regardless of slot count. .hotbar overflow changes from hidden to visible.