### PR TITLE
fix(hotbar): New button always visible (disabled at max) (#365)

### DIFF
--- a/cmd/webclient/ui/src/game/panels/HotbarPanel.tsx
+++ b/cmd/webclient/ui/src/game/panels/HotbarPanel.tsx
@@ -469,14 +469,17 @@ export function HotbarPanel() {
           )
         })}
         </div>
-        {hotbarCount < maxHotbars && (
-          <button
-            className="hotbar-new-btn"
-            onClick={createHotbar}
-            title="Create new hotbar"
-            type="button"
-          >+ New Hotbar</button>
-        )}
+        {/* #365: always render so the New button is visible even at max
+            hotbars; disabled state explains why it's not clickable. */}
+        <button
+          className="hotbar-new-btn"
+          onClick={createHotbar}
+          disabled={hotbarCount >= maxHotbars}
+          title={hotbarCount >= maxHotbars
+            ? `Max hotbars reached (${maxHotbars}). Switch with ▲/▼.`
+            : 'Create new hotbar'}
+          type="button"
+        >+ New</button>
       </div>
     </>
   )

--- a/cmd/webclient/ui/src/styles/game.css
+++ b/cmd/webclient/ui/src/styles/game.css
@@ -387,8 +387,14 @@ body:has(.game-layout) #root { height: 100%; overflow: hidden; }
   white-space: nowrap;
   font-family: monospace;
 }
-.hotbar-new-btn:hover {
+.hotbar-new-btn:hover:not(:disabled) {
   background: #1f4a1f;
+}
+.hotbar-new-btn:disabled {
+  background: #1a1a1a;
+  color: #555;
+  border-left-color: #333;
+  cursor: not-allowed;
 }
 
 /* Input panel */


### PR DESCRIPTION
Follow-up to PR #366. Render the New button unconditionally; disabled state explains 'Max hotbars reached'.